### PR TITLE
Pull physical documents if no binary data in GEN_FILE

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Controllers/ReferenceDocumentsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_Api/Controllers/ReferenceDocumentsController.cs
@@ -29,7 +29,6 @@ namespace CSETWeb_Api.Controllers
 
         [HttpGet]
         [Route("api/ReferenceDocuments/{fileName}")]
-
         public async Task<HttpResponseMessage> Get(string fileName)
         {
             return await Task.Run(() =>
@@ -51,23 +50,36 @@ namespace CSETWeb_Api.Controllers
 
                     foreach (var f in files.ToList())
                     {
-                        var stream = new MemoryStream(f.a.Data);
-                    result.Content = new StreamContent(stream);
-                        result.Content.Headers.ContentType = new MediaTypeHeaderValue(f.f.Mime_Type);
-                    return result;
-                    }
-                    return null;
+                        Stream stream;
 
+                        // use binary data if available, otherwise get physical file
+                        if (f.a.Data != null)
+                        {
+                            stream = new MemoryStream(f.a.Data);
+                        }
+                        else
+                        {
+                            var apiPath = System.Web.Hosting.HostingEnvironment.MapPath("~");
+                            var docPath = Path.Combine(apiPath, "Documents", f.a.File_Name);
+                            stream = new FileStream(docPath, FileMode.Open);
+                        }
+
+                        result.Content = new StreamContent(stream);
+                        result.Content.Headers.ContentType = new MediaTypeHeaderValue(f.f.Mime_Type);
+                        return result;
+                    }
+
+                    return null;
                 }
             });
         }
+
+
         [HttpPost]
         [CSETAuthorize]
         [Route("api/ReferenceDocuments")]
-
         public async Task<HttpResponseMessage> Post()
         {
-
             try
             {
                 // Check if the request contains multipart/form-data.
@@ -134,6 +146,8 @@ namespace CSETWeb_Api.Controllers
 
             }
         }
+
+
         private static string UnquoteToken(string token)
         {
             if (String.IsNullOrWhiteSpace(token))

--- a/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.html
@@ -10,7 +10,7 @@
     {{domain?.Description}}
 </p>
 
-<table *ngFor="let goal of domain?.SubGroupings" class="w-100 cset-table">
+<table *ngFor="let goal of domain?.SubGroupings" class="w-100 mb-5 cset-table">
     <tr>
         <td colspan="3">
             <div class="font-weight-bold mb-3">
@@ -44,3 +44,8 @@
         <td></td>
     </tr>
 </table>
+
+<h5>Domain Remarks - {{domain.Title}}</h5>
+<p class="mb-5">
+    {{domain.DomainRemark ? domain.DomainRemark : 'No remarks have been entered'}}
+</p>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Requests for a reference document pulled binary data from the GEN_FILE table's [Data] column.  To save space, we want to null out that column as much as possible.  I added code that will go after the physical file in the Documents folder if there is no binary content defined in [GEN_FILE].[Data].

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
