### PR TITLE
Add Flag for Enterprise Installation Mode

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using System.Reflection;
 using CSETWebCore.DatabaseManager;
 using System.IO;
+using System;
 
 namespace CSETWeb_ApiCore
 {
@@ -17,10 +18,12 @@ namespace CSETWeb_ApiCore
             var host = CreateHostBuilder(args).Build();
 
             var hostEnvironment = (IHostEnvironment)host.Services.GetService(typeof(IHostEnvironment));
+            var config = (IConfiguration)host.Services.GetService(typeof(IConfiguration));
 
-            if (hostEnvironment.EnvironmentName == "Production")
+            string isEnterpriseInstallation = config.GetSection("EnterpriseInstallation").Value;
+
+            if (hostEnvironment.EnvironmentName == "Production" && !Convert.ToBoolean(isEnterpriseInstallation))
             {
-                var config = (IConfiguration)host.Services.GetService(typeof(IConfiguration));
                 string clientCode = config.GetSection("ClientCode").Value;
                 string appCode = config.GetSection("AppCode").Value;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/appsettings.json
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/appsettings.json
@@ -3,7 +3,8 @@
     "CSET_DB": "(localdb)\\MSSQLLocalDb;initial catalog=CSETWeb;persist security info=True;Integrated Security=SSPI;MultipleActiveResultSets=True;Encrypt=false"
   },
   "ClientCode": "DHS",
-  "AppCode":  "CSET",
+  "AppCode": "CSET",
+  "EnterpriseInstallation": "false",
   "JWTExpiryMinutes": 60,
   "Logging": {
     "LogLevel": {
@@ -19,7 +20,7 @@
     "SMTP Password": "your-smtp-password",
     "SMTP SSL": "false",
     "Sender Email": "no-reply@changeme",
-    "Sender Display Name":  "CSET User Administration" 
+    "Sender Display Name": "CSET User Administration"
   },
   "AllowedHosts": "*"
 }

--- a/zip_binaries.sh
+++ b/zip_binaries.sh
@@ -7,6 +7,8 @@
 
 _versionNum=11010
 
+sed -i 's/\"EnterpriseInstallation\": \"false\"/\"EnterpriseInstallation\": \"true\"/g' CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/appsettings.json
+
 cd CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/etc/build
 ant
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
When CSET is packaged for enterprise installation, we do not want to enter database setup. This is avoided entirely now if the enterprise installation flag is set to true.

## 💭 Motivation and context ##
CSET-1594

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - _eschew scope creep!_
- [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
