### PR TITLE
ComponentsSummary - ignore component answers ...

### DIFF
--- a/Database Scripts/Views/Answer_Components_InScope.view.sql
+++ b/Database Scripts/Views/Answer_Components_InScope.view.sql
@@ -1,15 +1,21 @@
 
+
 CREATE VIEW [dbo].[Answer_Components_InScope]
 AS
 SELECT DISTINCT 
-                         a.Assessment_Id, a.Answer_Id, a.Question_Or_Requirement_Id, a.Answer_Text, CONVERT(nvarchar(1000), a.Comment) AS Comment, CONVERT(nvarchar(1000), a.Alternate_Justification) AS Alternate_Justification, 
-                         a.Question_Number, q.Simple_Question AS QuestionText, adc.label AS ComponentName, adc.Component_Symbol_Id, adc.Layer_Id, l.Name AS LayerName, z.Container_Id, 
-                         z.Name AS ZoneName, z.Universal_Sal_Level AS SAL, a.Is_Component, a.Component_Guid, a.Custom_Question_Guid, a.Old_Answer_Id, a.Reviewed, a.Mark_For_Review, a.Is_Requirement, 
-                         a.Is_Framework
-FROM            dbo.ANSWER AS a INNER JOIN
-                         dbo.COMPONENT_QUESTIONS AS cq ON cq.Question_Id = a.Question_Or_Requirement_Id INNER JOIN
-                         dbo.NEW_QUESTION AS q ON cq.Question_Id = q.Question_Id INNER JOIN
-                         dbo.ASSESSMENT_DIAGRAM_COMPONENTS AS adc ON a.Assessment_Id = adc.Assessment_Id AND adc.Component_Symbol_Id = cq.Component_Symbol_Id LEFT OUTER JOIN
-                         dbo.DIAGRAM_CONTAINER AS l ON adc.Layer_Id = l.Container_Id 
-						 LEFT OUTER JOIN dbo.DIAGRAM_CONTAINER AS z ON z.Assessment_Id = adc.Assessment_Id AND z.Container_Id = adc.Zone_Id
+                a.Assessment_Id, a.Answer_Id, a.Question_Or_Requirement_Id, a.Answer_Text, CONVERT(nvarchar(1000), a.Comment) AS Comment, CONVERT(nvarchar(1000), a.Alternate_Justification) AS Alternate_Justification, 
+                a.Question_Number, q.Simple_Question AS QuestionText, adc.label AS ComponentName, adc.Component_Symbol_Id, adc.Layer_Id, l.Name AS LayerName, z.Container_Id, 
+                z.Name AS ZoneName, z.Universal_Sal_Level AS SAL, a.Is_Component, a.Component_Guid, a.Custom_Question_Guid, a.Old_Answer_Id, a.Reviewed, a.Mark_For_Review, a.Is_Requirement, 
+                a.Is_Framework
+FROM            dbo.ANSWER AS a 
+					INNER JOIN dbo.COMPONENT_QUESTIONS AS cq ON cq.Question_Id = a.Question_Or_Requirement_Id 
+					INNER JOIN dbo.NEW_QUESTION AS q ON cq.Question_Id = q.Question_Id 
+					INNER JOIN dbo.ASSESSMENT_DIAGRAM_COMPONENTS AS adc ON a.Assessment_Id = adc.Assessment_Id AND adc.Component_Symbol_Id = cq.Component_Symbol_Id 
+					LEFT OUTER JOIN dbo.DIAGRAM_CONTAINER AS l ON adc.Layer_Id = l.Container_Id 
+					LEFT OUTER JOIN dbo.DIAGRAM_CONTAINER AS z ON z.Assessment_Id = adc.Assessment_Id AND z.Container_Id = adc.Zone_Id
+					INNER JOIN STANDARD_SELECTION ss on adc.Assessment_Id = ss.Assessment_Id
+					INNER JOIN NEW_QUESTION_SETS qs on q.question_id = qs.question_id and qs.Set_Name = 'Components'		
+					INNER JOIN NEW_QUESTION_LEVELS nql on qs.New_Question_Set_Id = nql.New_Question_Set_Id 
+						and nql.Universal_Sal_Level = dbo.convert_sal(ISNULL(z.Universal_Sal_Level, ss.Selected_Sal_Level))
+
 WHERE        (a.Is_Component = 1) AND (COALESCE (l.Visible, 1) = 1)

--- a/Database Scripts/Views/Answer_Questions_No_Components.view.sql
+++ b/Database Scripts/Views/Answer_Questions_No_Components.view.sql
@@ -1,6 +1,10 @@
+
+
 CREATE VIEW [dbo].[Answer_Questions_No_Components]
 AS
-SELECT        Answer_Id, Assessment_Id, Mark_For_Review, Comment, Alternate_Justification, Is_Requirement, Question_Or_Requirement_Id, Question_Number, Answer_Text, Component_Guid, Is_Component, Is_Framework, Reviewed, 
-                         FeedBack, Custom_Question_Guid, Old_Answer_Id
-FROM            dbo.ANSWER
+SELECT       Answer_Id, Assessment_Id, Mark_For_Review, Comment, Alternate_Justification, Is_Requirement, 
+			 Question_Or_Requirement_Id, Question_Number, Answer_Text, Component_Guid, Is_Component, Is_Framework, Reviewed, 
+                   FeedBack, Custom_Question_Guid, Old_Answer_Id
+FROM         dbo.ANSWER
 WHERE        (Is_Requirement = 0) AND (Is_Component = 0)
+


### PR DESCRIPTION
... not applicable to their component's zone's SAL.

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Before this fix, the view was picking up questions/answers that (correctly) were not asked.  The questions were attached to components that were in zones with a SAL level not compatible with the allowable SALs for the questions.  When the components summary graph was drawn, there was a block of unanswered questions in the graph, even though every asked question had been answered.  
This fix makes sure that questions not compatible with the component's zone are not considered "in scope."


## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
