### PR TITLE
Remove length restriction from Comments, format linebreaks

### DIFF
--- a/CSETWebApi/CSETWeb_Api/DataLayerCore/Model/ANSWER.cs
+++ b/CSETWebApi/CSETWeb_Api/DataLayerCore/Model/ANSWER.cs
@@ -19,7 +19,6 @@ namespace DataLayerCore.Model
         public bool Is_Requirement { get; set; }
         public int Question_Or_Requirement_Id { get; set; }
         public bool? Mark_For_Review { get; set; }
-        [StringLength(2048)]
         public string Comment { get; set; }
         [StringLength(2048)]
         public string Alternate_Justification { get; set; }
@@ -36,6 +35,7 @@ namespace DataLayerCore.Model
         public bool Reviewed { get; set; }
         [StringLength(2048)]
         public string Feedback { get; set; }
+        public bool Is_Maturity { get; set; }
 
         [ForeignKey("Answer_Text")]
         [InverseProperty("ANSWER")]

--- a/CSETWebApi/CSETWeb_Api/DataLayerCore/Model/ANSWER.cs
+++ b/CSETWebApi/CSETWeb_Api/DataLayerCore/Model/ANSWER.cs
@@ -35,7 +35,6 @@ namespace DataLayerCore.Model
         public bool Reviewed { get; set; }
         [StringLength(2048)]
         public string Feedback { get; set; }
-        public bool Is_Maturity { get; set; }
 
         [ForeignKey("Answer_Text")]
         [InverseProperty("ANSWER")]

--- a/CSETWebNg/src/app/assessment/prepare/irp-summary/irp-summary.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/irp-summary/irp-summary.component.html
@@ -43,7 +43,7 @@
               <td class="text-right">{{ irp.RiskCount[2] }}</td>
               <td class="text-right">{{ irp.RiskCount[3] }}</td>
               <td class="text-right">{{ irp.RiskCount[4] }}</td>
-              <td class="text-nowrap">{{ irp.Comment }}</td>
+              <td class="text-nowrap" [innerHTML]="irp.Comment"></td>
           </tr>
           <tr class="total-row">
               <td class="border-table">Totals</td>

--- a/CSETWebNg/src/app/assessment/results/dashboard/acet-dashboard.component.html
+++ b/CSETWebNg/src/app/assessment/results/dashboard/acet-dashboard.component.html
@@ -62,7 +62,7 @@
                 <td class="text-right">{{ irp.RiskCount[2] }}</td>
                 <td class="text-right">{{ irp.RiskCount[3] }}</td>
                 <td class="text-right">{{ irp.RiskCount[4] }}</td>
-                <td class="text-nowrap">{{ irp.Comment }}</td>
+                <td class="text-nowrap" [innerHTML]="reportSvc.formatLinebreaks(irp.Comment)"></td>
             </tr>
             <tr class="total-row">
                 <td class="border-table">Totals</td>

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.html
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.html
@@ -769,7 +769,7 @@
                     <td class="text-right">{{ irp.RiskCount[2] }}</td>
                     <td class="text-right">{{ irp.RiskCount[3] }}</td>
                     <td class="text-right">{{ irp.RiskCount[4] }}</td>
-                    <td class="text-nowrap">{{ irp.Comment }}</td>
+                    <td class="text-nowrap" [innerHTML]="reportSvc.formatLinebreaks(irp.Comment)"></td>
                 </tr>
                 <tr>
                     <td class="border-table">Totals</td>

--- a/CSETWebNg/src/app/reports/sitesummary/sitesummary.component.html
+++ b/CSETWebNg/src/app/reports/sitesummary/sitesummary.component.html
@@ -388,7 +388,7 @@
             </tr>
         </table>
 
-        
+
         <div *ngIf="response?.salTable.LastSalDeterminationType === 'GENERAL'">
             <p>
                 <b>Calculated General Security Assurance Levels (SAL)</b>
@@ -646,7 +646,7 @@
                     <td class="text-right">{{ irp.RiskCount[2] }}</td>
                     <td class="text-right">{{ irp.RiskCount[3] }}</td>
                     <td class="text-right">{{ irp.RiskCount[4] }}</td>
-                    <td class="text-nowrap">{{ irp.Comment }}</td>
+                    <td class="text-nowrap" [innerHTML]="reportSvc.formatLinebreaks(irp.Comment)"></td>
                 </tr>
                 <tr>
                     <td class="border-table">Totals</td>
@@ -795,7 +795,7 @@
             </tr>
             <tr>
                 <td class="tint2">Comment:</td>
-                <td colspan="2">{{c.Comment}}</td>
+                <td colspan="2" [innerHTML]="reportSvc.formatLinebreaks(c.Comment)"></td>
             </tr>
         </table>
 

--- a/CSETWebNg/src/app/services/maturity.service.ts
+++ b/CSETWebNg/src/app/services/maturity.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@angular/core';
+import { ConfigService } from './config.service';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+
+const headers = {
+  headers: new HttpHeaders().set("Content-Type", "application/json"),
+  params: new HttpParams()
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MaturityService {
+
+  /**
+   * 
+   */
+  levels = [
+    { name: "One", value: 1 },
+    { name: "Two", value: 2 },
+    { name: "Three", value: 3 },
+    { name: "Four", value: 4 },
+    { name: "Five", value: 5 }
+  ];
+
+  /**
+   * 
+   * @param http 
+   * @param configSvc 
+   */
+  constructor(
+    private http: HttpClient,
+    private configSvc: ConfigService
+  ) { }
+
+
+  /**
+   * Posts the current selections to the server.
+   */
+  postSelections(selections: string[]) {
+    return this.http.post(
+      this.configSvc.apiUrl + "MaturityModels",
+      selections,
+      headers
+    );
+  }
+
+  /**
+   * Gets the saved maturity level from the API
+   */
+  getLevel() {
+    return this.http.get(
+      this.configSvc.apiUrl + "MaturityLevel",
+      headers
+    )
+  }
+  /**
+   * Posts the selected maturity level to the API. 
+   * @param level 
+   */
+  saveLevel(level: number) {
+    return this.http.post(
+      this.configSvc.apiUrl + "MaturityLevel",
+      level,
+      headers
+    )
+  }
+
+}


### PR DESCRIPTION
Allow comments to be stored as varchar(max).  Removed maxlength restriction on screen.  
Format linebreaks for comments on reports.  

## 🗣 Description

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
