### PR TITLE
Reworked Assessor Workflow verbiage and Y/N button pairs.

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -72,19 +72,19 @@
 
     <div class="row mb-4">
       <div class="col-6">
-        <div class="row">
-          <label for="name" class="form-label">{{t('pcii requested')}}</label>
-          <div class="btn-group col-10" role="group" data-toggle="buttons">
-            <label class="btn btn-level btn-rounded form-check-label" [class.active]="assessment.is_PCII">
-              <input class="btn-check" name="standardYes" id="standardYes" type="radio" autocomplete="off"
-                (change)="changeIsPCII(true)" tabindex="0" [(ngModel)]="assessment.is_PCII" />
-              Yes
-            </label>
-            <label class="btn btn-level btn-rounded form-check-label" [class.active]="!assessment.is_PCII">
+        <label for="name" class="form-label">{{t('pcii requested')}}</label>
+        <div>
+          <div class="d-inline-flex btn-group align-items-start" role="group" data-toggle="buttons">
+            <label class="btn btn-level form-check-label px-4" [class.active]="!assessment.is_PCII">
               <input class="btn-check" name="standardNo" id="standardNo" type="radio" autocomplete="off"
                 (change)="changeIsPCII(false)" tabindex="0" [ngModel]="!assessment.is_PCII"
                 (ngModelChange)="assessment.is_PCII = $event" />
-              No
+              {{t('answer-options.button-labels.no')}}
+            </label>
+            <label class="btn btn-level form-check-label px-4" [class.active]="assessment.is_PCII">
+              <input class="btn-check" name="standardYes" id="standardYes" type="radio" autocomplete="off"
+                (change)="changeIsPCII(true)" tabindex="0" [(ngModel)]="assessment.is_PCII" />
+              {{t('answer-options.button-labels.yes')}}
             </label>
           </div>
         </div>
@@ -109,28 +109,27 @@
     <div class="mt-4">
       <h4>{{ t('assessment settings') }}</h4>
 
-      <div *ngIf="this.configSvc.userIsCisaAssessor; else content" class="mb-3 col-6">
-        <label class="form-label">{{t('protected features.cisa assessor workflow')}}</label>
-        <div>
-          <div class="btn-group btn-group-toggle col-10" data-toggle="buttons" style="border: 2px solid transparent; border-radius: 8px;">
-            <label class="btn btn-level form-check-label" [class.active]="assessment.assessorMode"
-              (change)="updateAssessorMode()">
-              <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
-                [checked]="assessment.assessorMode" />
-              {{t('answer-options.button-labels.yes')}}
-            </label>
-            <label class="btn btn-level form-check-label" [class.active]="!assessment.assessorMode"
-              (change)="updateAssessorMode()">
-              <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
-                [checked]="!assessment.assessorMode" />
-              {{t('answer-options.button-labels.no')}}
-            </label>
-          </div>
+      <div *ngIf="this.configSvc.userIsCisaAssessor; else nonassessor" class="mb-3">
+        <label>{{t('assessor workflow.control label')}}</label>
+        <label class="form-label fst-italic">{{t('assessor workflow.assessor workflow explanation')}}</label>
+        <div class="d-inline-flex btn-group align-items-start" role="group" data-toggle="buttons">
+          <label class="btn btn-level form-check-label px-4" [class.active]="!assessment.assessorMode"
+            (change)="updateAssessorMode()">
+            <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
+              [checked]="!assessment.assessorMode" />
+            {{t('answer-options.button-labels.no')}}
+          </label>
+          <label class="btn btn-level form-check-label px-4" [class.active]="assessment.assessorMode"
+            (change)="updateAssessorMode()">
+            <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
+              [checked]="assessment.assessorMode" />
+            {{t('answer-options.button-labels.yes')}}
+          </label>
         </div>
       </div>
-      <ng-template #content class=" mb-3">
+      <ng-template #nonassessor class="mb-3">
         <p>
