### PR TITLE
Fix Issues with Gallery Cards for Custom / Imported Modules

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -310,7 +310,7 @@ namespace CSETWebCore.Business.ModuleBuilder
             // Now to remove the Gallery Item and card. This gets the guid for the item / card.
             // Currently any custom SET will have a one-to-one relationship with a GALLERY_ITEM, so we can look for it
             // in the cards' config setup.
-            var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($@"[""{setName}""]")).FirstOrDefault();
+            var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($"[\"{setName}\"]")).FirstOrDefault();
 
             if (cardInfo != null)
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -309,13 +309,17 @@ namespace CSETWebCore.Business.ModuleBuilder
 
             // Now to remove the Gallery Item and card. This gets the guid for the item / card
             var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains(setName)).FirstOrDefault();
-            var cardDetailsRange = _context.GALLERY_GROUP_DETAILS.Where(x => x.Gallery_Item_Guid.Equals(cardInfo.Gallery_Item_Guid));
 
-            // This removes any cards with the same Gallery_Item_Guid from view, but the GALLERY_ITEM still exists
-            // because the Assessment still exists, and the Assessment's guid can't be left hanging
-            _context.GALLERY_GROUP_DETAILS.RemoveRange(cardDetailsRange);
+            if (cardInfo != null)
+            { 
+                var cardDetailsRange = _context.GALLERY_GROUP_DETAILS.Where(x => x.Gallery_Item_Guid.Equals(cardInfo.Gallery_Item_Guid));
+
+                // This removes any cards with the same Gallery_Item_Guid from view, but the GALLERY_ITEM still exists
+                // because the Assessment still exists, and the Assessment's guid can't be left hanging
+                _context.GALLERY_GROUP_DETAILS.RemoveRange(cardDetailsRange);
+            }
+
             _context.SaveChanges();            
-
             return resp;
         }
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -307,16 +307,14 @@ namespace CSETWebCore.Business.ModuleBuilder
             // This should cascade delete everything else (except the Gallery card stuff)
             _context.SETS.Remove(dbSet);
 
-            // Now to remove the Gallery Item and card. This gets the guid for the item / card
+            // Now to remove the Gallery Item and card. This gets the guid for the item / card.
+            // Currently any custom SET will have a one-to-one relationship with a GALLERY_ITEM, so we can look for it
+            // in the cards' config setup.
             var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains(setName)).FirstOrDefault();
 
             if (cardInfo != null)
-            { 
-                var cardDetailsRange = _context.GALLERY_GROUP_DETAILS.Where(x => x.Gallery_Item_Guid.Equals(cardInfo.Gallery_Item_Guid));
-
-                // This removes any cards with the same Gallery_Item_Guid from view, but the GALLERY_ITEM still exists
-                // because the Assessment still exists, and the Assessment's guid can't be left hanging
-                _context.GALLERY_GROUP_DETAILS.RemoveRange(cardDetailsRange);
+            {
+                _context.GALLERY_ITEM.Remove(cardInfo);
             }
 
             _context.SaveChanges();            

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -60,7 +60,7 @@ namespace CSETWebCore.Business.ModuleBuilder
                     SetCategory = set.Set_Category_Id != null ? (int)set.Set_Category_Id : 0,
                     IsCustom = set.Is_Custom,
                     IsDisplayed = set.Is_Displayed ?? false,
-
+                 
                     Clonable = true,
                     Deletable = true
                 };
@@ -310,7 +310,7 @@ namespace CSETWebCore.Business.ModuleBuilder
             // Now to remove the Gallery Item and card. This gets the guid for the item / card.
             // Currently any custom SET will have a one-to-one relationship with a GALLERY_ITEM, so we can look for it
             // in the cards' config setup.
-            var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains(setName)).FirstOrDefault();
+            var cardInfo = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($@"[""{setName}""]")).FirstOrDefault();
 
             if (cardInfo != null)
             {
@@ -390,7 +390,7 @@ namespace CSETWebCore.Business.ModuleBuilder
                 dbSet.Is_Custom = set.IsCustom;
                 dbSet.Is_Displayed = set.IsDisplayed;
 
-                var gallItem = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains(originalSet.Set_Name)).FirstOrDefault();
+                var gallItem = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($"[\"{originalSet.Set_Name}\"]")).FirstOrDefault();
 
                 gallItem.Description = gallDescription;
                 gallItem.Title = dbSet.Full_Name;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
