### PR TITLE
Fixed count refresh when domain is deselected

### DIFF
--- a/CSETWebNg/src/app/services/completion.service.ts
+++ b/CSETWebNg/src/app/services/completion.service.ts
@@ -89,7 +89,7 @@ export class CompletionService {
       // this version gathers questions from a Maturity response structure
       this.targetMaturityLevel = this.structure.maturityTargetLevel;
 
-      this.structure.groupings.forEach(g => {
+      this.structure.groupings.filter(x => x.selected).forEach(g => {
         g.questions.forEach(q => {
           if (q.maturityLevel <= this.targetMaturityLevel && (g.selected && q.countable)) {
             this.questionflat.push({
@@ -114,11 +114,11 @@ export class CompletionService {
    * in selected groupings and are considered 'countable' are collected.
    */
   private recurseSubgroups(gg) {
-    gg.subGroupings?.forEach(g => {
+    gg.subGroupings?.filter(x => x.selected).forEach(g => {
       g.questions.forEach(q => {
         // how do we only consider 'countable' questions?  For VADR the parents are countable, but for others, parents are not.
         // so we can't blindly treat parents one way for all models.
-        if (q.maturityLevel <= this.targetMaturityLevel && (g.selected && q.countable)) {
+        if (q.maturityLevel <= this.targetMaturityLevel && q.countable) {
           this.questionflat.push({
             id: q.questionId,
             answer: q.answer,


### PR DESCRIPTION
Fixed bug - when a domain is deselected without first deselecting its child goals, the recount was not reducing correctly.  Now we pay attention to the selected flag on domains and goals when building the list of questions that we count.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
