### PR TITLE
Refactor of CISA Assessor variable. Reports page tied to that now

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -108,7 +108,7 @@
 
     <div class="mt-4">
       <h4>{{ t('assessment settings') }}</h4>
-      <div *ngIf="this.configSvc.cisaAssessorWorkflow; else content"
+      <div *ngIf="this.configSvc.userIsCisaAssessor; else content"
         class="d-flex align-items-center flex-00a ms-auto me-5" style="margin-top:-5px;">
         <div class="d-flex align-items-center me-3 pt-2">{{ t('protected features.cisa assessor workflow') }}</div>
         <div class="mb-2">

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -95,7 +95,7 @@ export class AssessmentConfigIodComponent implements OnInit {
         this.assessment.pciiNumber = null;
       }
 
-      this.configSvc.cisaAssessorWorkflow = true;
+      this.configSvc.userIsCisaAssessor = true;
       this.assessSvc.updateAssessmentDetails(this.assessment);
     }
   }

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -75,7 +75,7 @@
         </div>
 
     </div>
-    <div *ngIf="this.configSvc.cisaAssessorWorkflow" class="mt-4">
+    <div *ngIf="this.configSvc.userIsCisaAssessor" class="mt-4">
         <h4>{{ t('assessment settings') }}</h4>
         <div class="d-flex align-items-center flex-00a ms-auto me-5" style="margin-top:-5px;">
             <div class="d-flex align-items-center me-3 pt-2">{{ t('protected features.cisa assessor workflow') }}</div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
