### PR TITLE
fix overflow on crr-appendix and container on crr contact information

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrContactInformation.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrContactInformation.cshtml
@@ -24,9 +24,9 @@
 
 }
 
-
-@{ RenderContactInformation(); }
-
+<div class="container-fluid">
+    @{ RenderContactInformation(); }
+</div>
 
 
 <style>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrPerformanceAppendixA.cshtml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Views/Shared/_CrrPerformanceAppendixA.cshtml
@@ -31,14 +31,14 @@
                                 var totalDistribution = Model.CRRScores.FullAnswerDistrib();
                                 var totalBarChartInput = new BarChartInput() { Height = 50, Width = 110 };
                                 totalBarChartInput.AnswerCounts = new List<int>
-                                                                    { totalDistribution.Green, totalDistribution.Yellow, totalDistribution.Red };
+                                                                                    { totalDistribution.Green, totalDistribution.Yellow, totalDistribution.Red };
                                 var totalBarChart = new ScoreBarChart(totalBarChartInput);
 
                             }
                             @Html.Raw(totalBarChart.ToString())
 
                         </div>
-                        <div class="row" style="padding: 0;">
+                        <div class="col" style="padding: 0;">
                             <h5 class="appendix-label">CRR Summary</h5>
                         </div>
                     </div>
@@ -59,7 +59,7 @@
                         @Html.Raw(legend.ToString())
                     </div>
                 </div>
-                <div class="row header" style="border-top: 1px solid black;">
+                <div class="row header" style="border-top: 1px solid black; padding: 0;">
                     <div style="width: 60%;">
                             <b>MIL-1 Performed</b>
                             <br />
@@ -124,11 +124,11 @@
         foreach (XElement domain in XDocument.Root.Elements())
         {
             var domainScores = Model.CRRScores.DomainAnswerDistrib(domain.Attribute("abbreviation").Value);
-            var barChartInput = new BarChartInput() { Height = 50, Width = 75 };
+            var barChartInput = new BarChartInput() { Height = 45, Width = 75 };
             barChartInput.AnswerCounts = new List<int> { domainScores.Green, domainScores.Yellow, domainScores.Red };
             var barChart = new ScoreBarChart(barChartInput);
 
-            <div class="row" style="border-top: 1px solid black;">
+            <div class="row" style="border-top: 0.5px solid black;">
                 <div class="col-1" style="width: 15%; padding: 0 0.25rem 0 0;">
                     <div class="row">
                         <div style="font-size: 0.7rem; font-weight: bold;">
@@ -212,7 +212,7 @@
 
     .header div {
         padding: 0;
-        font-size: 8px;
+        font-size: 7.5px;
         padding: 0.1rem;
     }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Some minor CSS fixes that bring the CRR Appendix A onto one page, and prevents cutoff on the CRR Contact Information logo.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Closes CSET-1469
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
[CSET CRR Comments and Marked Report (29).pdf](https://github.com/cisagov/cset/files/7824271/CSET.CRR.Comments.and.Marked.Report.29.pdf)
[CSET CRR Deficiency Report (42).pdf](https://github.com/cisagov/cset/files/7824272/CSET.CRR.Deficiency.Report.42.pdf)
[CSET CRR Report - 2022-01-06T122609.312.pdf](https://github.com/cisagov/cset/files/7824273/CSET.CRR.Report.-.2022-01-06T122609.312.pdf)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

