### PR TITLE
Added a confirmation dialog if the user backs out ...

### DIFF
--- a/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.html
+++ b/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.html
@@ -26,16 +26,19 @@
   <div class="w-100">
     <div class="form-group">
       <label>{{ this.aggregationSvc?.modeDisplay(false) }} Name</label>
-      <input type="text" class="form-control" [(ngModel)]="aggregationSvc.currentAggregation.AggregationName" (change)="updateAggregation()" />
+      <input type="text" class="form-control" [(ngModel)]="aggregationSvc.currentAggregation.AggregationName"
+        (change)="updateAggregation()" />
     </div>
   </div>
 
-  <div class="mt-3 mb-3">    
+  <div class="mt-3 mb-3">
     <div>
-      Selected Assessments Questions Compatibility: <span class="font-weight-bold">{{ aliasData?.Aggregation.QuestionsCompatibility | percent : '0.3' }}</span>
-    </div>    
+      Selected Assessments Questions Compatibility: <span
+        class="font-weight-bold">{{ aliasData?.Aggregation.QuestionsCompatibility | percent : '0.3' }}</span>
+    </div>
     <div>
-      Selected Assessments Requirements Compatibility: <span class="font-weight-bold">{{ aliasData?.Aggregation.RequirementsCompatibility | percent : '0.3' }}</span>
+      Selected Assessments Requirements Compatibility: <span
+        class="font-weight-bold">{{ aliasData?.Aggregation.RequirementsCompatibility | percent : '0.3' }}</span>
     </div>
   </div>
 
@@ -43,9 +46,10 @@
     Assessments can be added and removed from the {{ this.aggregationSvc?.modeDisplay(false) | lowercase }}
     by clicking Select Assessments. The alias of each assessment can be modified to be meaningful.
   </div>
-  
+
   <div class="mt-3 mb-3">
-    <button class="btn btn-primary" (click)="openDialog()"><i class="far fa-check-square mr-2"></i>Select Assessments</button>
+    <button class="btn btn-primary" (click)="openSelectionDialog()"><i class="far fa-check-square mr-2"></i>Select
+      Assessments</button>
   </div>
 
   <table *ngIf="aliasData?.Assessments.length > 0" class="assessment-summary td-p-1">
@@ -65,7 +69,8 @@
     </tr>
     <tr *ngFor="let assess of aliasData.Assessments">
       <td class="pr-3">
-        <input type="text" [(ngModel)]="assess.Alias" class="form-control" maxlength="15" (change)="changeAlias(assess)" />
+        <input type="text" [(ngModel)]="assess.Alias" class="form-control" maxlength="15"
+          (change)="changeAlias(assess)" />
       </td>
       <td>
         {{ assess.AssessmentName }}
@@ -73,18 +78,19 @@
       <td>
         {{ assess.AssessmentDate | date:'dd-MMM-yyyy' }}
       </td>
-      <td *ngFor="let s of assess.SelectedStandards" class="text-center" [innerHTML]= "showDot(s.Selected)">
+      <td *ngFor="let s of assess.SelectedStandards" class="text-center" [innerHTML]="showDot(s.Selected)">
       </td>
     </tr>
   </table>
-  
+
   <div *ngIf="aliasData?.Assessments.length === 0" class="mt-3 mb-5 alert-warning p-3 font-weight-bold text-center">
     There are no assessments selected for this {{ this.aggregationSvc?.modeDisplay(false) }}
   </div>
 
   <div class="mt-3 d-flex justify-content-between flex-00a">
-    <button class="btn btn-primary" (click)="navSvc.navBack('alias-assessments')">Back</button>
-    <button class="btn btn-primary" [disabled]="aliasData?.Assessments.length < 2" (click)="navSvc.navNext('alias-assessments')">Next</button>
+    <button class="btn btn-primary" (click)="navBackIfValid()">Back</button>
+    <button class="btn btn-primary" [disabled]="aliasData?.Assessments.length < 2"
+      (click)="navSvc.navNext('alias-assessments')">Next</button>
   </div>
 
 </div>


### PR DESCRIPTION
... of a draft trend/compare.

This will prevent dummy trend/compares from piling up, if the user backs out of a trend/compare with less than 2 assessments.  

## 🗣 Description

If the trend/compare has 2 or more assessments then the user can back up to the list page.  But if they have less than 2, they can't go forward, so the trend/compare is not "real" yet.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