-          {{ t('protected features.assessor mode') }}
+          {{ t('assessor workflow.non assessor explanation') }}
         </p>
       </ng-template>
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -61,13 +61,11 @@ export class AssessmentConfigIodComponent implements OnInit {
    */
   getAssessmentDetail() {
     this.assessment = this.assessSvc.assessment;
-    this.IsPCII = this.assessment.is_PCII;
-
-
+    this.IsPCII = this.assessment.is_PCII ?? false;
 
     this.assessSvc.isBrandNew = false;
     // Null out a 'low date' so that we display a blank
-    const assessDate: Date = new Date(this.assessment.assessmentDate);
+    const assessDate: Date = new Date(this.assessment.assessmentDate ?? '0001-01-01');
     if (assessDate.getFullYear() <= 1900) {
       this.assessment.assessmentDate = null;
     }
@@ -79,20 +77,23 @@ export class AssessmentConfigIodComponent implements OnInit {
   update(e) {
     // default Assessment Name if it is left empty
     if (this.assessment) {
-      if (this.assessment.assessmentName.trim().length === 0) {
+      if (this.assessment.assessmentName?.trim().length === 0) {
         this.assessment.assessmentName = '(Untitled Assessment)';
       }
     }
     this.assessSvc.updateAssessmentDetails(this.assessment);
   }
 
+  /**
+   * 
+   */
   changeIsPCII(val: boolean) {
     if (this.assessment) {
       this.IsPCII = val;
       this.assessment.is_PCII = val;
 
       if (!this.assessment.is_PCII) {
-        this.assessment.pciiNumber = null;
+        this.assessment.pciiNumber = undefined;
       }
 
       this.configSvc.userIsCisaAssessor = true;

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -75,28 +75,38 @@
         </div>
 
     </div>
-    <div *ngIf="this.configSvc.userIsCisaAssessor" class="mt-4">
+    <div class="mt-4">
         <h4>{{ t('assessment settings') }}</h4>
 
-        <div class="mb-3 col-6">
-            <label class="form-label">{{t('protected features.cisa assessor workflow')}}</label>
-            <div>
-                <div class="btn-group btn-group-toggle col-10" data-toggle="buttons"
-                    style="border: 2px solid transparent; border-radius: 8px;">
-                    <label class="btn btn-level form-check-label" [class.active]="assessment.assessorMode"
-                        (change)="updateAssessorMode()">
-                        <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
-                            [checked]="assessment.assessorMode" />
-                        {{t('answer-options.button-labels.yes')}}
-                    </label>
-                    <label class="btn btn-level form-check-label" [class.active]="!assessment.assessorMode"
-                        (change)="updateAssessorMode()">
-                        <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
-                            [checked]="!assessment.assessorMode" />
-                        {{t('answer-options.button-labels.no')}}
-                    </label>
-                </div>
+        <div *ngIf="this.configSvc.userIsCisaAssessor" class="mb-3">
+            <label>{{t('assessor workflow.control label')}}</label>
+            <label class="form-label fst-italic">{{t('assessor workflow.assessor workflow explanation')}}</label>
+            <div class="d-inline-flex btn-group align-items-start" role="group" data-toggle="buttons">
+                <label class="btn btn-level form-check-label px-4" [class.active]="!assessment.assessorMode"
+                    (change)="updateAssessorMode()">
+                    <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
+                        [checked]="!assessment.assessorMode" />
+                    {{t('answer-options.button-labels.no')}}
+                </label>
+                <label class="btn btn-level form-check-label px-4" [class.active]="assessment.assessorMode"
+                    (change)="updateAssessorMode()">
+                    <input class="btn-check align-items-center" type="radio" autocomplete="off" tabindex="0"
+                        [checked]="assessment.assessorMode" />
+                    {{t('answer-options.button-labels.yes')}}
+                </label>
             </div>
         </div>
+
+        <div class="mb-5">
+            <label class="form-label" for="techDomain">{{t('tech domain.label')}}</label>
+            <select class="form-select" id="techDomain" tabindex="0" name="techDomain" (change)="updateDemographics()"
+                [(ngModel)]="demographics.techDomain">
+                <option [ngValue]="null">-- {{t('tech domain.select')}} --</option>
+                <option value="OT">{{t('tech domain.ot')}}</option>
+                <option value="IT">{{t('tech domain.it')}}</option>
+                <option value="OT+IT">{{t('tech domain.ot+it')}}</option>
+            </select>
+        </div>
+
     </div>
 </ng-container>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
@@ -30,6 +30,7 @@ import { ConfigService } from '../../../../services/config.service';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import { AwwaStandardComponent } from '../../standards/awwa-standard/awwa-standard.component';
 import { AwwaService } from '../../../../services/awwa.service';
+import { DemographicService } from '../../../../services/demographic.service';
 
 
 @Component({
@@ -45,6 +46,8 @@ export class AssessmentDetailComponent implements OnInit {
     assessmentName: ''
   };
 
+  demographics: any = {};
+
   dialogRefAwwa: MatDialogRef<AwwaStandardComponent>;
   isAwwa = false;
 
@@ -53,6 +56,7 @@ export class AssessmentDetailComponent implements OnInit {
    */
   constructor(
     private assessSvc: AssessmentService,
+    public demoSvc: DemographicService,
     public navSvc: NavigationService,
     public awwaSvc: AwwaService,
     public configSvc: ConfigService,
@@ -60,12 +64,18 @@ export class AssessmentDetailComponent implements OnInit {
     public dialog: MatDialog
   ) { }
 
+  /**
+   * 
+   */
   ngOnInit() {
     if (this.assessSvc.id()) {
       this.getAssessmentDetail();
     }
-  }
 
+    this.demoSvc.getDemographic().subscribe((data: any) => {
+      this.demographics = data;
+    });
+  }
 
   /**
    * Called every time this page is loaded.
@@ -94,6 +104,14 @@ export class AssessmentDetailComponent implements OnInit {
       }
     }
     this.assessSvc.updateAssessmentDetails(this.assessment);
+  }
+
+  /**
+   * Included demographics support for persisting Technology Domain;
+   * this may expand in the future with additional data items.
+   */
+  updateDemographics() {
+    this.demoSvc.updateDemographic(this.demographics);
   }
 
   showAssessmentNameDisclaimer() {

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
@@ -20,7 +20,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 -------------------------->
-<form>
+<form *transloco="let t">
   <h6 class="p-3 mb-4 alert-warning">
     NOTE: Completion of all organization demographic, assessment configuration, and critical service fields are required
     to access reports and assessment exports.
@@ -29,7 +29,7 @@
   <div class="mb-4">
     <label for="orgType" class="form-label">Organization Type</label>
     <select [ngClass]="{ 'alert-danger' : !demographicData.organizationType }" class="form-select" id="orgType"
-      tabindex="0" name="orgType" [(ngModel)]="demographicData.organizationType" (ngModelChange)="update($event)" >
+      tabindex="0" name="orgType" [(ngModel)]="demographicData.organizationType" (ngModelChange)="update($event)">
       <option [ngValue]="null">-- Select Type --</option>
       <option *ngFor="let t of demographicData.listOrgTypes" [ngValue]="t.optionValue"
         [selected]="t.optionValue === demographicData.organizationType">
@@ -131,7 +131,8 @@
     </label>
 
     <select [ngClass]="{ 'alert-danger' : !demographicData.annualRevenue }" class="form-select" id="totalAnnualRevenue"
-      tabindex="0" name="totalAnnualRevenue" [(ngModel)]="demographicData.annualRevenue" (ngModelChange)="update($event)">
+      tabindex="0" name="totalAnnualRevenue" [(ngModel)]="demographicData.annualRevenue"
+      (ngModelChange)="update($event)">
       <option [ngValue]="null">-- Select --</option>
       <option *ngFor="let i of demographicData.listRevenueAmounts" [ngValue]="i.optionValue"
         [selected]="i.optionValue === demographicData.annualRevenue">
@@ -146,26 +147,27 @@
   <!-- #6 -->
 
   <!-- #7 -->
-  <div class="mb-5">
-    <label for="assetValue" class="col-8">Does your organization use a body of practice, industry standard, or similar
-      resource to support or inform its
-      cybersecurity efforts?
+  <div class="row mb-5">
+    <label for="assetValue" class="col-9">Does your organization use a body of practice, industry standard, or similar
+      resource to support or inform its cybersecurity efforts?
     </label>
 
-    <div class="btn-group col-4" role="group" data-toggle="buttons">
-      <label class="btn btn-level btn-rounded" [class.active]="demographicData.usesStandard"
-        (change)="setBool(demographicData, 'usesStandard', true)">
-        <input class="btn-check" name="standardYes" id="standardYes" type="radio" autocomplete="off" tabindex="0"
-          [checked]="demographicData.usesStandard" />
-        Yes
-      </label>
-      <label class="btn btn-level btn-rounded" [class.active]="!demographicData.usesStandard"
+    <div class="col-3 d-inline-flex btn-group justify-content-end align-items-start" role="group" data-toggle="buttons">
+      <label class="btn btn-level btn-rounded px-4" [class.active]="!demographicData.usesStandard"
         (change)="setBool(demographicData, 'usesStandard', false)">
         <input class="btn-check" name="standardNo" id="standardNo" type="radio" autocomplete="off" tabindex="0"
           [checked]="!demographicData.usesStandard" />
-        No
+        {{t('answer-options.button-labels.no')}}
+      </label>
+      <label class="btn btn-level btn-rounded px-4" [class.active]="demographicData.usesStandard"
+        (change)="setBool(demographicData, 'usesStandard', true)">
+        <input class="btn-check" name="standardYes" id="standardYes" type="radio" autocomplete="off" tabindex="0"
+          [checked]="demographicData.usesStandard" />
+        {{t('answer-options.button-labels.yes')}}
       </label>
     </div>
+
+
 
     <div *ngIf="demographicData.usesStandard ?? false" class="ms-5">
       <div class="fst-italic my-2">
@@ -193,22 +195,22 @@
   </div>
 
   <!-- #8 -->
-  <div class="mb-5">
-    <label class="col-8" for="assetValue">Is your organization required to comply with mandatory, cybersecurity-related
+  <div class="row mb-5">
+    <label class="col-9" for="assetValue">Is your organization required to comply with mandatory, cybersecurity-related
       regulation?
     </label>
 
-    <div class="btn-group col-4" role="group" data-toggle="buttons">
-      <label class="btn btn-level btn-rounded" [class.active]="demographicData.requiredToComply">
-        <input class="btn-check" name="complyYes" id="complyYes" type="radio" autocomplete="off" tabindex="0"
-          (change)="setBool(demographicData, 'requiredToComply', true)" [checked]="demographicData.requiredToComply" />
-        Yes
-      </label>
-      <label class="btn btn-level btn-rounded" [class.active]="!demographicData.requiredToComply"
+    <div class="col-3 d-inline-flex btn-group justify-content-end align-items-start" role="group" data-toggle="buttons">
+      <label class="btn btn-level btn-rounded px-4" [class.active]="!demographicData.requiredToComply"
         (change)="setBool(demographicData, 'requiredToComply', false)">
         <input class="btn-check" name="complyNo" id="complyNo" type="radio" autocomplete="off" tabindex="0"
           [checked]="!demographicData.requiredToComply" />
-        No
+        {{t('answer-options.button-labels.no')}}
+      </label>
+      <label class="btn btn-level btn-rounded px-4" [class.active]="demographicData.requiredToComply">
+        <input class="btn-check" name="complyYes" id="complyYes" type="radio" autocomplete="off" tabindex="0"
+          (change)="setBool(demographicData, 'requiredToComply', true)" [checked]="demographicData.requiredToComply" />
+        {{t('answer-options.button-labels.yes')}}
       </label>
     </div>
 

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.html
@@ -53,14 +53,18 @@
       <div class="mb-3">
         <label class="form-label" for="multisiteService">Multi-site Service?</label>
         <div class="btn-group btn-group-toggle d-block mb-2" id="multisiteService" data-toggle="buttons" ngbRadioGroup>
-          <label ngbButtonLabel class="btn btn-level border-2 mb-1" [class.active]="csiServiceDemographic.multiSite">
+          <label ngbButtonLabel class="btn btn-level border-2 mb-1 px-4" [class.active]="!csiServiceDemographic.multiSite">
             <input ngbButton type="radio" class="btn-check" autocomplete="off" name="multisiteService"
               [(ngModel)]="csiServiceDemographic.multiSite"
-              (change)="csiServiceDemographic.multiSiteDescription = null; update()" [value]="true" />Yes</label>
-          <label ngbButtonLabel class="btn btn-level border-2 mb-1" [class.active]="!csiServiceDemographic.multiSite">
+              (change)="csiServiceDemographic.multiSiteDescription = null; update()" [value]="false" />
+            {{t('answer-options.button-labels.no')}}
+          </label>
+          <label ngbButtonLabel class="btn btn-level border-2 mb-1 px-4" [class.active]="csiServiceDemographic.multiSite">
             <input ngbButton type="radio" class="btn-check" autocomplete="off" name="multisiteService"
               [(ngModel)]="csiServiceDemographic.multiSite"
-              (change)="csiServiceDemographic.multiSiteDescription = null; update()" [value]="false" />No</label>
+              (change)="csiServiceDemographic.multiSiteDescription = null; update()" [value]="true" />
+            {{t('answer-options.button-labels.yes')}}
+          </label>
         </div>
         <input [ngClass]="{
           'alert-danger':

--- a/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
+++ b/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
@@ -67,21 +67,23 @@
             <div *ngIf="showCisaAssessorWorkflowSwitch()">
                 <div class="d-flex align-items-center">
                     <span class="fa fa-globe fs-base-6 me-3"></span>
-                    <span class="fw-600 form-label">{{ t('protected features.cisa assessor
-                        workflow')}}</span>
+                    <span class="fw-600 form-label">{{ t('assessor workflow.user is cisa assessor')}}</span>
+                </div>
+                <div>
+                    {{ t('assessor workflow.cisa assessor explanation')}}
                 </div>
                 <div class="btn-group btn-group-toggle pt-2" data-toggle="buttons">
                     <label class="btn btn-level btn-rounded form-check-label" [class.active]="!cisaWorkflowEnabled"
                         (change)="toggleCisaAssessorWorkflow()">
                         <input class="btn-check" type="radio" autocomplete="off" tabindex="0"
                             [checked]="!cisaWorkflowEnabled" />
-                        {{t('menu.user.off')}}
+                        {{t('answer-options.button-labels.no')}}
                     </label>
                     <label class="btn btn-level btn-rounded form-check-label" [class.active]="cisaWorkflowEnabled"
                         (change)="toggleCisaAssessorWorkflow()">
                         <input class="btn-check" type="radio" autocomplete="off" tabindex="0"
                             [checked]="cisaWorkflowEnabled" />
-                        {{t('menu.user.on')}}
+                        {{t('answer-options.button-labels.yes')}}
                     </label>
                 </div>
             </div>

--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -904,9 +904,14 @@
     "protected features": "Protected Features",
     "module name": "Module Name",
     "module full name": "Module Full Name",
-    "enable modules": "Enable Modules",
-    "cisa assessor workflow": "CISA Assessor",
-    "assessor mode": "The assessment is currently in assessor workflow mode."
+    "enable modules": "Enable Modules"
+  },
+  "assessor workflow": {
+    "user is cisa assessor": "CISA Assessor",
+    "cisa assessor explanation": "This setting indicates if the user is with the CISA assessment team",
+    "control label": "CISA Assessor Workflow",
+    "assessor workflow explanation": "Turning on the Assessor Workflow includes screens exclusive to assessments conducted by the CISA assessment team",
+    "non assessor explanation": "The assessment is in assessor workflow mode, which causes other Prepare step screens to appear. Only a CISA assessor can change this setting."
   },
   "parameters": {
     "text1": "Many Standards in 'Requirements Mode' contain parameters that you can change to match your specific situation. The table below allows you to change the parameter values for the indicated parameter names in this Assessment by clicking on the Parameter Value. Changing a parameter value will update all related parameter values in the requirement text of the currently selected Cybersecurity Standard(s).",

--- a/CSETWebNg/src/assets/i18n/es.json
+++ b/CSETWebNg/src/assets/i18n/es.json
@@ -810,9 +810,14 @@
         "protected features": "Funciones protegidas",
         "module name": "Nombre de módulo",
         "module full name": "Nombre completo de módulo",
-        "enable modules": "Habitar módulos",
-        "cisa assessor workflow": "Evaluador de CISA",
-        "assessment mode": "La evaluación está actualmente en modo de flujo de trabajo del evaluador."
+        "enable modules": "Habitar módulos"
+    },
+    "assessor workflow": {
+        "user is cisa assessor": "Asesor CISA",
+        "cisa assessor explanation": "Esta configuración indica si el usuario está con el equipo de evaluación de CISA",
+        "control label": "Flujo de trabajo del asesor de CISA",
+        "assessor workflow explanation": "La activación del flujo de trabajo del evaluador incluye pantallas exclusivas para las evaluaciones realizadas por el equipo de evaluación de CISA",
+        "non assessor explanation": "La evaluación está en modo de flujo de trabajo del evaluador, lo que provoca que aparezcan otras pantallas del paso de Preparar. Solo un evaluador CISA puede cambiar esta configuración.."
     },
     "parameters": {
         "text1": "Muchos estándares en 'modo requisitos' contienen parámetros que se pueden cambiar para que coincidan con su situación específica. La tabla a continuación le permite cambiar los valores de los parámetros indicados en esta evaluación haciendo clic en el Valor de Parámetro. Cambiar un valor de parámetro actualizará todos los valores de parámetros relacionados en el texto del requisito de los Estándares de Ciberseguridad actualmente seleccionados.",

--- a/CSETWebNg/src/assets/navigation/workflow-omni.xml
+++ b/CSETWebNg/src/assets/navigation/workflow-omni.xml
@@ -46,8 +46,7 @@
         <!-- target level selection -->
         <node d="cmmc target level selection" id="cmmc-levels" path="assessment/{:id}/prepare/cmmc-levels" visible="MATURITY-ANY(2,6)" />
         <node d="cmmc target level selection" id="cmmc2-levels" path="assessment/{:id}/prepare/cmmc2-levels" visible="MATURITY-ANY(19)" />
-        <node d="cisa vadr target level selection" id="cisa-vadr-levels" path="assessment/{:id}/prepare/cisa-vadr-levels" visible="MATURITY-ANY(25)" />
-
+    
     </node>
 
 
@@ -327,7 +326,9 @@
 
         <node d="assessment complete" id="tsa-assessment-complete" path="assessment/{:id}/results/tsa-assessment-complete" visible="INSTALL-MODE:TSA" />
 
+    <!--
         <node displaytext="Sync to Server" id="analytics" path="assessment/{:id}/results/analytics" visible="IS-CSA HAS-URL-ANALYTICS"/>
+    -->
     </node>
 
 </nav>


### PR DESCRIPTION
This pull request introduces several UI and internationalization improvements to the assessment configuration and demographics screens, focusing on consistency, accessibility, and expanded support for technology domain demographics. The main changes include refactoring radio button groups for clarity and translation support, updating labels and explanations for CISA Assessor workflow, and adding technology domain selection to assessment details. Additionally, the code now better handles default and null values, and includes new translation keys for improved localization.

**UI Consistency and Internationalization:**

* Refactored radio button groups for Yes/No questions across multiple components (`assessment-config-iod.component.html`, `demographics-iod.component.html`, `csi-service-demographics.component.html`, `user-settings.component.html`) to use consistent styling, layout, and translation keys for button labels. [[1]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L75-R87) [[2]](diffhunk://#diff-4171d348699b700860ab07fa9a57aa58cf68394c04a9564726ad56455c5a0aa2L149-R171) [[3]](diffhunk://#diff-4171d348699b700860ab07fa9a57aa58cf68394c04a9564726ad56455c5a0aa2L196-R213) [[4]](diffhunk://#diff-c4353d4f447386808f53bd266045e36541b0706c12c522c388b97ab42cf1df6dL56-R67) [[5]](diffhunk://#diff-8bdc23ecf0b0cf593319d495402dbf33895690f136e6f79cbc28bd5a8459f95aL70-R86)
* Updated labels and explanations for the CISA Assessor workflow, moving text to new translation keys and improving clarity for both assessors and non-assessors. [[1]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L112-R132) [[2]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL78-R110) [[3]](diffhunk://#diff-8bdc23ecf0b0cf593319d495402dbf33895690f136e6f79cbc28bd5a8459f95aL70-R86) [[4]](diffhunk://#diff-7afd423f1c0f741d216fbd1bccffbd94ea4377b9b4f4c2dcfdc083f1015b7e63L907-R914)

**Assessment Details and Demographics Support:**

* Added support for selecting and persisting technology domain (OT, IT, OT+IT) in the assessment details screen, including new UI elements and integration with the `DemographicService`. [[1]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL78-R110) [[2]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR49-R50) [[3]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR59-R78) [[4]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR109-R116)
* Improved handling of null and default values for assessment fields such as `is_PCII`, `assessmentDate`, and `assessmentName`, reducing the risk of errors and improving user experience. [[1]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6L64-R68) [[2]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6L82-R96)

**Translation and Accessibility Enhancements:**

* Added new translation keys to `en.json` for assessor workflow labels, explanations, and answer option button labels, enabling better localization and accessibility.
* Updated forms to use the translation pipe for dynamic text rendering and improved accessibility of form controls. [[1]](diffhunk://#diff-4171d348699b700860ab07fa9a57aa58cf68394c04a9564726ad56455c5a0aa2L23-R23) [[2]](diffhunk://#diff-4171d348699b700860ab07fa9a57aa58cf68394c04a9564726ad56455c5a0aa2L134-R135)

These changes collectively improve the usability, clarity, and internationalization of the assessment configuration and demographic screens.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
