### PR TITLE
Added MIL functionality to the CRE grouping selector control

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
@@ -42,7 +42,7 @@
     <h3>
       {{t('titles.diagram component questions')}}
     </h3>
-    <div *ngIf="filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
+    <div *ngIf="!!categories && filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
 
     <div *ngIf="!categories" class="w-100">
       <div class="spinner-container" style="margin: 2em auto">

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
@@ -34,14 +34,13 @@
           <div *ngFor="let g of model" class="mb-2">
                <input class="checkbox-custom d-none" type="checkbox" id="dom-{{g.groupingId}}" [(ngModel)]="g.selected"
                     (change)="changeGroupSelection(g.groupingId, $event)">
-               <label for="dom-{{g.groupingId}}" class="checkbox-custom-label mb-3" style="color: white">{{g?.title}}
-                    {{g.groupingId}}</label>
+               <label for="dom-{{g.groupingId}}" class="checkbox-custom-label mb-3" style="color: white">{{g?.title}}</label>
                <div [hidden]="!g.selected" class="collapsible-content ms-4 mb-3 pb-2 nested-list section-border">
                     <div *ngFor="let sg of g.subGroupings">
                          <input class="checkbox-custom d-none" type="checkbox" id="subdom-{{sg.groupingId}}"
                               [(ngModel)]="sg.selected" (change)="changeGroupSelection(sg.groupingId, $event)">
                          <label for="subdom-{{sg.groupingId}}" class="checkbox-custom-label"
-                              style="color: white">{{sg.title}} {{sg.groupingId}}</label>
+                              style="color: white">{{sg.title}}</label>
                     </div>
                </div>
           </div>

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
@@ -32,17 +32,48 @@
      <div [@expandCollapse]="expanded ? 'expanded' : 'collapsed'">
           <div class="mt-3"></div>
           <div *ngFor="let g of model" class="mb-2">
-               <input class="checkbox-custom d-none" type="checkbox" id="dom-{{g.groupingId}}" [(ngModel)]="g.selected"
-                    (change)="changeGroupSelection(g.groupingId, $event)">
-               <label for="dom-{{g.groupingId}}" class="checkbox-custom-label mb-3" style="color: white">{{g?.title}}</label>
-               <div [hidden]="!g.selected" class="collapsible-content ms-4 mb-3 pb-2 nested-list section-border">
-                    <div *ngFor="let sg of g.subGroupings">
-                         <input class="checkbox-custom d-none" type="checkbox" id="subdom-{{sg.groupingId}}"
-                              [(ngModel)]="sg.selected" (change)="changeGroupSelection(sg.groupingId, $event)">
-                         <label for="subdom-{{sg.groupingId}}" class="checkbox-custom-label"
-                              style="color: white">{{sg.title}}</label>
+
+               <!-- Rows of checkboxes, for ad hoc grouping selections -->
+               <div *ngIf="!cumulativeLevels; else cumulative">
+                    <input class="checkbox-custom d-none" type="checkbox" id="dom-{{g.groupingId}}"
+                         [(ngModel)]="g.selected" (change)="changeGroupSelection(g.groupingId, $event)">
+                    <label for="dom-{{g.groupingId}}" class="checkbox-custom-label mb-3"
+                         style="color: white">{{g?.title}}</label>
+                    <div [hidden]="!g.selected" class="collapsible-content ms-4 mb-3 pb-2 nested-list section-border">
+                         <div *ngFor="let sg of g.subGroupings">
+                              <input class="checkbox-custom d-none" type="checkbox" id="subdom-{{sg.groupingId}}"
+                                   [(ngModel)]="sg.selected" (change)="changeGroupSelection(sg.groupingId, $event)">
+                              <label for="subdom-{{sg.groupingId}}" class="checkbox-custom-label"
+                                   style="color: white">{{sg.title}}</label>
+                         </div>
                     </div>
                </div>
