### PR TITLE
NWD-1486 - import cleanup of unnecessary standards

### DIFF
--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/AssessmentIO/import/ImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/AssessmentIO/import/ImportManager.cs
@@ -40,7 +40,7 @@ namespace CSETWeb_Api.BusinessLogic.BusinessManagers
                     ZipArchive zip = new ZipArchive(fs);
                     StreamReader r = new StreamReader(zip.GetEntry("model.json").Open());
                     string jsonObject = r.ReadToEnd();
-                 
+
                     // Apply any data updates to older versions
                     ImportUpgradeManager upgrader = new ImportUpgradeManager();
                     jsonObject = upgrader.Upgrade(jsonObject);
@@ -48,120 +48,132 @@ namespace CSETWeb_Api.BusinessLogic.BusinessManagers
                     try
                     {
                         UploadAssessmentModel model = (UploadAssessmentModel)JsonConvert.DeserializeObject(jsonObject, new UploadAssessmentModel().GetType());
-                   
-                    foreach (var doc in model.CustomStandardDocs)
-                    {
-                        var genFile = context.GEN_FILE.FirstOrDefault(s => s.File_Name == doc);
-                        if (genFile == null)
-                        {
-                            StreamReader docReader = new StreamReader(zip.GetEntry(doc + ".json").Open());
-                            var docModel = JsonConvert.DeserializeObject<ExternalDocument>(docReader.ReadToEnd());
-                            genFile = docModel.ToGenFile();
-                            var extension = Path.GetExtension(genFile.File_Name).Substring(1);
-                            genFile.File_Type_ = context.FILE_TYPE.Where(s => s.File_Type1 == extension).FirstOrDefault();
 
-                            try
-                            {
-                                context.FILE_REF_KEYS.Add(new FILE_REF_KEYS { Doc_Num = genFile.Doc_Num });
-                                await context.SaveChangesAsync();
-                            }
-                            catch(Exception e)
-                            {
-                                  
-                            }
-                            context.GEN_FILE.Add(genFile);
-                            context.SaveChanges();
-                        }
-                    }
-                    foreach (var standard in model.CustomStandards)
-                    {
-                        var sets = context.SETS.Where(s => s.Set_Name.Contains(standard)).ToList();
-                        SETS set = null;
-                        StreamReader setReader = new StreamReader(zip.GetEntry(standard + ".json").Open());
-                        var setJson = setReader.ReadToEnd();
-                        var setModel = JsonConvert.DeserializeObject<ExternalStandard>(setJson);
-                        var originalSetName = setModel.ShortName;
-                        foreach (var testSet in sets)
+                        foreach (var doc in model.CustomStandardDocs)
                         {
-                            setModel.ShortName = testSet.Short_Name;
-                            var testSetJson = JsonConvert.SerializeObject(testSet.ToExternalStandard(), Formatting.Indented);
-                            if (testSetJson == setJson)
+                            var genFile = context.GEN_FILE.FirstOrDefault(s => s.File_Name == doc);
+                            if (genFile == null)
                             {
-                                set = testSet;
-                                break;
-                            }
-                            else
-                            {
-                                setModel.ShortName = originalSetName;
-                            }
-                        }
-                        if (set == null)
-                        {
-                            int incr = 1;
-                            while (sets.Any(s => s.Short_Name == setModel.ShortName))
-                            {
-                                setModel.ShortName = originalSetName + " " + incr;
-                                incr++;
-                            }
-                            var setResult = await setModel.ToSet();
-                            if (setResult.IsSuccess)
-                            {
-                                context.SETS.Add(setResult.Result);
+                                StreamReader docReader = new StreamReader(zip.GetEntry(doc + ".json").Open());
+                                var docModel = JsonConvert.DeserializeObject<ExternalDocument>(docReader.ReadToEnd());
+                                genFile = docModel.ToGenFile();
+                                var extension = Path.GetExtension(genFile.File_Name).Substring(1);
+                                genFile.File_Type_ = context.FILE_TYPE.Where(s => s.File_Type1 == extension).FirstOrDefault();
 
-                                foreach (var question in setResult.Result.NEW_REQUIREMENT.SelectMany(s => s.NEW_QUESTIONs()).Where(s => s.Question_Id != 0).ToList())
-                                {
-                                    context.Entry(question).State = EntityState.Unchanged;
-                                }
                                 try
                                 {
+                                    context.FILE_REF_KEYS.Add(new FILE_REF_KEYS { Doc_Num = genFile.Doc_Num });
                                     await context.SaveChangesAsync();
                                 }
                                 catch (Exception e)
                                 {
-                                    throw (e);
+
                                 }
-                                //Set the GUID at time of export so we are sure it's right!!!
-                                model.jANSWER = model.jANSWER.Where(s => s.Is_Requirement).GroupJoin(setResult.Result.NEW_REQUIREMENT, s => s.Custom_Question_Guid, req => new Guid(new MD5CryptoServiceProvider().ComputeHash(Encoding.Default.GetBytes(originalSetName + "|||" + req.Requirement_Title + "|||" + req.Requirement_Text))).ToString(), (erea, s) =>
-                                {
-                                    var req = s.FirstOrDefault();
-                                    if (req != null)
-                                    {
-                                        erea.Question_Or_Requirement_Id = req.Requirement_Id;
-                                    }
-                                    return erea;
-                                }).Concat(model.jANSWER.Where(s => !s.Is_Requirement).GroupJoin(setResult.Result.NEW_QUESTION, s => s.Custom_Question_Guid, req => new Guid(new MD5CryptoServiceProvider().ComputeHash(Encoding.Default.GetBytes(req.Simple_Question))).ToString(), (erer, s) =>
-                                {
-                                    var req = s.FirstOrDefault();
-                                    if (req != null)
-                                    {
-                                        erer.Question_Or_Requirement_Id = req.Question_Id;
-                                    }
-                                    return erer;
-                                })).ToList();
+                                context.GEN_FILE.Add(genFile);
+                                context.SaveChanges();
                             }
                         }
-                        foreach (var availableStandard in model.jAVAILABLE_STANDARDS.Where(s => s.Set_Name == Regex.Replace(originalSetName, @"\W", "_") && s.Selected))
+                        foreach (var standard in model.CustomStandards)
                         {
-                            availableStandard.Set_Name = Regex.Replace(setModel.ShortName, @"\W", "_");
+                            var sets = context.SETS.Where(s => s.Set_Name.Contains(standard)).ToList();
+                            SETS set = null;
+                            StreamReader setReader = new StreamReader(zip.GetEntry(standard + ".json").Open());
+                            var setJson = setReader.ReadToEnd();
+                            var setModel = JsonConvert.DeserializeObject<ExternalStandard>(setJson);
+                            var originalSetName = setModel.ShortName;
+                            foreach (var testSet in sets)
+                            {
+                                setModel.ShortName = testSet.Short_Name;
+                                var testSetJson = JsonConvert.SerializeObject(testSet.ToExternalStandard(), Formatting.Indented);
+                                if (testSetJson == setJson)
+                                {
+                                    set = testSet;
+                                    break;
+                                }
+                                else
+                                {
+                                    setModel.ShortName = originalSetName;
+                                }
+                            }
+                            if (set == null)
+                            {
+                                int incr = 1;
+                                while (sets.Any(s => s.Short_Name == setModel.ShortName))
+                                {
+                                    setModel.ShortName = originalSetName + " " + incr;
+                                    incr++;
+                                }
+                                var setResult = await setModel.ToSet();
+                                if (setResult.IsSuccess)
+                                {
+                                    context.SETS.Add(setResult.Result);
+
+                                    foreach (var question in setResult.Result.NEW_REQUIREMENT.SelectMany(s => s.NEW_QUESTIONs()).Where(s => s.Question_Id != 0).ToList())
+                                    {
+                                        context.Entry(question).State = EntityState.Unchanged;
+                                    }
+                                    try
+                                    {
+                                        await context.SaveChangesAsync();
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        throw (e);
+                                    }
+                                    //Set the GUID at time of export so we are sure it's right!!!
+                                    model.jANSWER = model.jANSWER.Where(s => s.Is_Requirement).GroupJoin(setResult.Result.NEW_REQUIREMENT, s => s.Custom_Question_Guid, req => new Guid(new MD5CryptoServiceProvider().ComputeHash(Encoding.Default.GetBytes(originalSetName + "|||" + req.Requirement_Title + "|||" + req.Requirement_Text))).ToString(), (erea, s) =>
+                                    {
+                                        var req = s.FirstOrDefault();
+                                        if (req != null)
+                                        {
+                                            erea.Question_Or_Requirement_Id = req.Requirement_Id;
+                                        }
+                                        return erea;
+                                    }).Concat(model.jANSWER.Where(s => !s.Is_Requirement).GroupJoin(setResult.Result.NEW_QUESTION, s => s.Custom_Question_Guid, req => new Guid(new MD5CryptoServiceProvider().ComputeHash(Encoding.Default.GetBytes(req.Simple_Question))).ToString(), (erer, s) =>
+                                    {
+                                        var req = s.FirstOrDefault();
+                                        if (req != null)
+                                        {
+                                            erer.Question_Or_Requirement_Id = req.Question_Id;
+                                        }
+                                        return erer;
+                                    })).ToList();
+                                }
+                            }
+                            foreach (var availableStandard in model.jAVAILABLE_STANDARDS.Where(s => s.Set_Name == Regex.Replace(originalSetName, @"\W", "_") && s.Selected))
+                            {
+                                availableStandard.Set_Name = Regex.Replace(setModel.ShortName, @"\W", "_");
+                            }
                         }
-                    }
 
-                    string email = context.USERS.Where(x => x.UserId == currentUserId).First().PrimaryEmail;
+                        string email = context.USERS.Where(x => x.UserId == currentUserId).First().PrimaryEmail;
 
-                    Importer import = new Importer();
-                    int newAssessmentId = import.RunImportManualPortion(model, currentUserId, email, context);
-                    import.RunImportAutomatic(newAssessmentId, jsonObject, context);
+                        Importer import = new Importer();
+                        int newAssessmentId = import.RunImportManualPortion(model, currentUserId, email, context);
+                        import.RunImportAutomatic(newAssessmentId, jsonObject, context);
 
-		            //NOTE THAT THIS ENTRY WILL ONLY COME FROM A OLD .cset file 
-                    //IMPORT
-                    ZipArchiveEntry importLegacyDiagram = zip.GetEntry("Diagram.csetd");
-                    if (importLegacyDiagram != null)
-                    {
-                        StreamReader ldr = new StreamReader(importLegacyDiagram.Open());
-                        string oldXml = ldr.ReadToEnd();
-                        DiagramManager dm = new DiagramManager(context);
-                        dm.ImportOldCSETDFile(oldXml, newAssessmentId);                        
-                    }
+
+                        // Clean up any imported standards that are unselected or deprecated
+                        var unselectedStandards = context.AVAILABLE_STANDARDS.Where(x => x.Assessment_Id == newAssessmentId && !x.Selected).ToList();
+                        context.AVAILABLE_STANDARDS.RemoveRange(unselectedStandards);
+                        var deprecatedStandards = from av in context.AVAILABLE_STANDARDS
+                                                  join set in context.SETS on av.Set_Name equals set.Set_Name
+                                                  where set.Is_Deprecated
+                                                  select av;
+                        context.AVAILABLE_STANDARDS.RemoveRange(deprecatedStandards.ToList());
+                        context.SaveChanges();
+
+
+                        //NOTE THAT THIS ENTRY WILL ONLY COME FROM A OLD .cset file 
+                        //IMPORT
+                        ZipArchiveEntry importLegacyDiagram = zip.GetEntry("Diagram.csetd");
+                        if (importLegacyDiagram != null)
+                        {
+                            StreamReader ldr = new StreamReader(importLegacyDiagram.Open());
+                            string oldXml = ldr.ReadToEnd();
+                            DiagramManager dm = new DiagramManager(context);
+                            dm.ImportOldCSETDFile(oldXml, newAssessmentId);
+                        }
                     }
                     catch (Exception e)
                     {

--- a/Database Scripts/Stored Procedures/usp_getStandardsSummary.proc.sql
+++ b/Database Scripts/Stored Procedures/usp_getStandardsSummary.proc.sql
@@ -32,7 +32,7 @@ begin
 		from (select Short_Name,l.Answer_Full_Name,l.Answer_Text from AVAILABLE_STANDARDS a 
 		join SETS s on a.Set_Name = s.Set_Name
 		, ANSWER_LOOKUP l
-		where a.Assessment_Id = @assessment_id) a left join (
+		where a.Assessment_Id = @assessment_id) a join (
 		SELECT ms.Short_Name, a.Answer_Text, isnull(count(c.question_id),0) qc, SUM(count(c.question_id)) OVER(PARTITION BY Short_Name) AS Total
 				FROM Answer_Questions a 
 				join NEW_QUESTION c on a.Question_Or_Requirement_Id = c.Question_Id				
@@ -56,7 +56,7 @@ begin
 		from (select Short_Name,l.Answer_Full_Name,l.Answer_Text from AVAILABLE_STANDARDS a 
 		join SETS s on a.Set_Name = s.Set_Name
 		, ANSWER_LOOKUP l
-		where a.Assessment_Id = @assessment_id) a left join (
+		where a.Assessment_Id = @assessment_id) a join (
 		SELECT ms.Short_Name, a.Answer_Text, isnull(count(c.Requirement_Id),0) qc, SUM(count(c.Requirement_Id)) OVER(PARTITION BY Short_Name) AS Total  
 				FROM Answer_Requirements a 
 				join NEW_REQUIREMENT c on a.Question_Or_Requirement_Id = c.Requirement_Id				


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Old imports may come with a bunch of ‘unselected’ standards (AVAILABLE_STANDARDS).  They also might have a deprecated standard selected.  This was causing issues in usp_getStandardsSummary, because he was doing a left join, which picked up all of the ghost standards as well.  

FIX:  I changed the joins in usp_getStandardsSummary.  Also, after the generic import, we clean up any unselected or deprecated AVAILABLE_STANDARDS records.


## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
