### PR TITLE
Feature/CSET-766

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
@@ -28,9 +28,7 @@ namespace CSETWeb_ApiCore
                     int startPort = 5000;
                     int httpPort = CheckPorts(startPort);
                     int httpsPort = CheckPorts(httpPort + 1);
-                    webBuilder.UseUrls("http://localhost:" + httpPort.ToString() + ";https://localhost:" + httpsPort.ToString())
-                               .UseKestrel()
-                               .UseStartup<Startup>();
+                    webBuilder.UseStartup<Startup>().UseUrls("http://localhost:" + httpPort.ToString() + ";https://localhost:" + httpsPort.ToString());
                 });
 
 
@@ -50,7 +48,7 @@ namespace CSETWeb_ApiCore
                     try
                     {
                         tcpClient.Connect("127.0.0.1", port);
-                        Console.WriteLine("Port " + port.ToString() + " is already listening for connections. Looking at next port...\r\n");
+                        Console.WriteLine("Port " + port.ToString() + " is already listening for connections. Incrementing to next port...\r\n");
                         port++;
                     }
                     catch (Exception)

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System;
+using System.Net.Sockets;
 
 namespace CSETWeb_ApiCore
 {
@@ -23,7 +25,42 @@ namespace CSETWeb_ApiCore
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    int startPort = 5000;
+                    int httpPort = CheckPorts(startPort);
+                    int httpsPort = CheckPorts(httpPort + 1);
+                    webBuilder.UseUrls("http://localhost:" + httpPort.ToString() + ";https://localhost:" + httpsPort.ToString())
+                               .UseKestrel()
+                               .UseStartup<Startup>();
                 });
+
+
+        /// <summary>
+        /// Checks if local port is already in use and increments by one until available port is found
+        /// </summary>
+        /// <param name="port"> The starting port to check </param>
+        /// <returns> The next available port to be used by the api </returns>
+        private static int CheckPorts(int port)
+        {
+            bool foundAvailablePort = false;
+            Console.WriteLine("Begin check for available ports to be used...\r\n");
+            while (foundAvailablePort == false)
+            {
+                using (TcpClient tcpClient = new TcpClient())
+                {
+                    try
+                    {
+                        tcpClient.Connect("127.0.0.1", port);
+                        Console.WriteLine("Port " + port.ToString() + " is already listening for connections. Looking at next port...\r\n");
+                        port++;
+                    }
+                    catch (Exception)
+                    {
+                        Console.Write("Port " + port.ToString() + " is not listening for any connections. Application will use this port.\r\n");
+                        foundAvailablePort = true;
+                    }
+                }
+            }
+            return port;
+        }
     }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

First attempt at automatic port migration when default api ports are already in use by another process. Default ports 5000 and 5001 availability are checked at runtime and, if they are in use already, the port number is incremented until available ports are found.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
