### PR TITLE
table-of-contents should have its own style definitions

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Crr/CrrReport.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Crr/CrrReport.cshtml
@@ -12,6 +12,7 @@
     View = "crrReport",
     Filename = "CSET CRR Report.pdf"
 })
+@await Html.PartialAsync("_CrrSideToc")
 
 <div class="report-body-crr">
     <div id="toc-top">
@@ -79,4 +80,3 @@
     </div>
 </div>
 
-@await Html.PartialAsync("_CrrSideToc") 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Home/CrrResults.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Home/CrrResults.cshtml
@@ -3,8 +3,9 @@
 @{
     ViewData["Title"] = "CRR Report - CSET";
 }
-@*<link rel="stylesheet" href="@(TempData["links"]+"/css/site.css")" />
-<link rel="stylesheet" href="@(TempData["links"]+"/css/CRRResults.css")" />*@
+<link rel="stylesheet" href="wwwroot/css/site.css" />
+<link rel="stylesheet" href="wwwroot/css/CRRResults.css" />
+
 <div class="parent">
     <div class="CrrResultsHeaderSection">
         <div class="CrrResultsHeaderSectionTopRow">

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrSideToc.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrSideToc.cshtml
@@ -1,4 +1,29 @@
-﻿<link rel="stylesheet" href="wwwroot/css/site.css" />
+﻿<style>
+    .side-toc {
+        background-color: #fff;
+        box-sizing: border-box;
+        border-right: solid 1px #E5E4E2;
+        box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+        position: fixed;
+        left: 0;
+        top: 60px;
+        height: calc(100vh - 60px);
+        padding: 0.75rem;
+        overflow-y: auto;
+        width: 15vw;
+        min-width: 250px;
+    }
+
+    .side-toc a {
+        font-size: 12px;
+        word-break: break-word;
+        text-decoration: none;
+    }
+
+    .side-toc div {
+        margin: 10px;
+    }
+</style>
 
 <div class="side-toc">
     <div>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/wwwroot/css/site.css
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/wwwroot/css/site.css
@@ -116,33 +116,6 @@ table {
     font-family: Arial;
 }
 
-
-
-.side-toc {
-    background-color: #fff;
-    box-sizing: border-box;
-    border-right: solid 1px #E5E4E2;
-    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
-    position: fixed;
-    left: 0;
-    top: 60px;
-    height: calc(100vh - 60px);
-    padding: 0.75rem;
-    overflow-y: auto;
-    width: 15vw;
-    min-width: 250px;
-}
-
-    .side-toc a {
-        font-size: 12px;
-        word-break: break-word;
-        text-decoration: none;
-    }
-
-    .side-toc div {
-        margin: 10px;
-    }
-
 @media print {
     .mat-section {
         break-inside: avoid;


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The table-of-contents element in cset-test is not styled. This PR moves css styling from the global stylesheet into the local .cshtml
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Debug rogue report element
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
This is a bug in our test environment
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##
![image](https://user-images.githubusercontent.com/46133948/144876600-51b7d1d0-ab4b-4814-916c-e46804da434a.png)

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All new and existing tests pass.
