### PR TITLE
Flag missing alt justifications for ACET installations

### DIFF
--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/AssessmentManager.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/AssessmentManager.cs
@@ -88,7 +88,8 @@ namespace CSETWeb_Api.BusinessManagers
 
             using (var db = new CSET_Context())
             {
-                list = db.Assessments_For_User.Where(x => x.UserId == userId).ToList();
+                // list = db.Assessments_For_User.Where(x => x.UserId == userId).ToList();
+                list = db.usp_AssessmentsForUser(userId).ToList();
             }
 
             return list;

--- a/CSETWebApi/CSETWeb_Api/DataLayerCore/Manual/Assessments_For_User.cs
+++ b/CSETWebApi/CSETWeb_Api/DataLayerCore/Manual/Assessments_For_User.cs
@@ -17,18 +17,29 @@ namespace DataLayerCore.Model
     /// </summary>
     public partial class Assessments_For_User
     {
-        //[Key]
-        //public int RowNumber { get; set; }
         public int AssessmentId { get; set; }
+
         public string AssessmentName { get; set; }
+
         public DateTime AssessmentDate { get; set; }
+
         public DateTime AssessmentCreatedDate { get; set; }
-        public string CreatorName { get; set; }        
+
+        public string CreatorName { get; set; }    
+        
         public DateTime LastModifiedDate { get; set; }
+
         /// <summary>
         /// Indicates if any questions in the assessment are marked for review
         /// </summary>
-        public bool MarkedForReview { get; set; }        
+        public bool MarkedForReview { get; set; }  
+        
+        /// <summary>
+        /// Indicates if any questions in the assessment are answered ALT 
+        /// but have no corresponding alternate answer text. 
+        /// </summary>
+        public bool AltTextMissing { get; set; }
+
         public int UserId { get; set; }
     }
 }

--- a/CSETWebApi/CSETWeb_Api/DataLayerCore/Manual/CSET_Context.cs
+++ b/CSETWebApi/CSETWeb_Api/DataLayerCore/Manual/CSET_Context.cs
@@ -162,6 +162,30 @@ namespace DataLayerCore.Model
 
 
         /// <summary>
+        /// Executes stored procedure usp_AssesmentsForUser.
+        /// This used to be queried as a view, but in order to get the AltTextMissing it was 
+        /// easier to build a procedure.
+        /// </summary>
+        /// <param name="assessment_id"></param>
+        /// <returns></returns>
+        public virtual IList<Assessments_For_User> usp_AssessmentsForUser(Nullable<int> userId)
+        {
+            if (!userId.HasValue)
+                throw new ApplicationException("parameters may not be null");
+
+            IList<Assessments_For_User> myrval = null;
+            this.LoadStoredProc("usp_Assessments_For_User")
+                     .WithSqlParam("user_id", userId)
+
+                     .ExecuteStoredProc((handler) =>
+                     {
+                         myrval = handler.ReadToList<Assessments_For_User>();
+                     });
+            return myrval;
+        }
+
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="originalEmail"></param>

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
@@ -135,8 +135,9 @@
         </div>
 
         <div *ngIf="q.Answer === 'A'">
-          <textarea appAutoSize class="form-control" style="height: 80px; width: 100%; min-height: 72px;"
+          <textarea appAutoSize class="form-control" [class.alt-text-required]="isAltTextRequired(q)" style="width: 100%; min-height: 80px;"
             [placeholder]="altTextPlaceholder" [(ngModel)]="q.AltAnswerText" (change)="storeAltText(q)"></textarea>
