### PR TITLE
Remove Redundant Zoom Button from Window Tab in Electron Menu

### DIFF
--- a/CSETWebNg/main-electron.js
+++ b/CSETWebNg/main-electron.js
@@ -77,6 +77,21 @@ function createWindow() {
           submenu: newSubmenu,
         })
       );
+    } else if (x.role === 'windowmenu') {
+      let newSubmenu = new Menu();
+
+      // Remove unnecessary Zoom button from window tab
+      x.submenu.items.filter(y => y.label != 'Zoom').forEach(z => newSubmenu.append(z));
+      x.submenu = newSubmenu;
+
+      newMenu.append(
+        new MenuItem({
+          role: x.role,
+          type: x.type,
+          label: x.label,
+          submenu: newSubmenu,
+        })
+      );
     } else {
       newMenu.append(x);
     }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Non-working Zoom button removed from Window tab. There are already zoom in and zoom out buttons in the View tab anyways.

## 💭 Motivation and context ##

CSET-1390
## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

![image](https://user-images.githubusercontent.com/46506777/145867802-ceb52775-0b9f-4375-95b3-4bec6fe098f5.png)


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
