### PR TITLE
Fixed ACET-266 and ACET-267

### DIFF
--- a/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/InformationTabData/QuestionDetailsContentViewModel.cs
+++ b/CSETWebApi/CSETWeb_Api/BusinessLogic/BusinessManagers/InformationTabData/QuestionDetailsContentViewModel.cs
@@ -169,15 +169,17 @@ namespace CSET_Main.Views.Questions.QuestionDetails
 
             if (questionId != null)
             {
+                var selectedSets = this.DataContext.AVAILABLE_STANDARDS.Where(x => x.Assessment_Id == assessmentId);
+
                 AssessmentModeData mode = new AssessmentModeData(this.DataContext, assessmentId);
                 bool IsQuestion = mode.IsQuestion;
                 bool IsRequirement = IsComponent ? !IsComponent : mode.IsRequirement;
-                var newqp = this.DataContext.NEW_QUESTION.Where(q => q.Question_Id == questionId).FirstOrDefault();
-                var newAnswer = this.DataContext.ANSWER.Where(a => a.Question_Or_Requirement_Id == questionId
-                    && a.Is_Requirement == IsRequirement && a.Assessment_Id == assessmentId).FirstOrDefault();
-                var gettheselectedsets = this.DataContext.AVAILABLE_STANDARDS.Where(x => x.Assessment_Id == assessmentId);
 
-                
+                var newqp = this.DataContext.NEW_QUESTION.Where(q => q.Question_Id == questionId).FirstOrDefault();
+                var newAnswer = this.DataContext.ANSWER.Where(a =>
+                    a.Question_Or_Requirement_Id == questionId
+                    && a.Assessment_Id == assessmentId).FirstOrDefault();
+
 
                 if (newAnswer == null)
                 {

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -64,7 +64,7 @@
     <div class="form-row" [hidden]="!configSvc.acetInstallation">
             <div class="form-group col-md-6">
                     <label class="mb-1" for="charter">Charter</label>
-                    <input type="text" [maxlength]="5" class="form-control" id="charter" name="charter" [(ngModel)]="assessment.Charter" 
+                    <input type="text" [maxlength]="5" class="form-control" id="charter" name="charter" [(ngModel)]="assessment.Charter" digitsOnly
                         (change)="update($event)" (blur)="update($event)" (input)="createAcetName()" tabindex="0">
                 </div>
         <div class="form-group col-md-6">


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

ACET-266 - disappearing Observation.  The query for an existing answer was using an IsRequirement flag, which may not be relevant in maturity situations, and it was causing the API to think that the answer was not there, so it could not find the existing Observation.   

ACET-267 - Applied a "digitsOnly" directive to the Charter number field.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