+            <div *ngIf="isAltTextRequired(q)" class="alt-text-required-msg">* Description required</div>
         </div>
       </div>
     </div>

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
@@ -55,8 +55,16 @@ export class QuestionBlockComponent implements OnInit {
   private _timeoutId: NodeJS.Timeout;
 
   altTextPlaceholder = "Description, explanation and/or justification for alternate answer";
-  altTextPlaceholder_ACET = "Description, explanation and/or justification for a compensating control";
+  altTextPlaceholder_ACET = "Description, explanation and/or justification for compensating control";
 
+  /**
+   * 
+   * @param questionsSvc 
+   * @param filterSvc 
+   * @param dialog 
+   * @param configSvc 
+   * @param assessSvc 
+   */
   constructor(
     public questionsSvc: QuestionsService,
     public filterSvc: QuestionFilterService,
@@ -70,6 +78,9 @@ export class QuestionBlockComponent implements OnInit {
     this.matLevelMap.set("Inn", "Innovative");
   }
 
+  /**
+   * 
+   */
   ngOnInit() {
     this.refreshReviewIndicator();
     this.refreshPercentAnswered();
@@ -180,11 +191,16 @@ export class QuestionBlockComponent implements OnInit {
   /**
    * Looks at all questions in the subcategory to see if any
    * are marked for review.
+   * Also returns true if alt text is required but not supplied.
    */
   refreshReviewIndicator() {
     this.mySubCategory.HasReviewItems = false;
     this.mySubCategory.Questions.forEach(q => {
       if (q.MarkForReview) {
+        this.mySubCategory.HasReviewItems = true;
+        return;
+      }
+      if (q.Answer == 'A' && this.isAltTextRequired(q)) {
         this.mySubCategory.HasReviewItems = true;
         return;
       }
@@ -300,6 +316,18 @@ export class QuestionBlockComponent implements OnInit {
 
     this.questionsSvc.storeAnswer(answer)
       .subscribe();
+  }
+
+  /**
+   * For ACET installations, alt answers require 3 or more characters of 
+   * justification.
+   */
+  isAltTextRequired(q: Question) {
+    if (this.configSvc.acetInstallation 
+      && (!q.AltAnswerText || q.AltAnswerText.trim().length < 3)) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/CSETWebNg/src/app/initial/landing-page/landing-page.component.html
+++ b/CSETWebNg/src/app/initial/landing-page/landing-page.component.html
@@ -151,7 +151,7 @@
                 </td>
                 <td>{{assessment.LastModifiedDate | date:'dd-MMM-yyyy'}}</td>
                 <td>{{assessment.CreatorName}}</td>
-                <td><span *ngIf="assessment.MarkedForReview" class=""
+                <td><span *ngIf="assessment.MarkedForReview || assessment.AltTextMissing" class=""
                         matTooltip="This assessment contains answers that require further review.">Needs
                         Review</span></td>
                 <td>

--- a/CSETWebNg/src/app/initial/landing-page/landing-page.component.ts
+++ b/CSETWebNg/src/app/initial/landing-page/landing-page.component.ts
@@ -46,6 +46,7 @@ interface UserAssessment {
   CreatorName: string;
   LastModifiedDate: string;
   MarkedForReview: boolean;
+  AltTextMissing: boolean;
 }
 
 @Component({

--- a/CSETWebNg/src/sass/styles.scss
+++ b/CSETWebNg/src/sass/styles.scss
@@ -600,6 +600,13 @@ table.td-align-top td {
   color: $gray-900;
 }
 
+.alt-text-required {
+  border: 2px solid $validation-color;
+}
+
+.alt-text-required-msg {
+  color: $validation-color;
+}
 
 
 .btn-sal-select {

--- a/Database Scripts/Stored Procedures/usp_Assessments_For_User.proc.sql
+++ b/Database Scripts/Stored Procedures/usp_Assessments_For_User.proc.sql
@@ -1,0 +1,62 @@
+
+
+CREATE PROCEDURE [usp_Assessments_For_User]
+@User_Id int
+AS
+
+-- Replaces view Assessments_For_User.  Gathering missing alt justification is
+-- more straightforward using a procedure than a view.
+
+-- build a temp table with ALT answers without justification
+select distinct assessment_id 
+into #ATM
+from Answer_Standards_InScope
+where (isnull(alternate_justification, '') = '' and answer_text = 'A')
+
+insert into #ATM
+select distinct assessment_id 
+from Answer_Maturity
+where (isnull(alternate_justification, '') = '' and answer_text = 'A')
+
+insert into #ATM
+select distinct assessment_id 
+from Answer_Components_InScope
+where (isnull(alternate_justification, '') = '' and answer_text = 'A')
+
+
+select 	
+    AssessmentId = a.Assessment_Id,
+	AssessmentName = Assessment_Name,
+	AssessmentDate = Assessment_Date,
+	AssessmentCreatedDate,
+	CreatorName = u.FirstName + ' ' + u.LastName,
+	LastModifiedDate = LastAccessedDate,
+	MarkedForReview = isnull(mark_for_review,0),
+	case when a.assessment_id in (select assessment_id from #ATM) then CAST(1 AS BIT) else CAST(0 AS BIT) END as AltTextMissing,
+	c.UserId
+	from ASSESSMENTS a 
+		join INFORMATION i on a.Assessment_Id = i.Id
+		join USERS u on a.AssessmentCreatorId = u.UserId
+		join ASSESSMENT_CONTACTS c on a.Assessment_Id = c.Assessment_Id and c.UserId = @User_Id
+		left join (
+			select distinct a.Assessment_Id, v.Mark_For_Review
+			from ASSESSMENTS a 
+			join Answer_Standards_InScope v on a.Assessment_Id = v.Assessment_Id 
+			where v.Mark_For_Review = 1 
+
+			union
+
+			select distinct a.Assessment_Id, Mark_For_Review
+			from ASSESSMENTS a
+			join Answer_Maturity v on a.Assessment_id = v.Assessment_Id
+			where v.Mark_For_Review = 1
+
+			union 
+
+			select distinct a.Assessment_Id, Mark_For_Review 
+			from ASSESSMENTS a 
+			join Answer_Components_InScope v on a.Assessment_Id = v.Assessment_Id 
+			where v.Mark_For_Review = 1) b 
+			
+		on a.Assessment_Id = b.Assessment_Id
+		where u.UserId = @user_id


### PR DESCRIPTION
# Indicate missing alternate justification text #

## 🗣 Description ##

NCUA wants to require justifications for any "alt" answers.  Rather than trap the user's cursor in the field, we will highlight the field, display a validation message next to the field and indicate that the category and assessment require review.

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
