### PR TITLE
Rewrote SaveAssessmentDetail to not stomp existing values

### DIFF
--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/AssessmentManager.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/AssessmentManager.cs
@@ -4,18 +4,17 @@
 // 
 // 
 //////////////////////////////// 
- 
-using BusinessLogic.Helpers;
-using CSETWeb_Api.BusinessLogic.BusinessManagers;
-using CSETWeb_Api.BusinessLogic.Helpers;
-using CSETWeb_Api.Helpers;
-using CSETWeb_Api.Models;
-using DataLayerCore.Model;
-using Microsoft.EntityFrameworkCore;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BusinessLogic.Helpers;
+using CSETWeb_Api.BusinessLogic.BusinessManagers;
+using CSETWeb_Api.BusinessLogic.Helpers;
 using CSETWeb_Api.BusinessLogic.Models;
+using CSETWeb_Api.Helpers;
+using CSETWeb_Api.Models;
+using DataLayerCore.Model;
 
 namespace CSETWeb_Api.BusinessManagers
 {
@@ -173,7 +172,7 @@ namespace CSETWeb_Api.BusinessManagers
                     assessment.Charter = string.IsNullOrEmpty(result.aa.Charter) ? "" : result.aa.Charter;
                     assessment.CreditUnion = result.aa.CreditUnionName;
                     assessment.Assets = result.aa.Assets;
-                    
+
                     // Fields located on the Overview page
                     assessment.ExecutiveSummary = result.ii.Executive_Summary;
                     assessment.AssessmentDescription = result.ii.Assessment_Description;
@@ -194,52 +193,67 @@ namespace CSETWeb_Api.BusinessManagers
         /// <returns></returns>
         public int SaveAssessmentDetail(int assessmentId, AssessmentDetail assessment)
         {
-            var db = new DataLayerCore.Model.CSET_Context();
-            TokenManager tm = new TokenManager();
-            string app_code = tm.Payload(Constants.Token_Scope);
-            // Add or update the ASSESSMENT record
-            var dbAssessment = new ASSESSMENTS()
+            using (var db = new DataLayerCore.Model.CSET_Context())
             {
-                Assessment_Id = assessment.Id,
-                AssessmentCreatedDate = assessment.CreatedDate,
-                AssessmentCreatorId = assessment.CreatorId,
-                Assessment_Date = assessment.AssessmentDate??DateTime.Now,
-                LastAccessedDate = assessment.LastModifiedDate,
-                Charter = string.IsNullOrEmpty(assessment.Charter) ? string.Empty : assessment.Charter.PadLeft(5,'0'),
-                CreditUnionName = assessment.CreditUnion,
-                Assets = assessment.Assets, 
-                MatDetail_targetBandOnly = app_code == "ACET",
-                AnalyzeDiagram = false
-            };
+                TokenManager tm = new TokenManager();
+                string app_code = tm.Payload(Constants.Token_Scope);
 
-            db.ASSESSMENTS.AddOrUpdate( dbAssessment, x=> x.Assessment_Id);
+                // Add or update the ASSESSMENTS record
+                var dbAssessment = db.ASSESSMENTS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
 
-            db.SaveChanges();
-            assessmentId = dbAssessment.Assessment_Id;
-            var user = db.USERS.FirstOrDefault(x => x.UserId == dbAssessment.AssessmentCreatorId);
-            // then use its key for the INFORMATION record
-            var dbInfo = new INFORMATION
-            {
-                Id = assessmentId,
-                Assessment_Name = assessment.AssessmentName,                
-                Facility_Name = assessment.FacilityName,
-                City_Or_Site_Name = assessment.CityOrSiteName,
-                State_Province_Or_Region = assessment.StateProvRegion,
-                Executive_Summary = assessment.ExecutiveSummary,
-                Assessment_Description = assessment.AssessmentDescription,
-                Additional_Notes_And_Comments = assessment.AdditionalNotesAndComments, 
-                IsAcetOnly = assessment.IsAcetOnly
-            };
+                if (dbAssessment == null)
+                {
+                    dbAssessment = new ASSESSMENTS();
+                    db.ASSESSMENTS.Add(dbAssessment);
+                    db.SaveChanges();
+                    assessmentId = dbAssessment.Assessment_Id;
+                }
 
-            db.INFORMATION.AddOrUpdate( dbInfo, x=> x.Id);
+                dbAssessment.Assessment_Id = assessmentId;
+                dbAssessment.AssessmentCreatedDate = assessment.CreatedDate;
+                dbAssessment.AssessmentCreatorId = assessment.CreatorId;
+                dbAssessment.Assessment_Date = assessment.AssessmentDate ?? DateTime.Now;
+                dbAssessment.LastAccessedDate = assessment.LastModifiedDate;
+                dbAssessment.Charter = string.IsNullOrEmpty(assessment.Charter) ? string.Empty : assessment.Charter.PadLeft(5, '0');
+                dbAssessment.CreditUnionName = assessment.CreditUnion;
+                dbAssessment.Assets = assessment.Assets;
+                dbAssessment.MatDetail_targetBandOnly = (app_code == "ACET");
+                dbAssessment.AnalyzeDiagram = false;
 
-            db.SaveChanges();
+                db.ASSESSMENTS.AddOrUpdate(dbAssessment, x => x.Assessment_Id);
+                db.SaveChanges();
+
+                
+                var user = db.USERS.FirstOrDefault(x => x.UserId == dbAssessment.AssessmentCreatorId);
 
 
-            AssessmentUtil.TouchAssessment(assessmentId);
-            
+                var dbInformation = db.INFORMATION.Where(x => x.Id == assessmentId).FirstOrDefault();
+                if (dbInformation == null)
+                {
+                    dbInformation = new INFORMATION()
+                    {
+                        Id = assessmentId
+                    };
+                }
 
-            return dbInfo.Id;
+                // add or update the INFORMATION record
+                dbInformation.Assessment_Name = assessment.AssessmentName;
+                dbInformation.Facility_Name = assessment.FacilityName;
+                dbInformation.City_Or_Site_Name = assessment.CityOrSiteName;
+                dbInformation.State_Province_Or_Region = assessment.StateProvRegion;
+                dbInformation.Executive_Summary = assessment.ExecutiveSummary;
+                dbInformation.Assessment_Description = assessment.AssessmentDescription;
+                dbInformation.Additional_Notes_And_Comments = assessment.AdditionalNotesAndComments;
+                dbInformation.IsAcetOnly = assessment.IsAcetOnly;
+
+                db.INFORMATION.AddOrUpdate(dbInformation, x => x.Id);
+                db.SaveChanges();
+
+
+                AssessmentUtil.TouchAssessment(assessmentId);
+
+                return assessmentId;
+            }
         }
 
         /// <summary>
@@ -360,7 +374,7 @@ namespace CSETWeb_Api.BusinessManagers
                 AssetValue = assetValue
             };
 
-            db.DEMOGRAPHICS.AddOrUpdate( dbDemographics, x=> x.Assessment_Id);
+            db.DEMOGRAPHICS.AddOrUpdate(dbDemographics, x => x.Assessment_Id);
             db.SaveChanges();
             demographics.AssessmentId = dbDemographics.Assessment_Id;
 


### PR DESCRIPTION
The API was not sensitive to some values already on an existing assessment record and was overwriting them with nothing.

## 🗣 Description


## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
