### PR TITLE
Fix CMMC 2.0 Results Performance by Level Fails if User Doesn't Select Target Level

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
@@ -238,11 +238,20 @@ namespace CSETWebCore.Business.Maturity
 
             var model = _context.AVAILABLE_MATURITY_MODELS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
 
-            var targetLevel = _context.ASSESSMENT_SELECTED_LEVELS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
+            var selectedLevel = _context.ASSESSMENT_SELECTED_LEVELS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
+            int targetLevel;
+            if (selectedLevel == null)
+            {
+                targetLevel = 1;
+            }
+            else 
+            {
+                targetLevel = int.Parse(selectedLevel.Standard_Specific_Sal_Level);
+            }
 
             var levels = _context.MATURITY_LEVELS
                 .Include(x => x.MATURITY_QUESTIONS)
-                .Where(x => x.Maturity_Model_Id == model.model_id && x.Level <= int.Parse(targetLevel.Standard_Specific_Sal_Level))
+                .Where(x => x.Maturity_Model_Id == model.model_id && x.Level <= targetLevel)
                 .ToList();
 
             var answers = _context.Answer_Maturity.Where(x => x.Assessment_Id == assessmentId);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Added check to default the target level selection to level one if the user does not select anything on the CMMC 2.0 Target Level Selection Page.

## 💭 Motivation and context ##
bug/CSET-1441

## 🧪 Testing ##
Tested locally. No more nullReferenceExceptions when no target level selection is made.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
