### PR TITLE
Show Empty Charts on Comparison Summary When Applicable

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Reports/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CSETWebCore.Reports
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-summary/compare-summary.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-summary/compare-summary.component.ts
@@ -47,7 +47,7 @@ export class CompareSummaryComponent implements OnInit {
   assessmentColors: Map<string, string>;
 
   /**
-   * 
+   *
    */
   constructor(
     public aggregationSvc: AggregationService,
@@ -78,6 +78,11 @@ export class CompareSummaryComponent implements OnInit {
 
     // Standards Answers
     this.aggregationSvc.getStandardsAnswers().subscribe((x: any) => {
+      if (x.data.every(item => item === 0)) {
+        x.data = [100];
+        x.labels = ['No Standards Selected'];
+      }
+
       this.chartStandardsPie = this.chartSvc.buildDoughnutChart('canvasStandardsPie', x);
     });
 
@@ -85,6 +90,12 @@ export class CompareSummaryComponent implements OnInit {
 
     // Components Answers
     this.aggregationSvc.getComponentsAnswers().subscribe((x: any) => {
+      console.log(x);
+      if (x.data.every(item => item === 0)) {
+        x.data = [100];
+        x.labels = ['No Assessment Diagrams'];
+      }
+
       this.chartComponentsPie = this.chartSvc.buildDoughnutChart('canvasComponentsPie', x);
     });
 
@@ -122,7 +133,7 @@ export class CompareSummaryComponent implements OnInit {
   }
 
   /**
-   * 
+   *
    */
   buildMaturityChart(c) {
     c.datasets.forEach(ds => {

--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-summary/compare-summary.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-summary/compare-summary.component.ts
@@ -90,7 +90,6 @@ export class CompareSummaryComponent implements OnInit {
 
     // Components Answers
     this.aggregationSvc.getComponentsAnswers().subscribe((x: any) => {
-      console.log(x);
       if (x.data.every(item => item === 0)) {
         x.data = [100];
         x.labels = ['No Assessment Diagrams'];
@@ -124,10 +123,22 @@ export class CompareSummaryComponent implements OnInit {
 
     // Maturity Compliance By Model/Domain
     this.aggregationSvc.getAggregationMaturity(aggId).subscribe((resp: any) => {
+      let showLegend = true;
+
+      if (!resp.length) {
+        showLegend = false;
+        resp = [{
+          chartName: '',
+          labels: ['No Maturity Models Selected'],
+          datasets: [{data: 0}],
+          chart: null
+        }];
+      }
+
       this.chartsMaturityCompliance = resp;
 
       resp.forEach(x => {
-        this.buildMaturityChart(x);
+        this.buildMaturityChart(x, showLegend);
       });
     });
   }
@@ -135,14 +146,14 @@ export class CompareSummaryComponent implements OnInit {
   /**
    *
    */
-  buildMaturityChart(c) {
+  buildMaturityChart(c, showLegend) {
     c.datasets.forEach(ds => {
       ds.backgroundColor = this.colorSvc.getColorForAssessment(ds.label);
     });
 
 
     setTimeout(() => {
-      c.chart = this.chartSvc.buildHorizBarChart('canvasMaturityBars-' + c.chartName, c, true, true)
+      c.chart = this.chartSvc.buildHorizBarChart('canvasMaturityBars-' + c.chartName, c, showLegend, true)
     }, 1000);
   }
 }

--- a/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.ts
+++ b/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.ts
@@ -87,7 +87,6 @@ export class SelectAssessmentsComponent implements OnInit {
    * @param assessment
    */
   toggleSelection(event, assessment) {
-    console.log(assessment);
     this.aggregationSvc.saveAssessmentSelection(event.target.checked, assessment).subscribe((resp: any) => {
       this.aggregation = resp;
     });


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Some sections in comparison summary would be blank without charts if assessments didn't have the applicable content. Now showing empty charts, and why they are empty.

## 💭 Motivation and context ##
CSET-1753

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
