### PR TITLE
rounding in barchart percentage

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreBarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreBarChart.cs
@@ -49,7 +49,7 @@ namespace CSETWebCore.Helpers.ReportWidgets
                 var xRect = new XElement("rect");
                 xSvg.Add(xRect);
 
-                float pct = (float)d.AnswerCounts[i] / (float)maxAnswerCount;
+                float pct = d.AnswerCounts[i] / maxAnswerCount;
                 float barHeight = barSectionHeight * pct;                
                 // don't render a zero-height bar; provide some minimal color
                 if (barHeight < 3)
@@ -97,7 +97,10 @@ namespace CSETWebCore.Helpers.ReportWidgets
                 xText.SetAttributeValue("y", (lineY + 2).ToString());
                 xText.SetAttributeValue("dominant-baseline", "hanging");
                 xText.SetAttributeValue("text-anchor", "middle");
-                xText.Value = ((float)d.AnswerCounts[0] / (float)d.AnswerCounts.Sum()).ToString("P0");
+
+                var percentage = ((double)d.AnswerCounts[0] / (double)d.AnswerCounts.Sum()) * 100;
+                var value = (percentage >= 99 && percentage < 100 ? 99 : Math.Round(percentage, 0, MidpointRounding.AwayFromZero));
+                xText.Value = $"{value}%".ToString();
                 xText.SetAttributeValue("class", "text-normal");
             }
         }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Bar chart percentages in depictions should be rounded correctly.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
62.5% was being rounded to 62% instead of 63%

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
```
@{
    var percentage1 = ((double)5 / (double)8) * 100;
    var value1 = (percentage1 >= 99 && percentage1 < 100 ? 99 : Math.Round(percentage1, 0,
    MidpointRounding.AwayFromZero));
}
<p>@value1</p>
@* 62.5 -> 63 *@

@{
    var percentage2 = ((double)999 / (double)1000) * 100;
    var value2 = (percentage2 >= 99 && percentage2 < 100 ? 99 : Math.Round(percentage2, 0,
    MidpointRounding.AwayFromZero));
}
<p>@value2</p>
@* 99.9 -> 99 *@

@{
    var percentage3 = ((double)1 / (double)3) * 100;
    var value3 = (percentage3 >= 99 && percentage3 < 100 ? 99 : Math.Round(percentage3, 0,
    MidpointRounding.AwayFromZero));
}
<p>@value3</p>
@* 33.3 -> 33 *@
```
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
