### PR TITLE
On diagram load don't overwrite GUIDs of existing components.

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/etc/mxgraph/mxClient.js
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/etc/mxgraph/mxClient.js
@@ -9658,13 +9658,8 @@ mxGraphModel.cellAddedCSET = function (graph, cell)
         return;
     }    
 
-    if (cell.getCsetAttribute("redDot") == '1')
-    {
-        return;
-    }
-
     // assign a component GUID to components (not zones)
-    if (cell.getStyleValue('zone') != '1')
+    if (cell.getCsetAttribute('ComponentGuid') == null && cell.getStyleValue('zone') != '1')
     {
         var nextGuid = guidService.getInstance().getNextGuid();
         cell.setCsetAttribute('ComponentGuid', nextGuid);

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/src/main/webapp/js/diagramly/util/CsetUtils.js
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/src/main/webapp/js/diagramly/util/CsetUtils.js
@@ -237,6 +237,9 @@ CsetUtils.edgesToTop = function (graph, edit) {
             const edges = CsetUtils.getAllChildEdges(change.child);
             graph.orderCells(false, edges);
         }
+        if (change instanceof mxTerminalChange) {
+            graph.orderCells(false, [change.cell]);
+        }
     }
 }
 
@@ -346,7 +349,6 @@ CsetUtils.saveDiagram = async function (req) {
             url: localStorage.getItem('cset.host') + 'diagram/save',
             payload: JSON.stringify(req),
             onreadystatechange: function (e) {
-                console.log(e.readyState);
                 if (e.readyState !== 4) {
                     return;
                 } 
@@ -680,7 +682,6 @@ async function showSaving(requestId) {
     newDiv.appendChild(newContent);
 
     var tmppayload = JSON.stringify(requestId);
-    console.log(tmppayload);
     document.body.appendChild(newDiv);
     newDiv.id = "CSETSaving";
     newDiv.style.position = 'absolute';


### PR DESCRIPTION
Fixed setting link 'to front' on terminal change.