@@ -99,14 +99,17 @@ namespace CSETWebCore.Business.ModuleIO
                 }
             }
 
-            string description = category.Set_Category_Name;
-
-            if (!string.IsNullOrWhiteSpace(set.Standard_ToolTip)) 
+            if (!string.IsNullOrWhiteSpace(set.Standard_ToolTip))
             {
-                description += " - " + set.Standard_ToolTip; 
+                set.Standard_ToolTip = $"{category.Set_Category_Name} - {set.Standard_ToolTip}";
+            }
+            else 
+            {
+                set.Standard_ToolTip = $"{category.Set_Category_Name}";
             }
 
-            _galleryEditor.AddGalleryItem("", "", description, set.Full_Name, configSetup, custom.Group_Id, colIndex);
+
+            _galleryEditor.AddGalleryItem("", "", set.Standard_ToolTip, set.Full_Name, configSetup, custom.Group_Id, colIndex);
 
             try
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
@@ -84,10 +84,10 @@ namespace CSETWebCore.Business.ModuleIO
 
             _context.SaveChanges();
 
-            // Add custom gallery card for newly cloned set
+            // Add custom gallery card for newly imported set
             string configSetup = "{Sets:[\"" + set.Set_Name + "\"],SALLevel:\"Low\",QuestionMode:\"Questions\"}";
 
-            var custom = _context.GALLERY_GROUP.Where(x => x.Group_Title.Equals(category.Set_Category_Name)).FirstOrDefault();
+            var custom = _context.GALLERY_GROUP.Where(x => x.Group_Title.Equals("Custom")).FirstOrDefault();
             int colIndex = 0;
             if (custom != null)
             {
@@ -99,7 +99,14 @@ namespace CSETWebCore.Business.ModuleIO
                 }
             }
 
-            _galleryEditor.AddGalleryItem("", "", set.Standard_ToolTip, set.Full_Name, configSetup, custom.Group_Id, colIndex);
+            string description = category.Set_Category_Name;
+
+            if (!string.IsNullOrWhiteSpace(set.Standard_ToolTip)) 
+            {
+                description += " - " + set.Standard_ToolTip; 
+            }
+
+            _galleryEditor.AddGalleryItem("", "", description, set.Full_Name, configSetup, custom.Group_Id, colIndex);
 
             try
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
@@ -11,7 +11,7 @@ using CSETWebCore.DataLayer.Model;
 using System.Text.RegularExpressions;
 using CSETWebCore.Model.AssessmentIO;
 using CSETWebCore.Helpers;
-
+using CSETWebCore.Business.GalleryParser;
 
 namespace CSETWebCore.Business.ModuleIO
 {
@@ -22,15 +22,16 @@ namespace CSETWebCore.Business.ModuleIO
     public class ModuleImporter
     {
         private readonly CSETContext _context;
-
+        private readonly IGalleryEditor _galleryEditor;
 
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="context"></param>
-        public ModuleImporter(CSETContext context)
+        public ModuleImporter(CSETContext context, IGalleryEditor galleryEditor)
         {
             _context = context;
+            _galleryEditor = galleryEditor;
         }
 
 
@@ -80,8 +81,25 @@ namespace CSETWebCore.Business.ModuleIO
             set.Standard_ToolTip = externalStandard.summary;
 
             _context.SETS.Add(set);
+
             _context.SaveChanges();
 
+            // Add custom gallery card for newly cloned set
+            string configSetup = "{Sets:[\"" + set.Set_Name + "\"],SALLevel:\"Low\",QuestionMode:\"Questions\"}";
+
+            var custom = _context.GALLERY_GROUP.Where(x => x.Group_Title.Equals(category.Set_Category_Name)).FirstOrDefault();
+            int colIndex = 0;
+            if (custom != null)
+            {
+                var colIndexList = _context.GALLERY_GROUP_DETAILS.Where(x => x.Group_Id.Equals(custom.Group_Id)).ToList();
+
+                if (colIndexList != null)
+                {
+                    colIndex = colIndexList.Count;
+                }
+            }
+
+            _galleryEditor.AddGalleryItem("", "", set.Standard_ToolTip, set.Full_Name, configSetup, custom.Group_Id, colIndex);
 
             try
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContext.cs
@@ -452,6 +452,7 @@ namespace CSETWebCore.DataLayer.Model
                 entity.HasOne(d => d.GalleryItemGu)
                     .WithMany(p => p.ASSESSMENTS)
                     .HasForeignKey(d => d.GalleryItemGuid)
+                    .OnDelete(DeleteBehavior.SetNull)
                     .HasConstraintName("FK_ASSESSMENTS_GALLERY_ITEM");
             });
 
