### PR TITLE
fix: dependabot PR actions failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
-secrets:
-  PAT: ${{ secrets.PAT }}
 updates:
   - package-ecosystem: "github-actions" 
     directory: "/" 


### PR DESCRIPTION
This pull request alleviates GitHub Actions failures on Dependabot Pull Requests. It updates the GitHub Actions workflow to handle builds differently based on whether the actor is Dependabot or a regular user. It introduces conditional logic to skip certain jobs for Dependabot and adds a new job specifically for Dependabot to perform basic build tests.

Changes to workflow logic:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R19): Added conditional checks (`if: github.actor != 'dependabot[bot]`) to the `build-api` and `build-web` jobs to skip these jobs when Dependabot is the actor. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R19) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R39)

Dependabot-specific build testing:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R58-R70): Introduced a new `dependabot-build` job that runs only when Dependabot is the actor. This job performs basic build tests for both the API and Web components using Docker.