@@ -140,7 +140,7 @@ export class DemographicsIodComponent implements OnInit {
    * 
    */
   updateDemographics() {
-    this.configSvc.cisaAssessorWorkflow = true;
+    this.configSvc.userIsCisaAssessor = true;
     this.demographicData.sectorDirective = 'NIPP';
 
     // keep a few things in sync

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
@@ -133,7 +133,7 @@ export class ReportsComponent implements OnInit, AfterViewInit {
       this.router.navigate([value], { relativeTo: this.route.parent });
     });
 
-    if (this.configSvc.installationMode === 'IOD') {
+    if (this.configSvc.installationMode === 'IOD' && this.assessSvc.assessment.assessorMode) {
       this.reportSvc.validateCisaAssessorFields().subscribe((result: CisaWorkflowFieldValidationResponse) => {
         this.cisaAssessorWorkflowFieldValidation = result;
         if (!this.cisaAssessorWorkflowFieldValidation?.isValid) {
@@ -141,12 +141,12 @@ export class ReportsComponent implements OnInit, AfterViewInit {
         }
       });
     }
- 
+    
     this.assessSvc.getLastModified().subscribe((data: any) => {
       this.lastModifiedTimestamp = data.lastModifiedDate;
     });
-
-    this.configSvc.getCisaAssessorWorkflow().subscribe((resp: boolean) => this.configSvc.cisaAssessorWorkflow = resp);
+    
+    this.configSvc.getCisaAssessorWorkflow().subscribe((resp: boolean) => this.configSvc.userIsCisaAssessor = resp);
 
     this.updateSectionId();
   }

--- a/CSETWebNg/src/app/assessment/upgrade/upgrade.component.ts
+++ b/CSETWebNg/src/app/assessment/upgrade/upgrade.component.ts
@@ -164,7 +164,7 @@ export class UpgradeComponent implements OnInit {
     this.iodDemoSvc.getDemographics().subscribe((data: any) => {
       this.iodDemographics = data;
     });
-    if (this.configSvc.cisaAssessorWorkflow == true) {
+    if (this.configSvc.userIsCisaAssessor == true) {
       this.csiSvc.getCsiServiceDemographic().subscribe((result: CsiServiceDemographic) => {
         this.csiServiceDemographic = result;
       });
@@ -187,7 +187,7 @@ export class UpgradeComponent implements OnInit {
     this.assessment.galleryItemGuid = this.assessSvc.galleryItemGuid.toLowerCase()
     this.demoSvc.updateDemographic(this.demographicData);
     this.iodDemoSvc.updateDemographic(this.iodDemographics);
-    if (this.configSvc.cisaAssessorWorkflow == true) {
+    if (this.configSvc.userIsCisaAssessor == true) {
       this.csiSvc.updateCsiServiceDemographic(this.csiServiceDemographic);
       this.csiSvc.updateCsiServiceComposition(this.serviceComposition);
     }

--- a/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.ts
+++ b/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.ts
@@ -47,7 +47,7 @@ export class UserSettingsComponent implements OnInit {
       this.encryption = result
     });
     this.configSvc.getCisaAssessorWorkflow().subscribe((cisaWorkflowEnabled: boolean) => {
-      this.configSvc.cisaAssessorWorkflow = cisaWorkflowEnabled;
+      this.configSvc.userIsCisaAssessor = cisaWorkflowEnabled;
       this.cisaWorkflowEnabled = cisaWorkflowEnabled;
       this.cisaWorkflowStatusLoaded = true;
     });

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -139,7 +139,7 @@ export class MyAssessmentsComponent implements OnInit {
     }
 
 
-    this.configSvc.getCisaAssessorWorkflow().subscribe((resp: boolean) => this.configSvc.cisaAssessorWorkflow = resp);
+    this.configSvc.getCisaAssessorWorkflow().subscribe((resp: boolean) => this.configSvc.userIsCisaAssessor = resp);
   }
 
   /**
@@ -162,7 +162,7 @@ export class MyAssessmentsComponent implements OnInit {
     }
 
     if (column == 'export json') {
-      return this.configSvc.cisaAssessorWorkflow;
+      return this.configSvc.userIsCisaAssessor;
     }
 
     return true;

--- a/CSETWebNg/src/app/services/assessment.service.ts
+++ b/CSETWebNg/src/app/services/assessment.service.ts
@@ -233,7 +233,7 @@ export class AssessmentService {
         headers
       )
       .subscribe(() => {
-        if (this.configSvc.cisaAssessorWorkflow) {
+        if (this.configSvc.userIsCisaAssessor) {
           this.updateAssessmentName();
         }
       });

--- a/CSETWebNg/src/app/services/config.service.ts
+++ b/CSETWebNg/src/app/services/config.service.ts
@@ -99,7 +99,7 @@ export class ConfigService {
    * will contain an empty string or "none".
    */
   mobileEnvironment = '';
-  cisaAssessorWorkflow: boolean = false;
+  userIsCisaAssessor: boolean = false;
 
   /**
    * Constructor.
@@ -346,7 +346,7 @@ export class ConfigService {
   }
 
   setCisaAssessorWorkflow(cisaAssessorWorkflowEnabled: boolean) {
-    this.cisaAssessorWorkflow = cisaAssessorWorkflowEnabled;
+    this.userIsCisaAssessor = cisaAssessorWorkflowEnabled;
     return this.http.post(this.apiUrl + 'EnableProtectedFeature/setCisaAssessorWorkflow', cisaAssessorWorkflowEnabled);
   }
 

--- a/CSETWebNg/src/app/services/demographic-iod.service.ts
+++ b/CSETWebNg/src/app/services/demographic-iod.service.ts
@@ -77,7 +77,7 @@ export class DemographicIodService {
   updateDemographic(demographic: DemographicsIod) {
     this.http.post(this.apiUrl, demographic, headers)
       .subscribe(() => {
-        if (this.configSvc.cisaAssessorWorkflow) {
+        if (this.configSvc.userIsCisaAssessor) {
           this.assessSvc.updateAssessmentName();
         }
       });

--- a/CSETWebNg/src/app/services/demographic.service.ts
+++ b/CSETWebNg/src/app/services/demographic.service.ts
@@ -92,7 +92,7 @@ export class DemographicService {
 
     this.http.post(this.apiUrl, JSON.stringify(demographic), headers)
       .subscribe(() => {
-        if (this.configSvc.cisaAssessorWorkflow) {  
+        if (this.configSvc.userIsCisaAssessor) {  
 
         }
       });

--- a/CSETWebNg/src/app/services/navigation/page-visibility.service.ts
+++ b/CSETWebNg/src/app/services/navigation/page-visibility.service.ts
@@ -153,18 +153,18 @@ export class PageVisibilityService {
       }
 
       if (c == ('ASSESSOR')) {
-        if (this.configSvc.cisaAssessorWorkflow) {
-          show = show && (this.configSvc.cisaAssessorWorkflow && this.assessSvc.assessment?.assessorMode);
+        if (this.configSvc.userIsCisaAssessor) {
+          show = show && (this.configSvc.userIsCisaAssessor && this.assessSvc.assessment?.assessorMode);
         } else {
-          show = show && (this.configSvc.cisaAssessorWorkflow !== this.assessSvc.assessment?.assessorMode);
+          show = show && (this.configSvc.userIsCisaAssessor !== this.assessSvc.assessment?.assessorMode);
         }
       }
 
       if (c == ('ASSESSOR-NONE')) {
-        if (this.configSvc.cisaAssessorWorkflow) {
-          show = show && !(this.configSvc.cisaAssessorWorkflow && this.assessSvc.assessment?.assessorMode);
+        if (this.configSvc.userIsCisaAssessor) {
+          show = show && !(this.configSvc.userIsCisaAssessor && this.assessSvc.assessment?.assessorMode);
         } else {
-          show = show && !(this.configSvc.cisaAssessorWorkflow !== this.assessSvc.assessment?.assessorMode);
+          show = show && !(this.configSvc.userIsCisaAssessor !== this.assessSvc.assessment?.assessorMode);
         }
       }
 
@@ -344,7 +344,7 @@ export class PageVisibilityService {
    * Indicates whether the current user is a CISA CSA / assessor
    */
   isUserCisaAssessor(): boolean {
-    return this.configSvc.cisaAssessorWorkflow;
+    return this.configSvc.userIsCisaAssessor;
   }
 
   /**


### PR DESCRIPTION
There was a case where the Reports page disabled all of the report links and showed all of the missing fields when the assessment is in "normal" mode.  The reports page now looks at the assessorMode property of the assessment, rather than whether the user is a CISA assessor or not.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
