### PR TITLE
fix: trivy analysis permissions

### DIFF
--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 21 * * 0"
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   dotnet:
     name: .NET Analysis


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/trivy-analysis.yml` to include additional permissions for the `contents` and `security-events` scopes.

Workflow configuration updates:

* [`.github/workflows/trivy-analysis.yml`](diffhunk://#diff-a3002db223970335b4937634bc96909e652e5fee76d1612091aabaa2736e6297R11-R14): Added `permissions` block with `contents: read` and `security-events: write` to enhance security and allow the workflow to interact with security events.