### PR TITLE
fix: contact items

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
@@ -265,6 +265,30 @@ namespace CSETWebCore.Helpers
                 userIdSO = STANDALONE_USER_ID; // Always use STANDALONE_USER_ID
             }
 
+            // Add the standalone user to ASSESSMENT_CONTACTS if they're accessing an existing assessment
+            if (assessmentId.HasValue && assessmentId.Value > 0)
+            {
+                var existingContact = await _context.ASSESSMENT_CONTACTS
+                    .FirstOrDefaultAsync(ac => ac.Assessment_Id == assessmentId.Value && ac.UserId == userIdSO);
+
+                if (existingContact == null)
+                {
+                    var assessmentContact = new ASSESSMENT_CONTACTS
+                    {
+                        Assessment_Id = assessmentId.Value,
+                        UserId = userIdSO,
+                        FirstName = name,
+                        LastName = "",
+                        PrimaryEmail = primaryEmailSO,
+                        AssessmentRoleId = 2, // Admin role
+                        Invited = true
+                    };
+
+                    _context.ASSESSMENT_CONTACTS.Add(assessmentContact);
+                    await _context.SaveChangesAsync();
+                }
+            }
+
             if (string.IsNullOrEmpty(primaryEmailSO))
             {
                 return null;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ContactsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ContactsController.cs
@@ -475,6 +475,21 @@ namespace CSETWebCore.Api.Controllers
 
                 // update user detail                    
                 var user = _context.USERS.Where(x => x.UserId == userBeingUpdated.UserId).FirstOrDefault();
+                
+                // Check if the new email already exists for a different user
+                if (!string.IsNullOrEmpty(userBeingUpdated.PrimaryEmail) && 
+                    userBeingUpdated.PrimaryEmail != user.PrimaryEmail)
+                {
+                    var existingUserWithEmail = _context.USERS
+                        .Where(x => x.PrimaryEmail == userBeingUpdated.PrimaryEmail && x.UserId != userBeingUpdated.UserId)
+                        .FirstOrDefault();
+                    
+                    if (existingUserWithEmail != null)
+                    {
+                        return BadRequest($"A user with email '{userBeingUpdated.PrimaryEmail}' already exists.");
+                    }
+                }
+                
                 user.FirstName = userBeingUpdated.FirstName;
                 user.LastName = userBeingUpdated.LastName;
                 user.PrimaryEmail = userBeingUpdated.PrimaryEmail;

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
@@ -63,8 +63,9 @@
           <span class="cset-icons-pencil fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('buttons.change') }}</span>
         </button>
-        <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
-          (click)="openEmailDialog()" [disabled]="!enableMyControls" *ngIf="!auth.isLocal">
+        <button *ngIf="!auth.isLocal && !isCreator()" type="button"
+          class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a" (click)="openEmailDialog()"
+          [disabled]="!enableMyControls">
           <span class="cset-icons-envelope fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('contact.email') }}</span>
         </button>
@@ -110,8 +111,9 @@
           <span class="cset-icons-pencil fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('buttons.change') }}</span>
         </button>
-        <button type="button" class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a"
-          (click)="openEmailDialog()" [disabled]="!enableMyControls" *ngIf="!auth.isLocal">
+        <button *ngIf="!auth.isLocal && !isCreator()" type="button"
+          class="p-0 m-2 btn icon-button d-flex flex-column align-items-center flex-00a" (click)="openEmailDialog()"
+          [disabled]="!enableMyControls">
           <span class="cset-icons-envelope fs-base-2"></span>
           <span class="d-none d-md-flex fs-smaller">{{ t('contact.email') }}</span>
         </button>


### PR DESCRIPTION
This pull request introduces several improvements to user authentication, contact management, and UI controls for assessment contacts. The most significant changes include enforcing email uniqueness during user updates, ensuring standalone users are correctly added to assessment contacts, and refining UI logic for displaying email controls.

**Backend Improvements:**

* Enforced uniqueness of user email addresses during updates in `ContactsController`: When updating a user's email, the system now checks to ensure the new email isn't already used by another user, preventing duplicate email entries.
* Automatically add standalone users to `ASSESSMENT_CONTACTS` when accessing an existing assessment in `UserAuthentication.cs`: This ensures that standalone users are properly tracked as assessment contacts with admin privileges when they access an assessment.

**Frontend/UI Improvements:**

* Updated email button visibility logic in `contact-item.component.html`: The email button is now only shown for non-local users who are not the assessment creator, preventing unnecessary or inappropriate email actions. [[1]](diffhunk://#diff-dc7c187562758bb6816bac0776dfd6cccf18c08825769e97e691d827eef59137L66-R68) [[2]](diffhunk://#diff-dc7c187562758bb6816bac0776dfd6cccf18c08825769e97e691d827eef59137L113-R116)