### PR TITLE
Fix Blank Eject Screen on Initial Start

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TokenManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TokenManager.cs
@@ -533,7 +533,8 @@ namespace CSETWebCore.Helpers
                 Content = new StringContent("User not authorized for assessment"),
                 ReasonPhrase = "The current user is not authorized to access the target assessment"                
             };
-            throw new Exception(resp.Content.ToString());        }
+            throw new Exception(resp.Content.ReadAsStringAsync().Result);        
+        }
 
 
         /// <summary>

--- a/CSETWebNg/src/app/helpers/jwt.interceptor.ts
+++ b/CSETWebNg/src/app/helpers/jwt.interceptor.ts
@@ -72,7 +72,6 @@ export class JwtInterceptor implements HttpInterceptor {
           }
 
           if (e.status === 500 || (e.error && e.error.ExceptionMessage === 'JWT invalid')) {
-            console.log(e.error.ExceptionMessage);
             console.log('JWT Invalid. logging out.');
           }
 

--- a/CSETWebNg/src/app/helpers/jwt.interceptor.ts
+++ b/CSETWebNg/src/app/helpers/jwt.interceptor.ts
@@ -75,8 +75,9 @@ export class JwtInterceptor implements HttpInterceptor {
             console.log('JWT Invalid. logging out.');
           }
 
+          const userToken = localStorage.getItem('userToken')
           localStorage.clear();
-          this.router.navigateByUrl('/home/login/eject');
+          this.router.navigate(['/home/login/eject'], { queryParams: { token: userToken } });
 
           return of({});
         }

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -74,7 +74,7 @@ export class LoginCsetComponent implements OnInit {
       // default the page as 'login'
       this.mode = 'LOGIN';
       this.checkForEjection(this.route.snapshot.queryParams['token']);
-      // clear token query param to make the url look nicer.
+      // Clear token query param to make the url look nicer.
       if (this.route.snapshot.queryParams['token']) {
         this.router.navigate(['.'], { relativeTo: this.route, queryParams: { token: null } });
       }
@@ -141,7 +141,6 @@ export class LoginCsetComponent implements OnInit {
       let minutesSinceExpiration = 0;
 
       if (token) {
-        console.log(token);
         const jwt = new JwtParser();
         const parsedToken = jwt.decodeToken(token);
         const expTimeUnix = parsedToken.exp;

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -31,6 +31,7 @@ import { AssessmentService } from '../../services/assessment.service';
 import { AuthenticationService } from '../../services/authentication.service';
 import { ConfigService } from '../../services/config.service';
 import { EmailService } from '../../services/email.service';
+import { JwtParser } from '../../helpers/jwt-parser';
 
 @Component({
   selector: 'app-login-cset',
@@ -72,16 +73,7 @@ export class LoginCsetComponent implements OnInit {
       this.authenticationService.logout();
       // default the page as 'login'
       this.mode = 'LOGIN';
-      if (this.route.snapshot.params['eject']) {
-        localStorage.clear();
-        if (!this.isEjectDialogOpen) {
-          this.isEjectDialogOpen = true;
-          this.dialog
-            .open(EjectionComponent)
-            .afterClosed()
-            .subscribe(() => (this.isEjectDialogOpen = false));
-        }
-      }
+      this.checkForEjection(this.route.snapshot.queryParams['token']);
     }
     if (this.route.snapshot.params['id']) {
       this.assessmentId = +this.route.snapshot.params['id'];
@@ -137,6 +129,31 @@ export class LoginCsetComponent implements OnInit {
           this.incorrect = true;
         }
       );
+  }
+
+  checkForEjection(token: string) {
+    if (this.route.snapshot.params['eject']) {
+
+      let minutesSinceExpiration = 0;
+
+      if (token) {
+        const jwt = new JwtParser();
+        const parsedToken = jwt.decodeToken(token);
+        const expTimeUnix = parsedToken.exp;
+        const nowUtcUnix = Math.floor((new Date()).getTime() / 1000)
+        // divide by 3600 to convert seconds to hours
+        minutesSinceExpiration = (nowUtcUnix - expTimeUnix) / 3600;
+      }
+      console.log(minutesSinceExpiration);
+      // Only show eject dialog if token has been expired for less than an hour.
+      if (!this.isEjectDialogOpen && minutesSinceExpiration < 60) {
+        this.isEjectDialogOpen = true;
+        this.dialog
+        .open(EjectionComponent)
+        .afterClosed()
+        .subscribe(() => (this.isEjectDialogOpen = false));
+      }
+    }
   }
 
   continueStandAlone() {

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -74,6 +74,10 @@ export class LoginCsetComponent implements OnInit {
       // default the page as 'login'
       this.mode = 'LOGIN';
       this.checkForEjection(this.route.snapshot.queryParams['token']);
+      // clear token query param to make the url look nicer.
+      if (this.route.snapshot.queryParams['token']) {
+        this.router.navigate(['.'], { relativeTo: this.route, queryParams: { token: null } });
+      }
     }
     if (this.route.snapshot.params['id']) {
       this.assessmentId = +this.route.snapshot.params['id'];
@@ -137,12 +141,13 @@ export class LoginCsetComponent implements OnInit {
       let minutesSinceExpiration = 0;
 
       if (token) {
+        console.log(token);
         const jwt = new JwtParser();
         const parsedToken = jwt.decodeToken(token);
         const expTimeUnix = parsedToken.exp;
         const nowUtcUnix = Math.floor((new Date()).getTime() / 1000)
-        // divide by 3600 to convert seconds to hours
-        minutesSinceExpiration = (nowUtcUnix - expTimeUnix) / 3600;
+        // divide by 60 to convert seconds to minutes
+        minutesSinceExpiration = (nowUtcUnix - expTimeUnix) / 60;
       }
       console.log(minutesSinceExpiration);
       // Only show eject dialog if token has been expired for less than an hour.

--- a/CSETWebNg/src/app/services/authentication.service.ts
+++ b/CSETWebNg/src/app/services/authentication.service.ts
@@ -81,7 +81,7 @@ export class AuthenticationService {
             .toPromise().then(
                 (response: LoginResponse) => {
 
-                    if (response.email === null || response.email === undefined) {
+                    if (response?.email === null || response?.email === undefined) {
                         this.isLocal = false;
                     } else {
                         this.isLocal = true;
@@ -90,7 +90,7 @@ export class AuthenticationService {
 
                     localStorage.setItem('cset.isLocal', (this.isLocal + ''));
 
-                    localStorage.setItem('cset.linkerDate', response.linkerTime);
+                    localStorage.setItem('cset.linkerDate', response?.linkerTime);
                 },
                 error => {
                     console.warn('Error getting stand-alone status. Assuming non-stand-alone mode.');


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
The dialog that used to pop up on the eject screen will now only show up if the jwt has not been expired more than an hour. It should still show up for API crashes.

## 💭 Motivation and context ##
CSET-1936

## 🧪 Testing ##


<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
