### PR TITLE
Import demographics more bulletproof.  MaturityQuestions not so eager to pull data after login

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityController.cs
@@ -131,10 +131,11 @@ namespace CSETWebCore.Api.Controllers
         /// </summary>
         [HttpGet]
         [Route("api/MaturityQuestions")]
-        public IActionResult GetQuestions([FromQuery] string installationMode, bool fill, int groupingId = 0)
+        public IActionResult GetQuestions(bool fill, int groupingId = 0)
         {
             int assessmentId = _tokenManager.AssessmentForUser();
             string lang = _tokenManager.GetCurrentLanguage();
+            string installationMode = _tokenManager.Payload("scope");
 
             if (installationMode == "ACET")
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ResponseMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ResponseMessage.cs
@@ -1,0 +1,17 @@
+﻿namespace CSETWebCore.Api.Models
+{
+    public class ResponseMessage
+    {
+        public int Code { get; set; }
+        public string Message { get; set; }
+
+        /// <summary>
+        /// CTOR
+        /// </summary>
+        /// <param name="m"></param>
+        public ResponseMessage(int c, string m) { 
+            this.Code = c;
+            this.Message = m;
+        }
+    }
+}

--- a/CSETWebNg/src/app/app.module.ts
+++ b/CSETWebNg/src/app/app.module.ts
@@ -654,6 +654,7 @@ import { CisaWorkflowWarningsComponent } from './assessment/results/reports/cisa
 import { AnalyticsComponent } from './assessment/results/analytics/analytics.component';
 import { AnalyticsloginComponent } from './assessment/results/analysis/analytics-login/analytics-login.component';
 import { AnalyticsService } from './services/analytics.service';
+import { UploadDemographicsComponent } from './dialogs/import demographics/import-demographics.component';
 @NgModule({
   imports: [
     BrowserModule,
@@ -838,6 +839,7 @@ import { AnalyticsService } from './services/analytics.service';
     GlobalParametersComponent,
     ImportComponent,
     UploadExportComponent,
+    UploadDemographicsComponent,
     KeyboardShortcutsComponent,
     LicenseComponent,
     AcetDashboardComponent,

--- a/CSETWebNg/src/app/assessment/merge/merge-cie-analysis/merge-cie-analysis.component.ts
+++ b/CSETWebNg/src/app/assessment/merge/merge-cie-analysis/merge-cie-analysis.component.ts
@@ -156,7 +156,7 @@ export class MergeCieAnalysisComponent implements OnInit {
         console.log(myIssues)
 
         if (myIssues.length > 0) {
-          this.maturitySvc.getQuestionsList("CIE", false).subscribe(
+          this.maturitySvc.getQuestionsList(false).subscribe(
             (response: any) => {
               for (let i = 0; i < response.groupings[0].subGroupings.length; i++) {
                 for (let j = 0; j < response.groupings[0].subGroupings[i].subGroupings.length; j++) {
@@ -181,7 +181,7 @@ export class MergeCieAnalysisComponent implements OnInit {
 
   getExistingAssessmentAnswers() {
     this.assessSvc.getAssessmentToken(this.cieSvc.assessmentsToMerge[this.dataReceivedCount]).then(() => {
-      this.maturitySvc.getQuestionsList("CIE", false).subscribe(
+      this.maturitySvc.getQuestionsList(false).subscribe(
         (response: any) => {
           this.dataReceivedCount++;
           this.aggregateExistingAnswers(response);
@@ -604,7 +604,7 @@ export class MergeCieAnalysisComponent implements OnInit {
 
               // Send off a list of the assessment's new answers to the API to save.
               this.questionSvc.storeAllAnswers(this.existingAssessmentAnswers).subscribe((response: any) => {
-                this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false).subscribe(
+                this.maturitySvc.getQuestionsList(false).subscribe(
                   (questionListResponse: MaturityQuestionResponse) => {
 
                     // Grab all the new answer_id's to save Issues to the new questions

--- a/CSETWebNg/src/app/assessment/merge/merge-examinations.component.ts
+++ b/CSETWebNg/src/app/assessment/merge/merge-examinations.component.ts
@@ -163,7 +163,7 @@ export class MergeExaminationsComponent implements OnInit {
 
   getExistingAssessmentAnswers() {
     this.assessSvc.getAssessmentToken(this.ncuaSvc.assessmentsToMerge[this.dataReceivedCount]).then(() => {
-      this.maturitySvc.getQuestionsList("ACET", false).subscribe(
+      this.maturitySvc.getQuestionsList(false).subscribe(
         (response: any) => {
           this.dataReceivedCount++;
           this.aggregateExistingAnswers(response);
@@ -430,7 +430,7 @@ export class MergeExaminationsComponent implements OnInit {
 
               // Send off a list of the assessment's new answers to the API to save.
               this.questionSvc.storeAllAnswers(this.existingAssessmentAnswers).subscribe((response: any) => {
-                this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false).subscribe(
+                this.maturitySvc.getQuestionsList(false).subscribe(
                   (questionListResponse: MaturityQuestionResponse) => {
 
                     // Grab all the new answer_id's to save Issues to the new questions

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-acet.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-acet.component.ts
@@ -110,7 +110,7 @@ export class MaturityQuestionsAcetComponent implements OnInit, AfterViewInit {
   loadQuestions() {
     const magic = this.navSvc.getMagic();
     this.groupings = null;
-    this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false, null).subscribe(
+    this.maturitySvc.getQuestionsList(false, null).subscribe(
       (response: MaturityQuestionResponse) => {
         this.completionSvc.setQuestionArray(response);
         this.modelName = response.modelName;

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-cie/maturity-questions-cie.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-cie/maturity-questions-cie.component.ts
@@ -132,7 +132,7 @@ export class MaturityQuestionsCieComponent implements OnInit, AfterViewInit {
     this.sectionId = +this.route.snapshot.params['sec'];
     const magic = this.navSvc.getMagic();
     this.groupings = null;
-    this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false, this.sectionId.valueOf()).subscribe(
+    this.maturitySvc.getQuestionsList(false, this.sectionId.valueOf()).subscribe(
       (response: MaturityQuestionResponse) => {
         this.completionSvc.setQuestionArray(response);
         this.modelName = response.modelName;

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-ise.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions-ise.component.ts
@@ -114,7 +114,7 @@ export class MaturityQuestionsIseComponent implements OnInit, AfterViewInit {
     const magic = this.navSvc.getMagic();
     this.groupings = null;
 
-    this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false).subscribe(
+    this.maturitySvc.getQuestionsList(false).subscribe(
       (response: MaturityQuestionResponse) => {
         this.completionSvc.setQuestionArray(response);
         this.modelName = response.modelName;

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -112,7 +112,13 @@ export class MaturityQuestionsComponent implements OnInit {
     // NOTE: langChanges$ will emit the active language on subscription,
     // so load() will always fire on initial page load
     this.tSvc.langChanges$.subscribe(() => {
-      this.load();
+      
+      // check for assessment existence so that this isn't triggered when logging
+      // in after a timeout.  In that scenario there is no assessment ID in the JWT
+      // and the call to load questions or groupings will crash.
+      if (!!this.assessSvc.assessment) {
+        this.load();
+      }
     });
   }
 
@@ -153,7 +159,7 @@ export class MaturityQuestionsComponent implements OnInit {
     
     const magic = this.navSvc.getMagic();
     this.groupings = null;
-    this.maturitySvc.getQuestionsList(this.configSvc.installationMode, false).subscribe(
+    this.maturitySvc.getQuestionsList(false).subscribe(
       (response: MaturityQuestionResponse) => {
         this.modelId = response.modelId;
         this.modelName = response.modelName;

--- a/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.ts
@@ -39,7 +39,7 @@ export class MaturityIndicatorLevelsComponent implements OnInit {
   }
 
   getQuestions() {
-    this.maturitySvc.getQuestionsList('', true).subscribe((resp: MaturityQuestionResponse) => {
+    this.maturitySvc.getQuestionsList(true).subscribe((resp: MaturityQuestionResponse) => {
 
       this.maturitySvc.domains = resp.groupings.filter(x => x.groupingType == 'Domain');
 

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.ts
@@ -39,7 +39,7 @@ export class RelationshipFormationComponent implements OnInit {
   }
 
   getQuestions() {
-    this.maturitySvc.getQuestionsList('', true).subscribe((resp: MaturityQuestionResponse) => {
+    this.maturitySvc.getQuestionsList(true).subscribe((resp: MaturityQuestionResponse) => {
 
       this.maturitySvc.domains = resp.groupings.filter(x => x.groupingType == 'Domain');
 

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.ts
@@ -39,7 +39,7 @@ export class RelationshipManagementComponent implements OnInit {
   }
 
   getQuestions() {
-    this.maturitySvc.getQuestionsList('', true).subscribe((resp: MaturityQuestionResponse) => {
+    this.maturitySvc.getQuestionsList(true).subscribe((resp: MaturityQuestionResponse) => {
 
       this.maturitySvc.domains = resp.groupings.filter(x => x.groupingType == 'Domain');
 

--- a/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.ts
@@ -39,7 +39,7 @@ export class ServiceProtectionComponent implements OnInit {
   }
 
   getQuestions() {
-    this.maturitySvc.getQuestionsList('', true).subscribe((resp: MaturityQuestionResponse) => {
+    this.maturitySvc.getQuestionsList(true).subscribe((resp: MaturityQuestionResponse) => {
 
       this.maturitySvc.domains = resp.groupings.filter(x => x.groupingType == 'Domain');
 

--- a/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.ts
+++ b/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.ts
@@ -21,7 +21,6 @@
 //  SOFTWARE.
 //
 ////////////////////////////////
-import { ImportAssessmentService } from './../../services/import-assessment.service';
 import { FileUploadClientService } from '../../services/file-client.service';
 import { DiagramService } from './../../services/diagram.service';
 import { Component, OnInit, ViewChild, Inject } from '@angular/core';
@@ -64,9 +63,7 @@ export class UploadDemographicsComponent implements OnInit {
     public newDialog: MatDialog,
     private importSvc: ImportDemographicService,
     private fileSvc: FileUploadClientService,
-    private diagramSvc: DiagramService,
     private configSvc: ConfigService,
-    private ncuaSvc: NCUAService,
     @Inject(MAT_DIALOG_DATA) public data: any) {
   }
 
@@ -128,10 +125,8 @@ export class UploadDemographicsComponent implements OnInit {
     this.uploading = true;
 
     // start the upload and save the progress map
-
-   
     this.progress = this.importSvc.upload(this.files, this.data.IsNormalLoad, this.password);
-    
+
 
     // convert the progress map into an array
     const allProgressObservables = [];
@@ -169,7 +164,7 @@ export class UploadDemographicsComponent implements OnInit {
             this.canBeClosed = true;
             this.dialog.disableClose = false;
             this.statusText = fail.message;
-            if (fail.message.includes("File requires a password")) {
+            if (fail.code == 80) {
               this.passwordRequired = true;
             }
           }

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -111,14 +111,16 @@ export class LoginCsetComponent implements OnInit {
           if (this.assessmentId) {
             this.assessSvc
               .getAssessmentToken(this.assessmentId)
-              .then(() =>
+              .then(() => {
                 this.router.navigate(['/assessment', this.assessmentId])
-              );
+              });
           } else if (this.configSvc.isRunningAnonymous) {
+            this.assessSvc.dropAssessment();
             this.router.navigate(['/home', 'login-access'], {
               queryParamsHandling: 'preserve'
             });
           } else {
+            this.assessSvc.dropAssessment();
             this.router.navigate(['/home'], {
               queryParamsHandling: 'preserve'
             });

--- a/CSETWebNg/src/app/reports/edm/edm.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.ts
@@ -154,7 +154,7 @@ export class EdmComponent implements OnInit, AfterContentInit {
    *
    */
   getQuestions() {
-    this.maturitySvc.getQuestionsList('', true).subscribe((resp: MaturityQuestionResponse) => {
+    this.maturitySvc.getQuestionsList(true).subscribe((resp: MaturityQuestionResponse) => {
 
       this.maturitySvc.domains = resp.groupings.filter(x => x.groupingType == 'Domain');
 

--- a/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
@@ -108,7 +108,7 @@ export class OpenEndedQuestionsComponent implements OnInit {
   loadQuestions() {
     this.groupings = null;
     this.maturitySvc
-      .getQuestionsList(this.configSvc.installationMode, false)
+      .getQuestionsList(false)
       .subscribe(
         (response: MaturityQuestionResponse) => {
           this.modelName = response.modelName;

--- a/CSETWebNg/src/app/services/maturity.service.ts
+++ b/CSETWebNg/src/app/services/maturity.service.ts
@@ -215,12 +215,14 @@ export class MaturityService {
   /**
    * Asks the API for all maturity questions/answers for the current assessment.
    */
-  getQuestionsList(installationMode: string, fillEmpty: boolean, groupingId?: number) {
-    return this.http.get(
-      this.configSvc.apiUrl
-      + "MaturityQuestions?installationMode=" + installationMode + '&fill=' + fillEmpty + '&groupingId=' + groupingId,
-      headers
-    );
+  getQuestionsList(fillEmpty: boolean, groupingId?: number) {
+    let url = this.configSvc.apiUrl + 'MaturityQuestions?fill=' + fillEmpty;
+
+    if (!!groupingId) {
+      url = url + '&groupingId=' + groupingId;
+    }
+
+    return this.http.get(url, headers);
   }
 
   /**

--- a/CSETWebNg/src/app/services/navigation/nav-tree.service.ts
+++ b/CSETWebNg/src/app/services/navigation/nav-tree.service.ts
@@ -305,7 +305,6 @@ export class NavTreeService {
   }
 
   setSideNavScrollLocation(targetId) {
-    console.log(targetId)
     const sideNav = document.getElementsByClassName("mat-drawer-inner-container");
     if (sideNav.length > 0) {
       let target = document.getElementById(targetId);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Avoid crashing if bad import files are used.  We handle the bad file more elegantly and display a message to the user in the import dialog. 
Fixed the demographics import dialog to display (dialogs must be defined in the "declarations" section of app.module).
Removed assessmentId as a query parameter when uploading demographics.  The assessmentId is already baked into the JWT. 
 
The maturity-questions component tried to re-fetch its content when the user language is changed/set.  This happened when logging in, but there's no assessment to fetch, meaning a null assessmentId.  This resulted in a 500 error from an endpoint that should not be getting called at login.

Also simplified the query parameters for the maturityquestions endpoint; the installationMode is already baked into the JWT.  No need to send it explicitly in the query.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
