### PR TITLE
Fixed question counting at the questions page level for EDM, CIE+

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
@@ -856,7 +856,7 @@ namespace CSETWebCore.Business.Maturity
 
 
             // some special logic for the CIE model
-            if (groupingId != 0 && targetModelId != 17)
+            if (groupingId != 0 && targetModelId != Constants.Constants.Model_CIE)
             {
                 questionQuery = questionQuery.Where(x => x.Question_Text.StartsWith("A"));
             }
@@ -1011,7 +1011,7 @@ namespace CSETWebCore.Business.Maturity
 
                     var qa = QuestionAnswerBuilder.BuildQuestionAnswer(myQ, answer);
                     qa.MaturityModelId = sg.Maturity_Model_Id;
-                    qa.IsParentQuestion = parentQuestionIDs.Contains(myQ.Mat_Question_Id) || myQ.Parent_Question_Id == null;
+                    qa.IsParentQuestion = parentQuestionIDs.Contains(myQ.Mat_Question_Id);
 
 
                     // Include CSF mappings
@@ -1103,10 +1103,16 @@ namespace CSETWebCore.Business.Maturity
         /// <returns></returns>
         private bool IsQuestionCountable(int modelId, QuestionAnswer qa)
         {
-            // EDM and CRR and CPG2 - parent questions are unanswerable and not countable
-            if (modelId == Constants.Constants.Model_EDM || modelId == Constants.Constants.Model_CRR || modelId == Constants.Constants.Model_CPG2)
+            // CPG2 - parent questions are marked as not answerable and are not counted
+            if (modelId == Constants.Constants.Model_CPG2)
             {
-                return !qa.IsParentQuestion;
+                return qa.IsAnswerable;
+            }
+
+            // EDM and CRR - parent questions are unanswerable and not countable
+            if (modelId == Constants.Constants.Model_EDM || modelId == Constants.Constants.Model_CRR)
+            {
+                return qa.IsAnswerable;
             }
 
             // VADR - child questions are freeform and not countable

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/Constants.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/Constants.cs
@@ -443,6 +443,7 @@ namespace CSETWebCore.Constants
         public const int Model_ISE = 10;
         public const int Model_CPG = 11;
         public const int Model_HYDRO = 13;
+        public const int Model_CIE = 17;
         public const int Model_SSG_CHEM = 18;
         public const int Model_SSG_IT = 20;
         public const int Model_CPG2 = 21;

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
@@ -96,7 +96,8 @@ export class DiagramQuestionsComponent implements OnInit {
         this.categories = response.categories;
         this.loaded = true;
 
-        this.completionSvc.setQuestionArray(response);
+        this.completionSvc.structure = response;
+        this.completionSvc.setQuestionArray();
 
         this.refreshQuestionVisibility();
       },

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -263,7 +263,8 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
 
         this.loaded = true;
 
-        this.completionSvc.setQuestionArray(response);
+        this.completionSvc.structure = response;
+        this.completionSvc.setQuestionArray();
 
         this.refreshQuestionVisibility();
       },
@@ -312,7 +313,8 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
 
       this.loaded = true;
 
-      this.completionSvc.setQuestionArray(response);
+      this.completionSvc.structure = response;
+      this.completionSvc.setQuestionArray();
 
       this.refreshQuestionVisibility();
     },
@@ -392,6 +394,9 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
 
     // scroll to the question
     let qqElement = document.getElementById(`mq${mq}`);
