### PR TITLE
feature: Enable Edit Assessment Creator Contact

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
@@ -25,7 +25,7 @@
   <!-- Display Mode -->
   <ng-template #contact_display [ngIf]="editMode">
     <div *ngIf="!layoutSvc.hp" class="d-flex my-2 pe-2 br-standard align-items-center"
-      [ngClass]="!showControls() ? 'bgc-primary-50 c-gray-900 b-primary-200' : 'b-light'"
+      [ngClass]="isCreator() ? 'bgc-primary-50 c-gray-900 b-primary-200' : 'b-light'"
       style="width: 100%; height: 125px; overflow: hidden;">
       <div class="p-3 d-flex flex-column justify-content-center align-items-start" style="flex: 0 0 25%">
         <div class="d-flex">
@@ -35,6 +35,13 @@
           </div>
         </div>
         <div><em>{{getRoleName(contact.assessmentRoleId)}}</em></div>
+
+        <!-- Creator message display -->
+        <div class="fw-bold" *ngIf="isCreator()">
+          <div *ngIf="isCreator(); else Editor">{{t('contact.creator')}}</div>
+          <ng-template #Editor>{{t('contact.editor')}}</ng-template>
+        </div>
+
         <app-contact-tooltip *ngIf="showTooltip" [firstName]="contact.firstName" [lastName]="contact.lastName"
           [email]="contact.primaryEmail" [phone]="contact.phone" [assessmentRoleId]="contact.assessmentRoleId"
           [assessmentRole]="contact.role" [title]="contact.title" [organizationName]="contact.organizationName"
@@ -50,7 +57,7 @@
       <span class="d-flex align-items-center m-3 fw-600" style="text-align: center;">
       </span>
 
-      <span *ngIf="showControls()" class="d-flex align-items-center flex-00a">
+      <span class="d-flex align-items-center flex-00a">
         <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
           (click)="editContact()" [disabled]="!enableMyControls">
           <span class="cset-icons-pencil fs-base-2"></span>
@@ -61,22 +68,18 @@
           <span class="cset-icons-envelope fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('contact.email') }}</span>
         </button>
-        <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
-          (click)="removeContact()" [disabled]="!enableMyControls">
+        <button *ngIf="!isCreator()" type="button"
+          class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a" (click)="removeContact()"
+          [disabled]="!enableMyControls">
           <span class="cset-icons-trash-can fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('buttons.remove') }}</span>
         </button>
-      </span>
-
-      <span class="pe-4 align-items-center fw-300" *ngIf="!showControls()">
-        <div *ngIf="creatorId == contact.userId; else Editor">{{t('contact.creator')}}</div>
-        <ng-template #Editor>{{t('contact.editor')}}</ng-template>
       </span>
     </div>
 
 
     <div *ngIf="layoutSvc.hp" class="rkw d-flex flex-row justify-content-between my-2 p-2 br-standard"
-      [ngClass]="!showControls() ? 'bgc-primary-50 c-gray-900 b-primary-200' : 'b-light'"
+      [ngClass]="isCreator() ? 'bgc-primary-50 c-gray-900 b-primary-200' : 'b-light'"
       style="width: 100%; height: 125px; overflow: hidden;">
       <div class="p-3 d-flex flex-column justify-content-center align-items-start">
         <span class="m-0 fs-base-1 fw-600">{{contact.firstName}} {{contact.lastName}}</span>
@@ -101,7 +104,7 @@
           {{contact.emergencyCommunicationsProtocol}} </span>
       </div>
 
-      <div *ngIf="showControls()" class="d-flex align-items-center flex-00a">
+      <div class="d-flex align-items-center flex-00a">
         <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
           (click)="editContact()" [disabled]="!enableMyControls">
           <span class="cset-icons-pencil fs-base-2"></span>
@@ -112,8 +115,9 @@
           <span class="cset-icons-envelope fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('contact.email') }}</span>
         </button>
-        <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
-          (click)="removeContact()" [disabled]="!enableMyControls">
+        <button *ngIf="!isCreator()" type="button"
+          class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a" (click)="removeContact()"
+          [disabled]="!enableMyControls">
           <span class="cset-icons-trash-can fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('buttons.remove') }}</span>
         </button>
@@ -229,7 +233,7 @@
           </div>
 
           <!-- Role Buttons -->
-          <div class="form-group d-flex flex-column flex-11a mb-3">
+          <div class="form-group d-flex flex-column flex-11a mb-3" *ngIf="!isCreator()">
             <label class="form-label" for="role">{{ t('contact.role') }}</label>
             <div class="btn-group btn-group-toggle d-block" id="role" data-toggle="buttons" ngbRadioGroup>
               <label ngbButtonLabel class="btn btn-level btn-rounded form-check-label"

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
@@ -34,15 +34,14 @@ import { EmailService } from "../../../../../services/email.service";
 import { LayoutService } from "../../../../../services/layout.service";
 import { TranslocoService } from "@jsverse/transloco";
 import { DemographicIodService } from "../../../../../services/demographic-iod.service";
