### PR TITLE
Make assessment import handle non-period decimal separator

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
@@ -7,9 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace CSETWebCore.Business.AssessmentIO.Import
@@ -59,17 +57,32 @@ namespace CSETWebCore.Business.AssessmentIO.Import
 
 
             // Determine the version of the data
+            System.Version version = null;
+
             JObject j = JObject.Parse(json);
+            JToken csetVersionToken = j.SelectToken("jCSET_VERSION[0].Cset_Version1");
             JToken versionToken = j.SelectToken("jCSET_VERSION[0].Version_Id");
-            if (versionToken == null)
+
+            if (csetVersionToken == null && versionToken == null)
             {
                 throw new ApplicationException("Version could not be identifed corrupted assessment json");
             }
 
-            System.Version version = ConvertFromStringToVersion(versionToken.Value<string>());
-            version = NormalizeVersion(version);
+            if (csetVersionToken != null)
+            {
+                version = Version.Parse(csetVersionToken.Value<string>());
+            }
+            else
+            {
+                // If the export is older, there may not be a Cset_Version1 property in the export.
+                // In that case, fall back to Version_Id which is more error prone.
+                // Suggest deprecating this property as soon as practical.
+                version = ConvertFromStringToVersion(versionToken.Value<string>());
+                version = NormalizeVersion(version);
+            }
 
-            // correct version notation if necessary
+
+            // older versions may need some correction due to ambiguity
             if (version == new System.Version("9.21.0.0"))
             {
                 version = new System.Version("9.2.1.0");
@@ -81,7 +94,7 @@ namespace CSETWebCore.Business.AssessmentIO.Import
             if (version == new System.Version("101.0.0.0"))
             {
                 version = new System.Version("10.1.0.0");
-            }            
+            }
             if (version == new System.Version("10.11.0.0"))
             {
                 version = new System.Version("10.1.1.0");
@@ -137,20 +150,28 @@ namespace CSETWebCore.Business.AssessmentIO.Import
 
 
         /// <summary>
-        /// 
+        /// Attempts to convert an old "decimal" representation of the version
+        /// into a System.Version instance.
         /// </summary>
         /// <param name="v"></param>
         /// <returns></returns>
         private System.Version ConvertFromStringToVersion(String v)
         {
-            // The version string may come in from a float and not be interpreted correctly.  
+            // Convert the string to use decimals as the separator if necessary.
+            // Reason: another culture might have exported the decimal version string with
+            // a decimal separator other than a period (.)
+            Regex regex = new Regex("[^0-9]");
+            var parts = regex.Split(v);
+            v = String.Join(".", parts);
+
+
+            // The version string may come in from a decimal and not be interpreted correctly.  
             // This attempts to turn "9.04" into "9.0.4"
-            string[] parts = v.Split(".".ToCharArray());
             if (parts.Length > 1 && parts[1].StartsWith("0"))
             {
                 parts[1] = "0." + parts[1].Substring(1);
             }
-            v = String.Join(".", parts);
+
             if (v.EndsWith("."))
             {
                 v = v.TrimEnd('.');
@@ -161,6 +182,7 @@ namespace CSETWebCore.Business.AssessmentIO.Import
             {
                 return new System.Version(version, 0);
             }
+
             return new System.Version(v);
         }
     }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/AllGeneralJsonModels.cs
@@ -28,13 +28,11 @@ namespace CSETWebCore.Business.ImportAssessment.Models.Version_10_1
         [Required]
         public string AccessKey { get; set; }
     }
+
     public class jCSET_VERSION
     {
         [Required]
         public Int32 Id { get; set; }
-
-        [Required]
-        public string Version_Id { get; set; }
 
         [Required]
         [MaxLength(50)]
@@ -42,8 +40,8 @@ namespace CSETWebCore.Business.ImportAssessment.Models.Version_10_1
 
         [MaxLength(500)]
         public String Build_Number { get; set; }
-
     }
+
     public class jACCESS_KEY_ASSESSMENT
     {
         [Required]


### PR DESCRIPTION
An export from a previous version from a machine running Windows in another culture (Brazil, Switzerland, etc.) will export the Version_Id using a comma as the decimal separator.  

The import will now use Cset_Version1 as the primary source for the version string.  Failing that, the Version_Id decimal value will be used, but it will be parsed agnostically using any "non-numeric" character as the separator.

The old "Version_id" field is also no longer exported, as it is error-prone and ambiguous for representing a version.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