@@ -1658,7 +1659,6 @@ namespace CSETWebCore.DataLayer.Model
                 entity.HasOne(d => d.Gallery_Item_Gu)
                     .WithMany(p => p.GALLERY_GROUP_DETAILS)
                     .HasForeignKey(d => d.Gallery_Item_Guid)
-                    .OnDelete(DeleteBehavior.ClientSetNull)
                     .HasConstraintName("FK_GALLERY_GROUP_DETAILS_GALLERY_ITEM");
 
                 entity.HasOne(d => d.Group)

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StandardConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StandardConverter.cs
@@ -160,7 +160,7 @@ namespace CSETWebCore.Helpers
             externalStandard.shortName = standard.Short_Name;
             externalStandard.name = standard.Full_Name;
             externalStandard.summary = standard.Standard_ToolTip;
-            externalStandard.category = standard.Set_Category.Set_Category_Name;
+            externalStandard.category = standard.Set_Category?.Set_Category_Name ?? "";
 
             var requirements = new List<ExternalRequirement>();
             //Caching for performance

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SetsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SetsController.cs
@@ -15,6 +15,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using CSETWebCore.Model.AssessmentIO;
+using CSETWebCore.Business.GalleryParser;
 
 namespace CSETWebCore.Api.Controllers
 {
@@ -23,10 +24,12 @@ namespace CSETWebCore.Api.Controllers
     public class SetsController : ControllerBase
     {
         private CSETContext _context;
+        private readonly IGalleryEditor _galleryEditor;
 
-        public SetsController(CSETContext context)
+        public SetsController(CSETContext context, IGalleryEditor galleryEditor)
         {
             _context = context;
+            _galleryEditor = galleryEditor;
         }
 
         [HttpGet]
@@ -54,7 +57,7 @@ namespace CSETWebCore.Api.Controllers
                 {
                     try
                     {
-                        var mp = new ModuleImporter(_context);
+                        var mp = new ModuleImporter(_context, _galleryEditor);
                         mp.ProcessStandard(externalStandard);
                     }
                     catch (Exception exc)

--- a/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
+++ b/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
@@ -130,7 +130,7 @@ export class SetListComponent implements OnInit {
 
       if (this.setsInUseList.find(x => x.setName === s.setName)) {
         dialogRef.componentInstance.confirmMessage +=
-          "<div class=\"d-flex align-items-center mt-2\"><span class=\"mr-3 fs-base-6 cset-icons-exclamation-triangle\" style=\"color: #856404\"></span>This module is currently in use in one or more assessments.<br/> All assessment data pertaining to the module will be lost.</div>";
+          "<div class=\"d-flex justify-content-center mt-2\"><span class=\"mr-3 fs-base-6 cset-icons-exclamation-triangle\" style=\"color: #856404\"></span>This module is currently in use in one or more assessments.<br/> All assessment data pertaining to the module will be lost.</div>";
       }
 
       dialogRef.afterClosed().subscribe(result => {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

- Added custom gallery group back to all layouts in the database (except ONLINE).
- Imported modules will now also show up in the custom gallery row (they were inaccessible before) regardless of the category they are given. For now this seems to be the most reasonable solution since there is not a perfect mapping between `SETS_CATEGORY` and the available `GALLERY_GROUP` records. The category is now prepended to the module's description (the user can remove this in the module builder if they want).
- When a custom module is deleted, its associated gallery card will also be removed from the database (these records would never be used again anyways and just clutter the DB). There is a one-to-one relationship between custom modules and their gallery cards which allows us to safely do this.
- Assessments that were created with the deleted gallery card will have their `GalleryItemGuid` column set to null (in the future we might want to just delete the assessment as well, as it just turns into a blank assessment with no way of adding back new questions). There is already a warning presented before deleting modules that are in use within assessments.

## 💭 Motivation and context ##
TSA-369

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
