### PR TITLE
adjusted minimum width of nist stacked chart container

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrNistCsfCatSummary.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrNistCsfCatSummary.cshtml
@@ -182,7 +182,7 @@
                                                             @{
                                                                 var distSubcategory = GetAnswerDistrib(subcategory.Element("References"));
                                                                 distSubcategory.Height = 20;
-                                                                distSubcategory.Width = 250;
+                                                                distSubcategory.Width = 230;
                                                                 var chartSubcat = new ScoreStackedBarChart(distSubcategory);
                                                             }
                                                             @Html.Raw(chartSubcat)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The minimum width of the container around these bar charts was too wide
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Closes CSET-1411
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Generate the HTML report with provided answer distribution and now the bar charts are whole
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##
![image](https://user-images.githubusercontent.com/46133948/146423511-20ace626-dd4a-4bcd-b8cb-445cf85d281e.png)

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
