### PR TITLE
Remove Redundant API Calls Causing Slowdown on Initial Maturity Questions Page Load

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -93,11 +93,6 @@ export class MaturityQuestionsComponent implements OnInit {
       }
     });
 
-    this.tSvc.langChanges$.subscribe((event) => {
-      this.load();
-    });
-
-
     if (this.assessSvc.assessment == null) {
       this.assessSvc.getAssessmentDetail().subscribe(
         (data: any) => {
@@ -110,20 +105,19 @@ export class MaturityQuestionsComponent implements OnInit {
   }
 
   /**
-   * 
+   *
    */
   ngOnInit() {
-    this.load();
-
     // refresh the page in case of language change
-    this.tSvc.langChanges$.subscribe((event) => {
+    // NOTE: langChanges$ will emit the active language on subscription,
+    // so load() will always fire on initial page load
+    this.tSvc.langChanges$.subscribe(() => {
       this.load();
     });
-
   }
 
   /**
-   * 
+   *
    */
   load() {
     // determine whether displaying a grouping or all questions for the model


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
There were multiple http request going out when the maturity questions page was first loaded. This was causing the slow down and weird behavior with category box closing after opening.

## 💭 Motivation and context ##


## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
