### PR TITLE
Added back logic to place red dots on edges directly connecting compo…

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/src/main/webapp/js/diagramly/util/CsetUtils.js
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Diagram/src/main/webapp/js/diagramly/util/CsetUtils.js
@@ -606,6 +606,16 @@ CsetUtils.getTaggedCell = function (warning, graph) {
         return graph.getModel().getCell(warning.NodeId1);
     }
 
+    // if two components are provided, look for any edges that connect them directly
+    if (warning.NodeId1 && warning.NodeId2) {
+        const component1 = graph.getModel().getCell(warning.NodeId1);
+        const component2 = graph.getModel().getCell(warning.NodeId2);
+        const edges = graph.getModel().getEdgesBetween(component1, component2);
+        if (edges.length > 0) {
+            return edges[0];
+        }
+    }
+
     // if an edgeId is provided, the dot goes on the edge
     if (!!warning.edgeId) {
         return graph.getModel().getCell(warning.edgeId);


### PR DESCRIPTION
…nents.

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

When both connecting components are specified, just place the red dot on any edge that connects them directly.  If one doesn't exist, then place it on the edge that the warning logic indicates.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