+
+               <!-- This section is used for cumulative groupings, like MIL levels -->
+               <ng-template #cumulative>
+                    <div>
+                         <input class="checkbox-custom d-none" type="checkbox" id="dom-{{g.groupingId}}"
+                              [(ngModel)]="g.selected" (change)="changeGroupSelection(g.groupingId, $event)">
+                         <label for="dom-{{g.groupingId}}" class="checkbox-custom-label mb-3"
+                              style="color: white">{{g?.title}}</label>
+
+                         <div [hidden]="!g.selected"
+                              class="collapsible-content ms-4 mb-3 pb-2 nested-list section-border">
+                              <div class="btn-group btn-group-toggle mb-4" style="display: flex; width: 100%;"
+                                   data-toggle="buttons">
+                                   <ng-template ngFor let-sg [ngForOf]="g.subGroupings">
+                                        <label [attr.csetid]="'CRE-MIL-' + sg.groupingId"
+                                             class="btn btn-level primary btn-rounded" [class.active]="sg.selected"
+                                             (click)="changeMilSelection(sg.groupingId, $event)">
+                                             <input class="btn-check primary" tabindex="0" type="radio"
+                                                  autocomplete="off" name="cre_mil_main" [checked]="sg.selected">
+                                             {{ sg.title }}
+                                        </label>
+                                   </ng-template>
+                              </div>
+                         </div>
+                    </div>
+               </ng-template>
           </div>
      </div>
 </div>

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.ts
@@ -21,6 +21,8 @@ export class CreQuestionSelectorComponent implements OnInit {
 
   @Input() modelId: number;
 
+  @Input() cumulativeLevels = false;
+
   model: any;
 
   expanded = false;
@@ -50,7 +52,7 @@ export class CreQuestionSelectorComponent implements OnInit {
   }
 
   /**
-   * 
+   * Persists the selected/deselected state of a 
    */
   changeGroupSelection(id: number, evt: any) {
     const g = this.selectableGroupingsSvc.findGrouping(this.modelId, id);
@@ -66,6 +68,19 @@ export class CreQuestionSelectorComponent implements OnInit {
     // persist the changed group(s)
     const groupsChanged = this.buildList(g);
     this.selectableGroupingsSvc.save(groupsChanged, g.selected).subscribe();
+  }
+
+  /**
+   * Sets the clicked level and levels below it to true. 
+   */
+  changeMilSelection(id: number, evt: any) {
+    const gg = this.selectableGroupingsSvc.findGroupingAndLesser(this.modelId, id);
+
+    this.selectableGroupingsSvc.emitSelectionChanged();
+
+    // persist the true group and the false group to the API
+    this.selectableGroupingsSvc.save(gg.filter(x => x.selected).map(x => x.groupingId), true).subscribe();
+    this.selectableGroupingsSvc.save(gg.filter(x => !x.selected).map(x => x.groupingId), false).subscribe();
   }
 
   /**

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
@@ -62,14 +62,14 @@
       </span>
     </div>
 
-    <div *ngIf="filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
+    <div *ngIf="!!groupings && filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
 
     <div *ngIf="maturityFilteringSvc.showingAboveMaturityTargetLevel()" class="filters-engaged">Including Questions
       Above Target Level</div>
 
 
     <ng-container *ngIf="!!groupings">
-      <p class="mb-4" *ngIf="this.groupingId?.toLowerCase() == 'bonus'">
+      <p class="mb-4" *ngIf="this.navTarget?.toLowerCase() == 'bonus'">
         {{t('questions.instructions ssg')}}
       </p>
 
@@ -98,12 +98,12 @@
 
 
   <!-- normal navigation -->
-  <app-nav-back-next *ngIf="!groupingId" [page]="'maturity-questions'"></app-nav-back-next>
+  <app-nav-back-next *ngIf="!navTarget" [page]="'maturity-questions'"></app-nav-back-next>
   
   <!-- Show a different model (like CRE's additional models) -->
-  <app-nav-back-next *ngIf="groupingId?.toLowerCase().startsWith('m')" [page]="'maturity-questions-' + groupingId"></app-nav-back-next>
+  <app-nav-back-next *ngIf="navTarget?.toLowerCase().startsWith('m')" [page]="'maturity-questions-' + navTarget"></app-nav-back-next>
   
   <!-- Show a grouping only -->
-  <app-nav-back-next *ngIf="!!groupingId && !groupingId.toLowerCase().startsWith('m')" [page]="'maturity-questions-' + groupingId"></app-nav-back-next>
+  <app-nav-back-next *ngIf="!!navTarget && !navTarget.toLowerCase().startsWith('m')" [page]="'maturity-questions-' + navTarget"></app-nav-back-next>
 
 </div>

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
@@ -80,7 +80,7 @@
 
     <!-- CRE+ allows the user to limit questions shown on some pages -->
     <ng-container *ngIf="!!groupings && showGroupingSelector">
-      <app-cre-question-selector [modelId]="modelId"></app-cre-question-selector>
+      <app-cre-question-selector [modelId]="modelId" [cumulativeLevels]="groupingsAreMil"></app-cre-question-selector>
     </ng-container>
 
     <div *ngIf="!groupings" class="w-100">

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -57,6 +57,8 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
   navTarget: string | null; // this is a string to be able to support 'bonus' or 'm23'
 
   groupings: QuestionGrouping[] | null = [];
+  groupingsAreMil = false;
+
   pageTitle: string = '';
   moduleBehavior: ModuleBehavior;
   modelId: number;
@@ -226,24 +228,25 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
         // Show the selector for CRE+ Optional Domain Questions (model 23)
         // and CRE+ Optional MIL Questions (model 24)
         this.showGroupingSelector = this.moduleBehavior.mustSelectGroupings ?? false;
-
+        this.groupingsAreMil = this.moduleBehavior.groupingsAreMil ?? false;
         this.modelName = response.modelName;
         this.questionsAlias = response.questionsAlias;
         this.groupings = response.groupings;
         this.selectableGroupingSvc.setModelGroupings(this.modelId, response.groupings);
 
-
-        this.assessSvc.assessment.maturityModel.maturityTargetLevel = response.maturityTargetLevel;
+        if (this.assessSvc.assessment && this.assessSvc.assessment.maturityModel) {
+          this.assessSvc.assessment.maturityModel.maturityTargetLevel = response.maturityTargetLevel;
+          this.assessSvc.assessment.maturityModel.answerOptions = response.answerOptions;
+        }
 
         // 100 is the default level if the model does not support a target
         this.modelSupportsTargetLevel = response.maturityTargetLevel < 100;
 
-        this.assessSvc.assessment.maturityModel.answerOptions = response.answerOptions;
         this.filterSvc.answerOptions = response.answerOptions.slice();
         this.filterSvc.maturityModelId = response.modelId;
         this.filterSvc.maturityModelName = response.modelName;
         this.filterSvc.maturityTargetLevel = response.maturityTargetLevel;
-        
+
         // Adding Maturity Levels to the filters
         this.filterSvc.refreshAllowableFilters();
         this.filterSvc.forceRefresh();
@@ -291,9 +294,11 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
       this.modelName = response.modelName;
       this.questionsAlias = response.questionsAlias;
       this.groupings = response.groupings;
-      this.assessSvc.assessment.maturityModel.maturityTargetLevel = response.maturityTargetLevel;
+      if (this.assessSvc.assessment && this.assessSvc.assessment.maturityModel) {
+        this.assessSvc.assessment.maturityModel.maturityTargetLevel = response.maturityTargetLevel;
+        this.assessSvc.assessment.maturityModel.answerOptions = response.answerOptions;
+      }
 
-      this.assessSvc.assessment.maturityModel.answerOptions = response.answerOptions;
       this.filterSvc.answerOptions = response.answerOptions.slice();
       this.filterSvc.maturityModelId = response.modelId;
 

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -21,7 +21,7 @@
 //  SOFTWARE.
 //
 ////////////////////////////////
-import { AfterViewInit, Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { NavigationService } from '../../../services/navigation/navigation.service';
 import { AssessmentService } from '../../../services/assessment.service';
 import { MaturityService } from '../../../services/maturity.service';
@@ -34,9 +34,9 @@ import { ConfigService } from '../../../services/config.service';
 import { MaturityFilteringService } from '../../../services/filtering/maturity-filtering/maturity-filtering.service';
 import { GlossaryService } from '../../../services/glossary.service';
 import { CisService } from '../../../services/cis.service';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { filter } from 'rxjs/operators';
-import { Subscription } from 'rxjs';
+import { ActivatedRoute, NavigationEnd, Router, UrlSegment, UrlSegmentGroup, UrlTree } from '@angular/router';
+import { filter, takeUntil } from 'rxjs/operators';
+import { Subject, Subscription } from 'rxjs';
 import { CompletionService } from '../../../services/completion.service';
 import { TranslocoService } from '@jsverse/transloco';
 import { DemographicService } from '../../../services/demographic.service';
@@ -50,7 +50,11 @@ import { SelectableGroupingsService } from '../../../services/selectable-groupin
   templateUrl: './maturity-questions.component.html',
   standalone: false
 })
-export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
+export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDestroy {
+
+  private routerSubscription: Subscription;
+  private destroy$ = new Subject<void>();
+  navTarget: string | null; // this is a string to be able to support 'bonus' or 'm23'
 
   groupings: QuestionGrouping[] | null = [];
   pageTitle: string = '';
@@ -65,16 +69,18 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
   loaded = false;
 
   grouping: QuestionGrouping | null;
-  groupingId: string; // this is a string to be able to support 'bonus'
-  title: string;
   showGroupingSelector = false;
+
+  title: string;
 
   msgUnansweredEqualsNo = '';
 
   filterDialogRef: MatDialogRef<QuestionFiltersComponent>;
 
-  private _routerSub = Subscription.EMPTY;
 
+  /**
+   * 
+   */
   constructor(
     public assessSvc: AssessmentService,
     public demoSvc: DemographicService,
@@ -91,26 +97,21 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
     public glossarySvc: GlossaryService,
     public navSvc: NavigationService,
     private dialog: MatDialog,
-    private route: ActivatedRoute,
     private router: Router,
     private tSvc: TranslocoService
   ) {
+    this.routerSubscription = this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe((event: NavigationEnd) => {
+        this.setNavTarget(event);
+        this.load();
+      });
+  }
 
-    // listen for NavigationEnd to know when the page changed
-    this._routerSub = this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd)
-    ).subscribe((e: any) => {
-      if (e.urlAfterRedirects.includes('/maturity-questions/')) {
-        this.groupingId = this.route.snapshot.params['grp'];
-
-        if (parseInt(this.groupingId) == +this.groupingId) {
-          this.loadGrouping(+this.groupingId);
-        } else {
-          this.loadQuestions();
-        }
-      }
-    });
-
+  /**
+   *
+   */
+  ngOnInit() {
     if (this.assessSvc.assessment == null) {
       this.assessSvc.getAssessmentDetail().subscribe(
         (data: any) => {
@@ -118,32 +119,33 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
         });
     }
 
+    // listen for grouping selector changes
+    this.selectableGroupingSvc.selectionChanged$.subscribe(() => {
+      this.refreshQuestionVisibility();
+    });
+
+
+    // Refresh the page in case of user language change.  
+    // The more complex event analysis is needed because
+    // the Transloco service will also emit langChanges$ when the
+    // component is initialized.  We only care about a true language 
+    // change to avoid calling the API multiple times.
+    this.tSvc.events$
+      .pipe(
+        filter(event => event.type === 'langChanged'),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        if (this.assessSvc.assessment) {
+          this.load();
+        }
+      });
+
+
     localStorage.setItem("questionSet", "Maturity");
     this.assessSvc.currentTab = 'questions';
   }
 
