### PR TITLE
Leading spaces were confusing the requirement display.

### DIFF
--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/ModuleBuilderManager.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/ModuleBuilderManager.cs
@@ -461,7 +461,7 @@ namespace CSETWeb_Api.BusinessManagers
                 {
                     newStdRefNum = fellowQuestions.Max(x => x.Std_Ref_Number) + 1;
                 }
-                
+
 
 
 
@@ -1031,7 +1031,7 @@ namespace CSETWeb_Api.BusinessManagers
 
                 // Update text.  Try/catch in case they are setting duplicate question text.
                 try
-                {                    
+                {
                     var question = db.NEW_QUESTION.Where(x => x.Question_Id == questionID).FirstOrDefault();
                     if (question == null)
                     {
@@ -1047,7 +1047,7 @@ namespace CSETWeb_Api.BusinessManagers
                     return resp;
                 }
                 catch (Microsoft.EntityFrameworkCore.DbUpdateException exc)
-                {                    
+                {
                     resp.ErrorMessages.Add("DUPLICATE QUESTION TEXT");
                     return resp;
                 }
@@ -1241,10 +1241,10 @@ namespace CSETWeb_Api.BusinessManagers
 
                 NEW_REQUIREMENT req = new NEW_REQUIREMENT
                 {
-                    Requirement_Title = parms.Title==null?"":parms.Title.Truncate(250),
-                    Requirement_Text = parms.RequirementText,
-                    Standard_Category = parms.Category.Truncate(250),
-                    Standard_Sub_Category = parms.Subcategory==null?"":parms.Subcategory.Truncate(250),
+                    Requirement_Title = parms.Title == null ? "" : parms.Title.Trim().Truncate(250),
+                    Requirement_Text = parms.RequirementText.Trim(),
+                    Standard_Category = parms.Category.Trim().Truncate(250),
+                    Standard_Sub_Category = parms.Subcategory == null ? "" : parms.Subcategory.Trim().Truncate(250),
                     Question_Group_Heading_Id = parms.QuestionGroupHeadingID,
                     Original_Set_Name = parms.SetName.Truncate(50)
                 };
@@ -1755,7 +1755,7 @@ namespace CSETWeb_Api.BusinessManagers
         /// </summary>
         public int RecordDocInDB(FileUploadStreamResult result)
         {
-            
+
             using (var db = new CSET_Context())
             {
                 // Determine file type ID.  Store null if not known.
@@ -1794,7 +1794,7 @@ namespace CSETWeb_Api.BusinessManagers
 
                     return gf.Gen_File_Id;
                 }
-                return 0; 
+                return 0;
             }
         }
     }

--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/RequirementsManager.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/RequirementsManager.cs
@@ -114,6 +114,10 @@ namespace CSETWeb_Api.BusinessManagers
             {
                 var dbR = dbRPlus.Requirement;
 
+                // Make sure there are no leading or trailing spaces - it will affect the tree structure that is built
+                dbR.Standard_Category = dbR.Standard_Category.Trim();
+                dbR.Standard_Sub_Category = dbR.Standard_Sub_Category.Trim();
+
                 // If the Standard_Sub_Category is null (like CSC_V6), default it to the Standard_Category
                 if (dbR.Standard_Sub_Category == null)
                 {

--- a/CSETWebNg/src/sass/styles.scss
+++ b/CSETWebNg/src/sass/styles.scss
@@ -1399,6 +1399,7 @@ a.special-factors-link, a:not([href]):not([tabindex]).special-factors-link {
   transform: scaleY(-1);
   filter: FlipH;
   -ms-filter:  "FlipH";
+  margin-top: -10px;
 }
 
 .open-desc {
@@ -1536,6 +1537,7 @@ a.special-factors-link, a:not([href]):not([tabindex]).special-factors-link {
   transform: scaleY(-1);
   filter: FlipH;
   -ms-filter:  "FlipH";
+  margin-top: -10px;
 }
 
 .header-question {


### PR DESCRIPTION
Added code to trim leading and trailing spaces in ModuleBuilder as well as the Requirements page.
Also nudged the expand chevron placement a bit.