### PR TITLE
Added sorting to assessment lists in Best to Worst

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Controllers/AggregationAnalysisController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Controllers/AggregationAnalysisController.cs
@@ -718,11 +718,16 @@ namespace CSETWeb_Api.Controllers
                 keys.Sort();
                 foreach (string k in keys)
                 {
-                    response.Add(new BestToWorstCategory()
+                    var category = new BestToWorstCategory()
                     {
                         Category = k,
                         Assessments = dict[k]
-                    });
+                    };
+
+                    // sort best to worst
+                    category.Assessments.Sort((a, b) => (a.YesValue + a.AlternateValue).CompareTo(b.YesValue + b.AlternateValue));
+                    category.Assessments.Reverse();
+                    response.Add(category);
                 }
 
                 return response;


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Added LINQ sorting to the lists of assessments for each category, sorting by summing the YES and ALT percentages, descending.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
