### PR TITLE
feature: restoredb from backup script

### DIFF
--- a/backups/restoredb.sql
+++ b/backups/restoredb.sql
@@ -1,5 +1,11 @@
-RESTORE DATABASE CSETWeb.bak
+ALTER DATABASE CSETWeb
+SET SINGLE_USER
+WITH ROLLBACK IMMEDIATE
+GO
+
+RESTORE DATABASE CSETWeb
 FROM DISK = '/var/opt/mssql/backup/CSETWeb.bak'
-WITH MOVE 'CSETWeb' TO '/var/opt/mssql/data/CSETWeb.mdf'
+WITH REPLACE,
+MOVE 'CSETWeb' TO '/var/opt/mssql/data/CSETWeb.mdf',
 MOVE 'CSETWeb_Log' TO '/var/opt/mssql/data/CSETWeb_Log.ldf'
 GO


### PR DESCRIPTION
fix sql script for restoring database

## 🗣 Description ##
The sql script will drop any active connections and then restore CSETWeb database from the latest backup dropped in the `backups/` directory

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
