### PR TITLE
CSET Standalone Installation - Attach Clean Database in the Event of an Upgrade Error

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DbManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DbManager.cs
@@ -92,8 +92,10 @@ namespace CSETWebCore.DatabaseManager
                         }
                         catch (Exception e)
                         {
-                            // TODO: Attach clean database here if something goes wrong with database upgrade
                             log.Error(e.Message);
+                            // Attach clean database here if something goes wrong with database upgrade
+                            ForceCloseAndDetach(CurrentMasterConnectionString, DatabaseCode);
+                            AttachCleanDatabase(destDBFile, destLogFile);
                         }
 
                         // Verify that the database has been copied over and exists now
@@ -125,8 +127,10 @@ namespace CSETWebCore.DatabaseManager
                     }
                     catch (Exception e)
                     {
-                        // TODO: Attach clean database here if something goes wrong with database upgrade
                         log.Error(e.Message);
+                        // Attach clean database here if something goes wrong with database upgrade
+                        ForceCloseAndDetach(CurrentMasterConnectionString, DatabaseCode);
+                        AttachCleanDatabase(destDBFile, destLogFile);
                     }
 
                     // Verify that the database has been copied over and exists now
@@ -239,26 +243,19 @@ namespace CSETWebCore.DatabaseManager
         {
             string websitedataDir = "Data";
             string sourceDirPath = Path.Combine(InitialDbInfo.GetExecutingDirectory().FullName);
-            if (!File.Exists(destDBFile))
+            string sourcePath = Path.Combine(sourceDirPath, websitedataDir, DatabaseFileName);
+            string sourceLogPath = Path.Combine(sourceDirPath, websitedataDir, DatabaseLogFileName);
+
+            log.Info("Copying clean database file from " + sourcePath + " to " + destDBFile);
+            try
             {
-                log.Info("Control Database doesn't exist at location: " + destDBFile);
-                string sourcePath = Path.Combine(sourceDirPath, websitedataDir, DatabaseFileName);
-                string sourceLogPath = Path.Combine(sourceDirPath, websitedataDir, DatabaseLogFileName);
-
-                log.Info("copying database file over from " + sourcePath + " to " + destDBFile);
-                try
-                {
-                    File.Copy(sourcePath, destDBFile, true);
-                    File.Copy(sourceLogPath, destLogFile, true);
-                }
-                catch (Exception e)
-                {
-                    log.Info(e.Message);
-                }
+                File.Copy(sourcePath, destDBFile, true);
+                File.Copy(sourceLogPath, destLogFile, true);
             }
-            else
-                log.Info("Not necessary to copy the database");
-
+            catch (Exception e)
+            {
+                log.Info(e.Message);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Users will no longer be stuck with broken DB in the event of a database upgrade error. If an upgrade error occurs, a clean DB is attached for use.

## 💭 Motivation and context ##
CSET-1637

## 🧪 Testing ##
Tested DB upgrade during installation on Windows 10 VM using corrupted version 10 DBs.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
