### PR TITLE
feature: add validation to module content report field

### DIFF
--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.html
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.html
@@ -31,14 +31,15 @@
             <div class="position-relative" style="flex: 1">
                 <input type="text" class="form-control mb-3" [(ngModel)]="selectedItem" [ngbTypeahead]="search"
                     [inputFormatter]="formatter" [resultTemplate]="resultTemplate"
-                    [placeholder]="t('Start typing to search standards or models...')" (selectItem)="onItemSelect($event)"
-                    [focusFirst]="false" [showHint]="true" [readonly]="isReadOnly" />
-                <button *ngIf="isReadOnly" type="button" class="btn-clear" (click)="clearSelection()"
+                    [placeholder]="t('Start typing to search standards or models...')"
+                    (selectItem)="onItemSelect($event)" (ngModelChange)="onInputChange($event)" [focusFirst]="false"
+                    [showHint]="true" />
+                <button type="button" class="btn-clear" (click)="clearSelection()"
                     [attr.aria-label]="t('Clear selection')" title="{{ t('Clear selection') }}">
                     <i class="bi bi-x-lg"></i>
                 </button>
             </div>
-            <button class="btn btn-primary text-nowrap ms-3" (click)="launchReport()" [disabled]="!selectedOption">{{
+            <button class="btn btn-primary text-nowrap ms-3" (click)="launchReport()" [disabled]="!isValidSelection">{{
                 t('Launch Report') }}</button>
         </div>
 

--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
@@ -50,7 +50,7 @@ export class ModuleContentLaunchComponent implements OnInit {
 
   searchableItems: any[] = [];
   selectedItem: any;
-  isReadOnly = false;
+  isValidSelection = false;
 
   search = (text$: Observable<string>) =>
     text$.pipe(
@@ -163,7 +163,7 @@ export class ModuleContentLaunchComponent implements OnInit {
     if (event && event.item) {
       this.selectedOption = event.item.value;
       this.onSelectionChange();
-      this.isReadOnly = true;
+      this.isValidSelection = true;
     }
   }
 
@@ -175,7 +175,7 @@ export class ModuleContentLaunchComponent implements OnInit {
     this.selectedOption = '';
     this.selectedStandard = null;
     this.selectedModel = null;
-    this.isReadOnly = false;
+    this.isValidSelection = false;
   }
 
   /**
@@ -188,12 +188,30 @@ export class ModuleContentLaunchComponent implements OnInit {
   }
 
   /**
+   * Handle input text changes
+   */
+  onInputChange(value: any) {
+    // If the input was cleared or doesn't match any selected item, reset the selection
+    if (!value || (typeof value === 'string')) {
+      // Check if the typed value matches the currently selected item
+      const currentSelectedItem = this.searchableItems.find(item =>
+        this.selectedOption === item.value
+      );
+
+      if (!currentSelectedItem || value !== currentSelectedItem.displayName) {
+        // Text was modified, clear the selection
+        this.clearSelection();
+      }
+    }
+  }
+
+  /**
    * Launch the appropriate report based on selection
    */
   launchReport() {
-    if (this.selectedOption.startsWith('standard:')) {
+    if (this.isValidSelection && this.selectedOption.startsWith('standard:')) {
       this.launchStandardReport();
-    } else if (this.selectedOption.startsWith('model:')) {
+    } else if (this.isValidSelection && this.selectedOption.startsWith('model:')) {
       this.launchModelReport();
     }
   }


### PR DESCRIPTION
This pull request refines the `ModuleContentLaunchComponent` in `CSETWebNg` to improve user input handling and validation for launching reports. The changes include replacing the `isReadOnly` flag with a more descriptive `isValidSelection` flag, adding a new method to handle input changes, and enhancing the logic for determining valid selections.

### Improvements to input handling and validation:

* **Replaced `isReadOnly` with `isValidSelection`:** The `isReadOnly` flag was replaced with `isValidSelection` for better clarity and functionality. This flag now tracks whether the current selection is valid for launching a report. (`[[1]](diffhunk://#diff-f02dc382fc68cde92a5d8292c046cb3244816f9a9a95a65f6ded5aa71ce72836L53-R53)`, `[[2]](diffhunk://#diff-f02dc382fc68cde92a5d8292c046cb3244816f9a9a95a65f6ded5aa71ce72836L166-R166)`, `[[3]](diffhunk://#diff-f02dc382fc68cde92a5d8292c046cb3244816f9a9a95a65f6ded5aa71ce72836L178-R178)`)

* **Added `onInputChange` method:** Introduced a new method, `onInputChange`, to handle changes in the input field. This method ensures that the selection is cleared if the input is modified or doesn't match any valid item. (`[CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.tsR190-R214](diffhunk://#diff-f02dc382fc68cde92a5d8292c046cb3244816f9a9a95a65f6ded5aa71ce72836R190-R214)`)

### Enhancements to user interface:

* **Updated HTML bindings:** Modified the `module-content-launch.component.html` file to bind `onInputChange` to the `ngModelChange` event and adjusted button behavior to align with the new `isValidSelection` logic. (`[CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.htmlL34-R42](diffhunk://#diff-4aa5d2885ac6036d64ddd43ac11a31bf5d7f297dbbc19aeb6c14f87d174d35dfL34-R42)`)

### Improved report launching logic:

* **Validated selection before launching reports:** Enhanced the `launchReport` method to check `isValidSelection` before proceeding with launching either a standard or model report. (`[CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.tsR190-R214](diffhunk://#diff-f02dc382fc68cde92a5d8292c046cb3244816f9a9a95a65f6ded5aa71ce72836R190-R214)`)