### PR TITLE
Overrode the disabled class for the navigation buttons to be hidden

### DIFF
--- a/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.ts
+++ b/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.ts
@@ -86,6 +86,7 @@ export class NewAssessmentComponent implements OnInit, AfterViewInit {
       navigation: {
         nextEl: '.swiper-button-next', // selector for external button
         prevEl: '.swiper-button-prev', // selector for external button
+        disabledClass: 'swiper-button-hidden'
       },
       loop: false,
       breakpoints: {
@@ -137,7 +138,7 @@ export class NewAssessmentComponent implements OnInit, AfterViewInit {
   onHover(i: number) {
     this.hoverIndex = i;
     if (i > 0) {
-      var el = document.getElementById('c' + i.toString()).parentElement;
+      var el = document.getElementById('c' + i.toString())?.parentElement;
 
       var bounding = el.getBoundingClientRect();
 
@@ -155,7 +156,7 @@ export class NewAssessmentComponent implements OnInit, AfterViewInit {
   onHoverOut(i: number, cardId: number) {
     this.hoverIndex = i;
 
-    var el = document.getElementById('c' + cardId.toString()).parentElement;
+    var el = document.getElementById('c' + cardId.toString())?.parentElement;
     el.style.removeProperty('right');
   }
 
@@ -166,5 +167,5 @@ export class NewAssessmentComponent implements OnInit, AfterViewInit {
       data: data
     });
   }
-
+  
 }


### PR DESCRIPTION
This pull request updates the `NewAssessmentComponent` class in `new-assessment.component.ts` to improve code safety and enhance the user interface. The most important changes include adding a `disabledClass` for Swiper navigation buttons and using optional chaining to prevent potential runtime errors.

### User Interface Enhancements:
* Added a `disabledClass` property (`'swiper-button-hidden'`) to the Swiper navigation configuration, improving the styling and behavior of disabled navigation buttons.

### Code Safety Improvements:
* Updated `onHover` and `onHoverOut` methods to use optional chaining (`?.`) when accessing the `parentElement` of an element, preventing potential runtime errors if the element is null. [[1]](diffhunk://#diff-a6dc3c43926f816ae8266b62f834dbd54141b6a4745ded8edb095500464a8803L140-R141) [[2]](diffhunk://#diff-a6dc3c43926f816ae8266b62f834dbd54141b6a4745ded8edb095500464a8803L158-R159)<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
