### PR TITLE
Appendix A bar charts should use full-answer-distribution rather than just mil-1

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrPerformanceAppendixA.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrPerformanceAppendixA.cshtml
@@ -28,7 +28,7 @@
                     <div class="col" style="padding: 0;">
                         <div class="row" style="padding: 0;">
                             @{
-                                var totalDistribution = Model.CRRScores.MIL1FullAnswerDistrib();
+                                var totalDistribution = Model.CRRScores.FullAnswerDistrib();
                                 var totalBarChartInput = new BarChartInput() { Height = 50, Width = 110 };
                                 totalBarChartInput.AnswerCounts = new List<int>
                                                                     { totalDistribution.Green, totalDistribution.Yellow, totalDistribution.Red };
@@ -121,7 +121,7 @@
 
         foreach (XElement domain in XDocument.Root.Elements())
         {
-            var domainScores = Model.CRRScores.MIL1DomainAnswerDistrib(domain.Attribute("abbreviation").Value);
+            var domainScores = Model.CRRScores.DomainAnswerDistrib(domain.Attribute("abbreviation").Value);
             var barChartInput = new BarChartInput() { Height = 45, Width = 100 };
             barChartInput.AnswerCounts = new List<int> { domainScores.Green, domainScores.Yellow, domainScores.Red };
             var barChart = new ScoreBarChart(barChartInput);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The Appendix A bar charts were calling the wrong function
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Closes CSET-1351
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Bar charts now accurately reflect total domain score:

![image](https://user-images.githubusercontent.com/46133948/145449372-6236a205-5a3a-445b-af75-84e4a0704af6.png)

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
