### PR TITLE
CSET-954

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreStackedBarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreStackedBarChart.cs
@@ -17,7 +17,7 @@ namespace CSETWebCore.Helpers.ReportWidgets
 
         public ScoreStackedBarChart(BarChartInput d)
         {
-            int maxAnswerCount = d.AnswerCounts.Max();
+            int maxAnswerCount = d.AnswerCounts.Sum();
 
             xDoc = new XDocument(new XElement("svg"));
             var xSvg = xDoc.Root;
@@ -40,7 +40,7 @@ namespace CSETWebCore.Helpers.ReportWidgets
                     xSvg.Add(xRect);
 
                     float pct = (float)d.AnswerCounts[i] / (float)maxAnswerCount;
-                    var segmentWidth = (float)d.Width * pct;
+                    var segmentWidth = ((float)d.Width * pct);
 
                     xRect.SetAttributeValue("height", d.Height.ToString());
                     xRect.SetAttributeValue("width", segmentWidth.ToString());

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrMil1PerformanceSummary.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrMil1PerformanceSummary.cshtml
@@ -29,12 +29,12 @@
 
 
             <div class="row" style="border-bottom: 2px solid #000">
-                <div class="col-md-3">
+                <div class="col-md-2">
                     @domain.Attribute("title").Value
                     @Html.Raw(barChart.ToString())
                 </div>
                 
-                <div class="col-md-9">
+                <div class="col-md-10">
                     @{ 
                         foreach (XElement goal in domain.Elements().Elements())
                         {
@@ -47,8 +47,8 @@
                                 var stackedChart = new ScoreStackedBarChart(stackedBarChartInput);
 
                                 <div class="row">
-                                    <div class="col-md-6">@goal.Attribute("title").Value</div>
-                                    <div class="col-md-6" style="padding: 0.25rem;">@Html.Raw(stackedChart.ToString())</div>
+                                    <div class="col-md-8">@goal.Attribute("title").Value</div>
+                                    <div class="col-md-4" style="padding: 0.25rem;">@Html.Raw(stackedChart.ToString())</div>
                                 </div>
                             }
                             
@@ -57,79 +57,7 @@
 
                 </div>
             </div>
-
         }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-            @*foreach (XElement domain in XDocument.Root.Elements())
-            {
-
-            <table class="w-100 outer-table" style="border-bottom: 2px solid #000">
-                <tr class="col-md-3">
-                    <td style="width: 25%%">
-                        <div class="tbc-title">@domain.Attribute("title").Value</div>
-                        <br />
-                        @{
-                            var domainScores = Model.CRRScores.DomainAnswerDistrib(domain.Attribute("abbreviation").Value);
-                            var barChartInput = new BarChartInput();
-                            barChartInput.AnswerCounts = new List<int> { domainScores.Green, domainScores.Yellow, domainScores.Red };
-                            var barChart = new ScoreBarChart(barChartInput);
-
-                        }
-                        <div>@Html.Raw(barChart.ToString())</div>
-                    </td>
-
-
-
-                    <td class="col-md-9">
-                        <table class="w-100 inner-table mb-3">
-                            @{
-                                foreach (XElement goal in domain.Elements().Elements())
-                                {
-                                    if (goal.Attribute("title").Value.Contains("Goal"))
-                                    {
-                                        <tr class="tbc-bars">
-                                            <td>@goal.Attribute("title").Value</td>
-                                            @{
-                                                var goalScores = Model.CRRScores.GoalAnswerDistrib(domain.Attribute("abbreviation").Value, goal.Attribute("abbreviation").Value);
-                                                var stackedBarChartInput = new BarChartInput();
-                                                stackedBarChartInput.AnswerCounts = new List<int> { goalScores.Green, goalScores.Yellow, goalScores.Red };
-
-                                                var stackedChart = new ScoreStackedBarChart(stackedBarChartInput);
-
-                                            }
-
-                                            <td style="width: 100%; height: 1.5rem; padding: .25rem; vertical-align: middle;">@Html.Raw(stackedChart.ToString())</td>
-
-
-                                        </tr>
-                                    }
-                                }
-
-                            }
-
-
-                        </table>
-
-
-                    </td>
-                </tr>
-            </table>
-            <hr />
-
-        }*@
     }
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR closes task CSET-954. This PR is related to a small fix in the StackedBarChart.cs class, making the bar charts all have the same width independent of their answer distribution. I also made a small adjustment to the css-grid in the .cshtml, making it look more like the report.

## 💭 Motivation and context ##

StackedBarChart.cs change was a bug. CRRMil1Performance.cshtml is needed for report.

## 🧪 Testing ##

**1 pass / 1 fail**

Passes: Hitting the CrrReport endpoint from the Reports project generates the report with below screenshot.

Fails: My front-end is having issues, so I'm not able to verify PDF generation is functional. Before merging can you verify that report generation from the angular side works for you. 


## 📷 Screenshots (if appropriate) ##

![image](https://user-images.githubusercontent.com/46133948/133718547-ec570860-9d94-42a9-a154-50a718ce47db.png)

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