-  /**
-   *
-   */
-  ngOnInit() {
-    // refresh the page in case of language change
-    // NOTE: langChanges$ will emit the active language on subscription,
-    // so load() will always fire on initial page load
-    this.tSvc.langChanges$.subscribe(() => {
-
-      // check for assessment existence so that this isn't triggered when logging
-      // in after a timeout.  In that scenario there is no assessment ID in the JWT
-      // and the call to load questions or groupings will crash.
-      if (!!this.assessSvc.assessment) {
-        this.load();
-      }
-    });
-
-    
-    this.selectableGroupingSvc.selectionChanged$.subscribe(() => {
-      this.refreshQuestionVisibility();
-    });
-  }
 
   /**
    * 
@@ -155,17 +157,27 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * 
+   */
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+
+
+    if (this.routerSubscription) {
+      this.routerSubscription.unsubscribe();
+    }
+  }
+
+  /**
    *
    */
   load() {
     // determine whether displaying a grouping or all questions for the model
-    this.grouping = null;
-    this.groupingId = this.route.snapshot.params['grp'];
-
-    if (!this.groupingId || this.groupingId.toLowerCase() == 'bonus' || this.groupingId.toLowerCase().startsWith('m')) {
+    if (!this.navTarget || this.navTarget.toLowerCase() == 'bonus' || this.navTarget.toLowerCase().startsWith('m')) {
       this.loadQuestions();
     } else {
-      this.loadGrouping(+this.groupingId);
+      this.loadGrouping(+this.navTarget);
     }
 
     this.refreshQuestionVisibility();
@@ -191,14 +203,14 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
     // determine which endpoint to call to get the question list
     var obsGetQ;
 
-    if (this.groupingId?.toLowerCase() == 'bonus') {
+    if (this.navTarget?.toLowerCase() == 'bonus') {
       const bonusModelId = this.ssgSvc.ssgBonusModel();
       obsGetQ = this.maturitySvc.getBonusQuestionList(bonusModelId);
-      
-    } else if (this.groupingId?.toLowerCase().startsWith('m')) {
-      const bonusModelId = +this.groupingId.substring(1);
+
+    } else if (this.navTarget?.toLowerCase().startsWith('m')) {
+      const bonusModelId = +this.navTarget.substring(1);
       obsGetQ = this.maturitySvc.getBonusQuestionList(bonusModelId);
-      
+
     } else {
       obsGetQ = this.maturitySvc.getQuestionsList(false);
     }
@@ -230,7 +242,8 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
         this.filterSvc.answerOptions = response.answerOptions.slice();
         this.filterSvc.maturityModelId = response.modelId;
         this.filterSvc.maturityModelName = response.modelName;
-        this.filterSvc.maturityTargetLevel=response.maturityTargetLevel
+        this.filterSvc.maturityTargetLevel = response.maturityTargetLevel;
+        
         // Adding Maturity Levels to the filters
         this.filterSvc.refreshAllowableFilters();
         this.filterSvc.forceRefresh();
@@ -239,7 +252,7 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
 
         this.glossarySvc.glossaryEntries = response.glossary;
 
-        
+
         // set the message with the current "no" answer value
         let codeForNo = this.moduleBehavior.answerOptions?.find(o => o.unansweredEquivalent)?.code ?? 'N';
         const valueForNo = this.questionsSvc.answerButtonLabel(this.modelName, codeForNo);
@@ -309,7 +322,7 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
    */
   displayTitle() {
     // Bonus questions are for SSGs.
-    if (this.groupingId?.toLowerCase() == 'bonus') {
+    if (this.navTarget?.toLowerCase() == 'bonus') {
       this.pageTitle = this.tSvc.translate(`titles.ssg.${this.ssgSvc.ssgSimpleSectorLabel()}`);
       return;
     }
@@ -430,5 +443,63 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit {
    */
   showCreSelector(modelId: number): boolean {
     return (modelId == 23 || modelId == 24);
+  }
+
+
+  /**
+   * This component can load the entire model, a specific model
+   * or a particular grouping.
+   * Parses the URL to determine how to format the API call.
+   * navTarget is the property that gets set.
+   */
+  setNavTarget(event: any) {
+    const currentUrl = event.urlAfterRedirects;
+    if (!currentUrl.endsWith('/maturity-questions') && !currentUrl.includes('/maturity-questions/')) {
+      return;
+    }
+
+    // get the next URL segment, if there is one and set the navTarget
+    const mqIndex = this.findSegmentIndex(currentUrl, 'maturity-questions');
+    const t = this.getSegment(currentUrl, mqIndex + 1);
+    if (!!t) {
+      this.navTarget = t;
+    } else {
+      this.navTarget = null;
+    }
+  }
+
+  /**
+   * Helper method for parsing routing URLs.
+   */
+  findSegmentIndex(url: string, segmentToFind: string): number {
+    const urlTree: UrlTree = this.router.parseUrl(url);
+    const primaryGroup: UrlSegmentGroup = urlTree.root.children['primary'];
+
+    if (primaryGroup) {
+      const segments = primaryGroup.segments;
+      for (let i = 0; i < segments.length; i++) {
+        if (segments[i].path === segmentToFind) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Helper method for parsing routing URLs.
+   */
+  getSegment(url: string, idx: number): string | null {
+    const urlTree: UrlTree = this.router.parseUrl(url);
+    const primaryGroup: UrlSegmentGroup = urlTree.root.children['primary'];
+
+    if (primaryGroup) {
+      const segments = primaryGroup.segments;
+      if (segments.length > idx) {
+        return segments[idx].toString();
+      }
+    }
+
+    return null;
   }
 }

--- a/CSETWebNg/src/app/assessment/questions/questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.html
@@ -70,7 +70,7 @@
 
   <h2 *ngIf="this.assessSvc.applicationMode == 'Q'">{{t('titles.standard questions')}}</h2>
   <h2 *ngIf="this.assessSvc.applicationMode == 'R'">{{t('titles.standard requirements')}}</h2>
-  <div *ngIf="filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
+  <div *ngIf="!!categories && filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
 
   <div *ngIf="!categories" class="w-100">
     <div class="spinner-container" style="margin: 2em auto">

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
@@ -133,7 +133,7 @@ export class ReportsComponent implements OnInit, AfterViewInit {
       this.router.navigate([value], { relativeTo: this.route.parent });
     });
 
-    if (this.configSvc.installationMode === 'IOD' && this.assessSvc.assessment.assessorMode) {
+    if (this.configSvc.installationMode === 'IOD' && this.assessSvc.assessment?.assessorMode) {
       this.reportSvc.validateCisaAssessorFields().subscribe((result: CisaWorkflowFieldValidationResponse) => {
         this.cisaAssessorWorkflowFieldValidation = result;
         if (!this.cisaAssessorWorkflowFieldValidation?.isValid) {

--- a/CSETWebNg/src/app/models/module-config.model.ts
+++ b/CSETWebNg/src/app/models/module-config.model.ts
@@ -64,6 +64,12 @@ export class ModuleBehavior {
      mustSelectGroupings?: boolean = false;
 
      /**
+      * Indicates a model whose groupings are cumulative.  
+      * This was created for "CRE+ MIL" (model 24).  
+      */
+     groupingsAreMil?: boolean = false;
+
+     /**
       * 
       */
      independentSuppGuidance?: boolean;

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
@@ -28,7 +28,7 @@
      </p>
 </ng-template>
 
-<div *ngIf="groupings.length > 0; else no_groupings">
+<div *ngIf="groupings?.length > 0; else no_groupings">
      <p>
           {{ 'reports.core.cre.final reports.p1' | transloco }}
      </p>

--- a/CSETWebNg/src/app/reports/crePlus/cre-model-charts/cre-model-charts.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-model-charts/cre-model-charts.component.html
@@ -40,7 +40,7 @@
      <div class="page-break">
           <h1>{{ 'reports.core.cre.answer distribution' | transloco }}</h1>
 
-          <div *ngIf="domainList.length > 0; else no_selected_subdomains">
+          <div *ngIf="domainList?.length > 0; else no_selected_subdomains">
                <p>
 
                </p>

--- a/CSETWebNg/src/app/services/maturity.service.ts
+++ b/CSETWebNg/src/app/services/maturity.service.ts
@@ -66,7 +66,7 @@ export class MaturityService {
   ofc: any[];
 
 
-  cmmcData = null;
+  cmmcData;
 
   mvraGroupings: any[] = [];
   cisGroupings: any[] = [];
@@ -87,6 +87,7 @@ export class MaturityService {
     private configSvc: ConfigService,
     private assessSvc: AssessmentService
   ) {
+    this.cmmcData = null;
 
     // get MVRA grouping titles
     this.getGroupingTitles(9).subscribe((l: any[]) => {
@@ -156,8 +157,8 @@ export class MaturityService {
    */
   targetLevelName() {
     const model = this.assessSvc.assessment.maturityModel;
-    if (!!this.assessSvc.assessment && !!model.maturityTargetLevel) {
-      const l = model.levels.find(x => x.level == this.assessSvc.assessment.maturityModel.maturityTargetLevel);
+    if (!!this.assessSvc.assessment && !!model?.maturityTargetLevel) {
+      const l = model.levels.find(x => x.level == this.assessSvc.assessment.maturityModel?.maturityTargetLevel);
       if (!!l) {
         return l.label;
       }

--- a/CSETWebNg/src/app/services/navigation/navigation.service.ts
+++ b/CSETWebNg/src/app/services/navigation/navigation.service.ts
@@ -82,7 +82,7 @@ export class NavigationService implements OnDestroy, OnInit {
   /**
    * Defines the grouping or question to scroll to when "resuming"
    */
-  resumeQuestionsTarget: string = null;
+  resumeQuestionsTarget: string | null = null;
 
 
 

--- a/CSETWebNg/src/app/services/selectable-groupings.service.ts
+++ b/CSETWebNg/src/app/services/selectable-groupings.service.ts
@@ -78,6 +78,32 @@ export class SelectableGroupingsService {
   }
 
   /**
+   * Finds the target's parent, then iterate through the parent's children, 
+   * setting their selected property to true if they are below or at the 
+   * target level, and false above the target.
+   */
+  findGroupingAndLesser(modelId: number, id: number): QuestionGrouping[] {
+    let resp: Array<QuestionGrouping> = [];
+
+    const modelDomains = this.models.get(modelId);
+    const target = this.findDeep(modelDomains, item => item.groupingId == id);
+
+    const parent = this.findParent(modelDomains, target);
+
+    let selected = true;
+
+    for (let c of parent) {
+      resp.push(c);
+      c.selected = selected;
+      if (c == target) {
+        selected = false;
+      }
+    }
+
+    return resp;
+  }
+
+  /**
    * 
    */
   findDeep(arr, predicate): QuestionGrouping | null {
@@ -89,7 +115,7 @@ export class SelectableGroupingsService {
         result = item;
         break;
       }
-      
+
       if (item.subGroupings && item.subGroupings.length) {
         result = this.findDeep(item.subGroupings, predicate);
         if (result) break;
@@ -100,13 +126,35 @@ export class SelectableGroupingsService {
 
   /**
    * 
+   * @param obj 
+   * @param target 
+   * @returns 
+   */
+  findParent(obj, target) {
+    for (let key in obj) {
+      if (obj[key] === target) {
+        return obj;
+      }
+      if (typeof obj[key] === 'object' && obj[key] !== null) {
+        let parent = this.findParent(obj[key], target);
+        if (parent) {
+          return parent;
+        }
+      }
+    }
+    return null;
+  }
+
+
+  /**
+   * 
    */
   emitSelectionChanged() {
     this.selectionChangedSubject.next();
   }
 
   /**
-   * 
+   * Persists a group of groupings with the same selected status.
    */
   save(groupingId: number[], selected: boolean) {
     const payload = { groupingId: groupingId, selected: selected };

--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -974,6 +974,12 @@
       "selector 23 title": "Select domains and subdomains for additional questions",
       "selector 24 title": "Select domains and MILs for additional questions"
     },
+    "cre+ opt": {
+      "display-name": "CRE+ Optional Domains"
+    },
+    "cre+ mil": {
+      "display-name": "CRE+ MIL"
+    },
     "cmmc2": {
       "model long title": "Cybersecurity Maturity Model Certification (CMMC) 2.0 DRAFT",
       "model short title": "CMMC 2.0 DRAFT"

--- a/CSETWebNg/src/assets/i18n/reports/en.json
+++ b/CSETWebNg/src/assets/i18n/reports/en.json
@@ -812,8 +812,8 @@
                     },
                     "24": {
                          "title": "Cyber Resilience Essentials (CRE+) MIL Questions Charts",
-                         "chart footer1": "MIL Question Answer Distribution.  Only selected subdomains are included.",
-                         "chart footer2": "MIL Question Answer Distribution by domain. Only selected subdomains are included.",
+                         "chart footer1": "MIL Question Answer Distribution.  Only selected MILs are included.",
+                         "chart footer2": "MIL Question Answer Distribution by domain. Only selected MILs are included.",
                          "no selected": "None of the MILs were selected so there is nothing to show."
                     }
                }

--- a/CSETWebNg/src/assets/settings/config.json
+++ b/CSETWebNg/src/assets/settings/config.json
@@ -393,6 +393,7 @@
       "autoLoadSupplemental": true,
       "showMaturityLevelBadge": false,
       "mustSelectGroupings": true,
+      "groupingsAreMil": false,
       "questionIcons": {
         "showDetails": false,
         "showReviewed": false
@@ -436,6 +437,7 @@
       "autoLoadSupplemental": true,
       "showMaturityLevelBadge": false,
       "mustSelectGroupings": true,
+      "groupingsAreMil": true,
       "questionIcons": {
         "showDetails": false,
         "showReviewed": false

--- a/CSETWebNg/src/assets/settings/config.json
+++ b/CSETWebNg/src/assets/settings/config.json
@@ -387,8 +387,8 @@
     {
       "moduleName": "CRE+ OPT",
       "modelId": "23",
-      "displayNameKey": "modules.cre+.display-name",
-      "questionNodeKey": "modules.cre+.question node title",
+      "displayNameKey": "modules.cre+ opt.display-name",
+      "questionNodeKey": "modules.cre+ opt.question node title",
       "hideTopLevelGroupingName": false,
       "autoLoadSupplemental": true,
       "showMaturityLevelBadge": false,
@@ -430,8 +430,8 @@
     {
       "moduleName": "CRE+ MIL",
       "modelId": "24",
-      "displayNameKey": "modules.cre+.display-name",
-      "questionNodeKey": "modules.cre+.question node title",
+      "displayNameKey": "modules.cre+ mil.display-name",
+      "questionNodeKey": "modules.cre+ mil.question node title",
       "hideTopLevelGroupingName": false,
       "autoLoadSupplemental": true,
       "showMaturityLevelBadge": false,


### PR DESCRIPTION
This pull request introduces enhancements to the maturity questions component, including support for cumulative grouping levels, improved navigation logic, and cleanup of unused variables. The changes primarily focus on improving the user experience and code maintainability.

### Enhancements to Grouping and Selection:

* Added support for cumulative grouping levels (e.g., MIL levels) in the `CreQuestionSelectorComponent` by introducing the `cumulativeLevels` input property and implementing the `changeMilSelection` method to handle level selection logic. (`CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html`, `CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.ts`) [[1]](diffhunk://#diff-21c87125cacac15f70fc74414b92a62fe7edb1cadc4c244ccf29daa6e962dfc6L35-R76) [[2]](diffhunk://#diff-992dc4a59a569550daeb21a19bb93b4102f4cd2b63c3cb7310b962c2d49ab26eR24-R25) [[3]](diffhunk://#diff-992dc4a59a569550daeb21a19bb93b4102f4cd2b63c3cb7310b962c2d49ab26eR73-R85)

### Navigation and State Management:

* Replaced `groupingId` with a more descriptive `navTarget` property in `MaturityQuestionsComponent` to improve clarity and simplify navigation-related logic. (`CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts`) [[1]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443L53-R61) [[2]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443L94-R151) [[3]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443R161-R182)
* Updated navigation templates to use `navTarget` for determining the current navigation context. (`CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html`)

### Filtering and Loading Improvements:

* Enhanced filtering logic by ensuring that filters only engage when relevant data (`categories` or `groupings`) is available. (`CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html`, `CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html`) [[1]](diffhunk://#diff-a5767456566f3a3bb812bd37f2f7dd69b591784801deba417b25ef9089ea291aL45-R45) [[2]](diffhunk://#diff-5e2c6aaaa2f1b50860e711bd3bee101d6020ead99e794b30a5065a9e109f4ce8L65-R72)

### Code Cleanup and Refactoring:

* Removed unused variables and subscriptions, such as `_routerSub` and `groupingId`, and replaced them with cleaner alternatives. (`CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts`) [[1]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443L68-R85) [[2]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443R297-R301)
* Added proper cleanup for subscriptions in the `ngOnDestroy` lifecycle hook to prevent memory leaks. (`CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts`)

### Dependency Updates:

* Imported additional Angular modules and operators (`takeUntil`, `Subject`, etc.) to support new functionality and improve the component's lifecycle management. (`CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts`)<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
