### PR TITLE
Fixed alt text not persisting when leaving question page immediately after typing

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
@@ -1,24 +1,24 @@
-<!---------------------- 
+<!----------------------
 
-   Copyright 2021 Battelle Energy Alliance, LLC  
+   Copyright 2021 Battelle Energy Alliance, LLC
 
-  Permission is hereby granted, free of charge, to any person obtaining a copy 
-  of this software and associated documentation files (the "Software"), to deal 
-  in the Software without restriction, including without limitation the rights 
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-  copies of the Software, and to permit persons to whom the Software is 
-  furnished to do so, subject to the following conditions: 
- 
-  The above copyright notice and this permission notice shall be included in all 
-  copies or substantial portions of the Software. 
- 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
-  SOFTWARE. 
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 -------------------------->
 <div class="question-group">
 
@@ -41,7 +41,7 @@
         <i class="cset-icons-chevron-down q-expand" [class.expand-flip]="mySubCategory.expanded"></i>
       </div>
     </div>
-    <div class="header-question" *ngIf="mySubCategory.headerQuestionText !== null 
+    <div class="header-question" *ngIf="mySubCategory.headerQuestionText !== null
                   && mySubCategory.headerQuestionText.length > 0
                   && mySubCategory.questions.length > 1" [class.display-none]="!mySubCategory.expanded">
 
@@ -118,7 +118,7 @@
           <div *ngIf="q.answer === 'A'">
             <textarea appAutoSize class="form-control" [class.alt-text-required]="isAltTextRequired(q)"
               style="width: 100%; min-height: 80px;" [placeholder]="altTextPlaceholder" [(ngModel)]="q.altAnswerText"
-              (change)="storeAltText(q)" tabindex="0"></textarea>
+              (ngModelChange)="storeAltText(q)" tabindex="0"></textarea>
             <div *ngIf="isAltTextRequired(q)" class="alt-text-required-msg">* Description required</div>
           </div>
         </div>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The (change) DOM event will only fire when an HTML element has lost focus (the user has tabbed out of the textarea). By using the (ngModelChange) event, the alt text is actually saved immediately after any change in the textarea.

## 💭 Motivation and context ##
bug/CSET-835

## 🧪 Testing ##
**To verify fix:**
1. Enter alt text on a question, but don't tab out.
2. Immediately click on "Requirements Mode" button.
3. Return to Questions Mode.
4. Navigate to the same question that had alt text entered in step 1; the alt text now persists.

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