+    if (qqElement == null) {
+      return;
+    }
     setTimeout(() => {
       qqElement.scrollIntoView({ behavior: 'smooth' });
       return;

--- a/CSETWebNg/src/app/assessment/questions/questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.ts
@@ -306,7 +306,8 @@ export class QuestionsComponent implements AfterViewChecked, OnInit, AfterViewIn
         this.setHasQuestions = (response.questionCount > 0);
         this.questionsSvc.questions = response;
 
-        this.completionSvc.setQuestionArray(response);
+        this.completionSvc.structure = response;
+        this.completionSvc.setQuestionArray();
 
         this.categories = response.categories;
 

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/maturity-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/maturity-filtering.service.ts
@@ -322,14 +322,10 @@ export class MaturityFilteringService {
           return;
         }
       }
-      // OLD code to filter questionText
-      // if (filterSvc.filterSearchString.length > 0
-      //   && q.questionText.toLowerCase().indexOf(filterStringLowerCase) < 0) {
-      //   return;
-      // }
+
       // only apply maturity-level filtering when the user has toggled at least one numeric level
       const hasLevelFilter = filterSvc.showFilters.some(f => /^\d+$/.test(f));
-      if (maturityModel?.levels?.length > 0
+      if ((maturityModel?.levels?.length ?? 0) > 0
         && q.maturityLevel != null
         && hasLevelFilter) {
         const questionLevel = q.maturityLevel.toString();

--- a/CSETWebNg/src/app/services/selectable-groupings.service.ts
+++ b/CSETWebNg/src/app/services/selectable-groupings.service.ts
@@ -27,6 +27,7 @@ import { QuestionGrouping } from '../models/questions.model';
 import { BehaviorSubject, firstValueFrom, Observable, Subject } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ConfigService } from './config.service';
+import { CompletionService } from './completion.service';
 
 @Injectable({
   providedIn: 'root'
@@ -54,6 +55,7 @@ export class SelectableGroupingsService {
    * 
    */
   constructor(
+    private completionSvc: CompletionService,
     private http: HttpClient,
     private configSvc: ConfigService
   ) {
@@ -147,10 +149,12 @@ export class SelectableGroupingsService {
 
 
   /**
-   * 
+   * Reevaluate the selected groupings to recalculate
+   * the completion counts.  
    */
   emitSelectionChanged() {
     this.selectionChangedSubject.next();
+    this.completionSvc.toggleGroupSelection();
   }
 
   /**


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the maturity question handling and completion calculation in both the backend (C#) and frontend (Angular) codebases. The main themes are: more accurate completion counts based on selected groupings, improved handling of maturity model logic, and code refactoring for clarity and maintainability.

**Backend logic and model updates:**

* Refined the logic for determining countable questions in `IsQuestionCountable` to use the `IsAnswerable` property instead of relying solely on parent question status, ensuring correct handling for CPG2, EDM, and CRR models.
* Fixed the determination of parent questions by removing the check for null `Parent_Question_Id`, making it solely dependent on the `parentQuestionIDs` list.

**Frontend completion calculation and structure handling:**

* Refactored the `CompletionService` to require setting the `structure` property before calling `setQuestionArray()`, and updated all usages to follow this pattern. This ensures that completion counts are recalculated based on the current question structure and selected groupings. [[1]](diffhunk://#diff-068dfdf3366a846adbf433a4cae9a8812d1f2108dd0364b55e9b12f3649d4585R47) [[2]](diffhunk://#diff-068dfdf3366a846adbf433a4cae9a8812d1f2108dd0364b55e9b12f3649d4585R68-R77) [[3]](diffhunk://#diff-67b54bebf7ea6d24f15f4f4e8183f6a39fd8d67d406c5d774855e13e9fba4f1bL99-R100) [[4]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443L266-R267) [[5]](diffhunk://#diff-b20c0a2de2875ca087444c249c43a3161f3c0d8471d057a569168a014d54b443L315-R317) [[6]](diffhunk://#diff-cf49b0ab561c95938e3420f214a9286fd4938f8984a9eded208f5915eb2790fbL309-R310)
* Improved filtering of questions for completion counts to include only those in selected groupings and that are countable, both in main and recursive subgroup logic. [[1]](diffhunk://#diff-068dfdf3366a846adbf433a4cae9a8812d1f2108dd0364b55e9b12f3649d4585L84-R94) [[2]](diffhunk://#diff-068dfdf3366a846adbf433a4cae9a8812d1f2108dd0364b55e9b12f3649d4585L108-R121)
* Added a `toggleGroupSelection` method to `CompletionService` to recalculate completion stats when group selection changes, and integrated this with the `SelectableGroupingsService`. [[1]](diffhunk://#diff-068dfdf3366a846adbf433a4cae9a8812d1f2108dd0364b55e9b12f3649d4585R133-R140) [[2]](diffhunk://#diff-cb0bfdd883e2abc7ee2a0eb7691144c027bd5b8dd65be9b76eaaac8972977669R30) [[3]](diffhunk://#diff-cb0bfdd883e2abc7ee2a0eb7691144c027bd5b8dd65be9b76eaaac8972977669R58) [[4]](diffhunk://#diff-cb0bfdd883e2abc7ee2a0eb7691144c027bd5b8dd65be9b76eaaac8972977669L150-R157)

**Frontend bug fixes and UX improvements:**

* Added a null check before scrolling to a question element to prevent errors if the element is not found.
* Improved maturity-level filtering logic to handle cases where the maturity model may not have levels defined.

These changes collectively improve the accuracy and reliability of maturity question completion tracking, especially when users change selected groupings or work with different maturity models.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
