### PR TITLE
Fixed Module Builder default SAL level lying to you

### DIFF
--- a/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
+++ b/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
@@ -116,6 +116,7 @@ export class RequirementDetailComponent implements OnInit {
       // Default to a low SAL
       if (this.r.salLevels.length === 0) {
         this.r.salLevels.push('L');
+        this.setBuilderSvc.setSalLevel(this.r.requirementID, 0, 'L', true).subscribe();
       }
     });
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Originally, when creating a requirement within the Module Builder, the default SAL level appeared to be set to low. However, the selection was not being sent to the API, and the requirements count on the Standards Selection page remained at zero . This is now fixed.

## 💭 Motivation and context ##
Bug/CSET-733

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Steps taken to verify fix:
1. Create a new Module in Module Builder.
2. Add a new requirement, and do not change the default SAL (Low).
3. Enter an assessment and navigate to the "Cybersecurity Standards Selection" page.
4. Select only the module that was created in step 1.
5. The requirements count is now accurate (1).

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