-import { AssessmentContactsResponse } from "../../../../../models/assessment-info.model";
-import { RolesChangedComponent } from "../../../../../dialogs/roles-changed/roles-changed.component";
+
 
 @Component({
-    selector: "app-contact-item",
-    templateUrl: "./contact-item.component.html",
-    // eslint-disable-next-line
-    host: { class: 'd-flex flex-column flex-11a' },
-    standalone: false
+  selector: "app-contact-item",
+  templateUrl: "./contact-item.component.html",
+  // eslint-disable-next-line
+  host: { class: 'd-flex flex-column flex-11a' },
+  standalone: false
 })
 export class ContactItemComponent implements OnInit {
   @Input()
@@ -189,40 +188,38 @@ export class ContactItemComponent implements OnInit {
   }
 
   saveContact() {
-    this.assessSvc
-      .getAssessmentContacts()
-      .then((data: AssessmentContactsResponse) => {
-        if (data.currentUserRole == 2) {
-          if (this.contact.isNew) {
-            if (this.existsDuplicateEmail(this.contact.primaryEmail)) {
-              return;
-            }
+    if (this.contact.isNew) {
+      if (this.existsDuplicateEmail(this.contact.primaryEmail)) {
+        return;
+      }
 
-            this.create.emit(this.contact);
+      this.create.emit(this.contact);
 
-            this.contact.isNew = false;
-            this.editMode = true;
-          } else {
-            this.finishEdit();
-          }
-          return true;
-        } else {
-          this.scrollToTop();
-          this.abandonEdit();
-          let rolesChangeDialog = this.dialog.open(RolesChangedComponent)
-          rolesChangeDialog.afterClosed().subscribe(() => {
-          })
-          this.ngOnInit();
-          this.rolesChangedEvent.emit();
-        }
-      })
+      this.contact.isNew = false;
+      this.editMode = true;
+    } else {
+      this.finishEdit();
+    }
   }
 
   removeContact() {
     this.remove.emit(true);
   }
 
+  canEditContact(): boolean {
+    return this.assessSvc.userRoleId === 2;
+  }
+
   editContact() {
+    if (!this.canEditContact()) {
+      this.dialog.open(AlertComponent, {
+        data: {
+          messageText: "Only assessment facilitators can edit contact information. Please contact your assessment facilitator to make changes."
+        }
+      });
+      return;
+    }
+
     this.contact.startEdit();
     this.startEditEvent.emit();
     this.editMode = false;
@@ -273,10 +270,22 @@ export class ContactItemComponent implements OnInit {
   }
 
   showControls() {
+    // Assessment creators cannot be deleted and should not show delete controls
+    if (this.isCreator()) {
+      return false;
+    }
+
     if (this.assessSvc.userRoleId === 2 && !this.contact.isFirst) {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Check if this contact is the assessment creator
+   */
+  isCreator(): boolean {
+    return this.creatorId && this.contact.userId && this.creatorId == this.contact.userId;
   }
 
   getRoleName(roleId: number) {
@@ -296,8 +305,11 @@ export class ContactItemComponent implements OnInit {
   // Check if assessment was created by current user 
   assessmentCreator() {
     this.assessSvc.getCreator().then((response: any) => {
-      this.creatorId = response
-    })
+      this.creatorId = response;
+    }).catch(error => {
+      console.error('Error getting assessment creator:', error);
+      this.creatorId = null;
+    });
   }
 
   updatePosition(event: MouseEvent) {


### PR DESCRIPTION
This pull request enhances the assessment contacts feature by ensuring the assessment creator can be edited, is always displayed at the top of the contacts list, visually distinguishes the creator in the UI, and prevents accidental removal of the creator contact. It also improves role-based UI controls and error handling for contact management.

**Contact List Ordering and Logic:**
- The contacts list is now sorted so the assessment creator always appears first, followed by the current user (if different), with the creator visually marked and protected from removal or role changes. This sorting is applied after any contact changes, such as adding, removing, or updating contacts.

**UI and Visual Updates:**
- The contact item UI now visually highlights the creator, displays a specific message for the creator, and disables the delete button and role change controls for that contact.

**Role-based Permissions and Controls:**
- Only assessment facilitators (roleId 2) can edit contact information. Attempting to edit as another role shows an alert. The logic for showing edit/delete controls is updated to respect these permissions and the creator status.

**Error Handling Improvements:**
- Improved error handling when fetching the assessment creator and when updating contacts, with errors logged and the creatorId reset if retrieval fails.

**Code Cleanup:**
- Removed unused imports and legacy logic related to role changes, simplifying the codebase.