### PR TITLE
feature: add dockerized mssql server db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.bak
 *.log
 *.zip
 dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+---
+version: "3.8"
+
+services:
+  sqlserver:
+    container_name: cset-mssql
+    hostname: mssql
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    restart: unless-stopped
+    environment:
+      - ACCEPT_EULA=Y
+      - MSSQL_SA_PASSWORD=Password123
+    # These ports are exposed on the host; 'hostport:containerport'.
+    # You could connect to this server from outside with the *host's*
+    # DNS name or IP address and port 27017 (the left-hand side of the
+    # colon).
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql_data:/var/opt/mssql
+      - ./backups:/var/backups
+
+volumes:
+  mssql_data:
+


### PR DESCRIPTION
Add a docker-compose file to quickly run an mssql server database and load data from a .bak file.

## 🗣 Description ##
To launch a local ms sql server database:
- make sure you have docker for mac / windows installed and running
- retrieve a .bak backup file
- Create a `/backup` folder in the root directory of this project and add the .bak file in there
- run `docker compose up`

## 💭 Motivation and context ##
Simplify setting up a local mssql server database for mac users. (Windows users can use it too if they have docker installed).

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.