### PR TITLE
fix: cset-2299 gallery hover issue

### DIFF
--- a/CSETWebNg/src/app/initial/search-page/search-page.component.html
+++ b/CSETWebNg/src/app/initial/search-page/search-page.component.html
@@ -25,7 +25,7 @@
   <div *ngIf="rows.length == 0">
     {{t('no search results')}}
   </div>
-  <div style="height:235px; margin: 0 1.5rem" *ngFor="let row of rows">
+  <div *ngFor="let row of rows" class="m-4" style="height: 250px;">
     <swiper class="gallery-slider" [config]="config" (slideChange)="onSlideChange()" #swiper>
       <ng-template swiperSlide *ngFor="let c of row; let i = index">
 


### PR DESCRIPTION
[Gallery result card "arrow" button is hard to click](https://cset.atlassian.net/browse/CSET-2299?atlOrigin=eyJpIjoiZTU0ZDhhNmMxNjlmNDQ5YjliNDU3NDhmZTg2OWNiNzIiLCJwIjoiaiJ9)

## 🗣 Description ##
fixed an issue where it was difficult to click the arrow button when searching for assessments

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All new and existing tests pass.
