### PR TITLE
Using console.error instead of console.log for errors

### DIFF
--- a/CSETWebNg/src/app/aggregation/merge/merge.component.ts
+++ b/CSETWebNg/src/app/aggregation/merge/merge.component.ts
@@ -93,7 +93,7 @@ export class MergeComponent implements OnInit {
           // do something?
           this.dialogRef = undefined;
         },
-        error => console.log(error.message)
+        error => console.error(error.message)
       );
   }
 }

--- a/CSETWebNg/src/app/app.component.ts
+++ b/CSETWebNg/src/app/app.component.ts
@@ -167,7 +167,7 @@ export class AppComponent implements OnInit, AfterViewInit {
         }
         this.dialogRef = undefined;
       },
-      error => console.log(error.message)
+      error => console.error(error.message)
     );
     this.dialogSubscriptions.push(subscription); // Store the subscription
   }

--- a/CSETWebNg/src/app/assessment/assessment.component.ts
+++ b/CSETWebNg/src/app/assessment/assessment.component.ts
@@ -184,12 +184,6 @@ export class AssessmentComponent implements OnInit {
     this.expandNav = e;
   }
 
-  // isTocLoading(node) { 
-  //   console.log(node);
-  //   var s = node?.label;
-  //   return  (s === "Please wait" || s === "Loading questions") ;
-  // }
-
   goHome() {
     this.assessSvc.dropAssessment();
     this.router.navigate(['/home']);

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.ts
@@ -79,7 +79,7 @@ export class DiagramInventoryComponent implements OnInit {
       saveAs(data, 'diagram-inventory-export.xlsx');
     },
       error => {
-        console.log('Error downloading file');
+        console.error('Error downloading file');
       });
   }
 

--- a/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.ts
+++ b/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.ts
@@ -98,7 +98,7 @@ export class StatusCreateComponent implements OnInit, OnDestroy {
         submittedData).subscribe(
           event2 => this.handleProgress(event2),
           () => {
-            console.log('Server error');
+            console.error('Server error');
           });
 
       statusNgForm.resetForm({});

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
@@ -191,7 +191,7 @@ export class AssessmentContactsComponent implements OnInit {
           })
           .afterClosed()
           .subscribe();
-        console.log(
+        console.error(
           "Error adding assessment contact: " + JSON.stringify(contact)
         );
       }
@@ -311,7 +311,7 @@ export class AssessmentContactsComponent implements OnInit {
           .open(AlertComponent, { data: { title: "Error removing assessment contact" } })
           .afterClosed()
           .subscribe();
-        console.log(
+        console.error(
           "Error removing assessment contact: " + JSON.stringify(contact)
         );
       }

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -98,8 +98,8 @@ export class AssessmentDemographicsComponent implements OnInit {
                 this.sectorsList = data;
             },
             error => {
-                console.log('Error Getting all sectors: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error Getting all sectors (cont): ' + (<Error>error).stack);
+                console.error('Error Getting all sectors: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error Getting all sectors (cont): ' + (<Error>error).stack);
             });
         this.demoSvc.getAllAssetValues().subscribe(
             (data: DemographicsAssetValue[]) => {
@@ -107,16 +107,16 @@ export class AssessmentDemographicsComponent implements OnInit {
 
             },
             error => {
-                console.log('Error Getting all asset values: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error Getting all asset values (cont): ' + (<Error>error).stack);
+                console.error('Error Getting all asset values: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error Getting all asset values (cont): ' + (<Error>error).stack);
             });
         this.demoSvc.getSizeValues().subscribe(
             (data: AssessmentSize[]) => {
                 this.sizeList = data;
             },
             error => {
-                console.log('Error Getting size values: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error Getting size values (cont): ' + (<Error>error).stack);
+                console.error('Error Getting size values: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error Getting size values (cont): ' + (<Error>error).stack);
             });
 
         if (this.demoSvc.id) {
@@ -176,7 +176,7 @@ export class AssessmentDemographicsComponent implements OnInit {
                 // populate Industry dropdown based on Sector
                 this.populateIndustryOptions(this.demographicData.sectorId);
             },
-            error => console.log('Demographic load Error: ' + (<Error>error).message)
+            error => console.error('Demographic load Error: ' + (<Error>error).message)
         );
 
     }
@@ -209,8 +209,8 @@ export class AssessmentDemographicsComponent implements OnInit {
                 this.industryList = data;
             },
             error => {
-                console.log('Error Getting Industry: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error Getting Industry (cont): ' + (<Error>error).stack);
+                console.error('Error Getting Industry: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error Getting Industry (cont): ' + (<Error>error).stack);
             });
     }
 

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.ts
@@ -46,7 +46,7 @@ export class CsiServiceCompositionComponent implements OnInit {
         this.definingSystemsList = data;
       },
       (error) => {
-        console.log('Error getting all CSI defining systems options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all CSI defining systems options: ' + (<Error>error).name + (<Error>error).message);
       }
     );
 
@@ -137,7 +137,7 @@ export class CsiServiceCompositionComponent implements OnInit {
       (data: CsiServiceComposition) => {
         this.serviceComposition = data;
       },
-      (error) => console.log('CIS CSI service composition load Error: ' + (<Error>error).message)
+      (error) => console.error('CIS CSI service composition load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
@@ -100,7 +100,7 @@ export class CsiServiceDemographicsComponent implements OnInit {
         this.budgetBasisList = data;
       },
       (error) => {
-        console.log('Error getting all CSI budget basis options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all CSI budget basis options: ' + (<Error>error).name + (<Error>error).message);
       }
     );
     this.csiSvc.getAllCsiStaffCounts().subscribe(
@@ -109,7 +109,7 @@ export class CsiServiceDemographicsComponent implements OnInit {
         this.cyberSecurityItIcsStaffCountList = this.filterCybersecurityItIcsStaffCounts(data);
       },
       (error) => {
-        console.log('Error getting all CSI staff count options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all CSI staff count options: ' + (<Error>error).name + (<Error>error).message);
       }
     );
     this.csiSvc.getAllCsiUserCounts().subscribe(
@@ -118,7 +118,7 @@ export class CsiServiceDemographicsComponent implements OnInit {
         this.authorizedNonOrganizationalUserCountList = this.filterNonOrganizationalUserCounts(data);
       },
       (error) => {
-        console.log('Error getting all CSI user count options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all CSI user count options: ' + (<Error>error).name + (<Error>error).message);
       }
     );
     this.csiSvc.getAllCsiCustomerCounts().subscribe(
@@ -126,7 +126,7 @@ export class CsiServiceDemographicsComponent implements OnInit {
         this.customersCountList = this.sortCustomerCounts(data);
       },
       (error) => {
-        console.log('Error getting all CSI customer count options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all CSI customer count options: ' + (<Error>error).name + (<Error>error).message);
       }
     );
 

--- a/CSETWebNg/src/app/assessment/prepare/framework/framework.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/framework/framework.component.ts
@@ -55,8 +55,8 @@ export class FrameworkComponent implements OnInit {
         this.frameworks = data;
       },
       error => {
-        console.log('Error getting all frameworks: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error getting all frameworks: ' + (<Error>error).stack);
+        console.error('Error getting all frameworks: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting all frameworks: ' + (<Error>error).stack);
       });
   }
 

--- a/CSETWebNg/src/app/assessment/prepare/required/required.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/required/required.component.ts
@@ -66,8 +66,8 @@ export class RequiredDocsComponent implements OnInit {
                 this.documents = data;
             },
             error => {
-                console.log('Error getting all documents: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error getting all documents: ' + (<Error>error).stack);
+                console.error('Error getting all documents: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error getting all documents: ' + (<Error>error).stack);
             });
     }
 

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.ts
@@ -105,8 +105,8 @@ export class SalGenComponent implements OnInit {
 
       },
       error => {
-        console.log('Error getting gen sal descriptions: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error gen sal descriptions: ' + (<Error>error).stack);
+        console.error('Error getting gen sal descriptions: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error gen sal descriptions: ' + (<Error>error).stack);
       });
 
     // retrieve the existing sal_selection for this assessment
@@ -115,8 +115,8 @@ export class SalGenComponent implements OnInit {
         this.salsSvc.selectedSAL = data;
       },
       error => {
-        console.log('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error Getting all standards: ' + (<Error>error).stack);
+        console.error('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error Getting all standards: ' + (<Error>error).stack);
       });
   }
 
@@ -130,8 +130,8 @@ export class SalGenComponent implements OnInit {
         this.salsSvc.selectedSAL.selected_Sal_Level = data;
       },
       error => {
-        console.log('Error saving gensal: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error saving gensal: ' + (<Error>error).stack);
+        console.error('Error saving gensal: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error saving gensal: ' + (<Error>error).stack);
       });
   }
 }

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.ts
@@ -59,8 +59,8 @@ export class SalNistComponent implements OnInit {
         this.salsSvc.selectedSAL = data;
       },
       error => {
-        console.log('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error Getting all standards: ' + (<Error>error).stack);
+        console.error('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error Getting all standards: ' + (<Error>error).stack);
       });
 
     this.salsSvc.getInformationTypes().subscribe(
@@ -68,8 +68,8 @@ export class SalNistComponent implements OnInit {
         this.topModel = data;
       },
       error => {
-        console.log('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error Getting all standards: ' + (<Error>error).stack);
+        console.error('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error Getting all standards: ' + (<Error>error).stack);
       });
   }
 

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.ts
@@ -47,8 +47,8 @@ export class SalSimpleComponent implements OnInit {
         this.salsSvc.selectedSAL = data;
       },
       error => {
-        console.log('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error Getting all standards: ' + (<Error>error).stack);
+        console.error('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error Getting all standards: ' + (<Error>error).stack);
       });
   }
 }

--- a/CSETWebNg/src/app/assessment/prepare/sals/sals.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sals.component.ts
@@ -71,8 +71,8 @@ export class SalsComponent implements OnInit {
         this.selectedMethodology = data.methodology;
       },
       error => {
-        console.log('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error Getting all standards: ' + (<Error>error).stack);
+        console.error('Error Getting all standards: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error Getting all standards: ' + (<Error>error).stack);
       });
   }
 
@@ -88,8 +88,8 @@ export class SalsComponent implements OnInit {
     this.selectedMethodology = newType;
     this.salsSvc.saveSALType(newType).subscribe((data) => { },
       error => {
-        console.log('Error posting change: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error posting change: ' + (<Error>error).stack);
+        console.error('Error posting change: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error posting change: ' + (<Error>error).stack);
       });
   }
 }

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
@@ -107,7 +107,7 @@ export class DiagramQuestionsComponent implements OnInit {
           (<Error>error).name +
           (<Error>error).message
         );
-        console.log('Error getting questions: ' + (<Error>error).stack);
+        console.error('Error getting questions: ' + (<Error>error).stack);
       }
     );
   }

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.ts
@@ -94,7 +94,7 @@ export class MaturityQuestionsNestedComponent implements OnInit, AfterViewInit, 
       this.cisSvc.getIntegrityCheckOptions().subscribe((response: IntegrityCheckOption[]) => {
         this.cisSvc.integrityCheckOptions = response;
       }, error => {
-        console.log('Error getting CIS integrity check options: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error getting CIS integrity check options: ' + (<Error>error).name + (<Error>error).message);
       });
     }
 
@@ -156,7 +156,7 @@ export class MaturityQuestionsNestedComponent implements OnInit, AfterViewInit, 
           (<Error>error).name +
           (<Error>error).message
         );
-        console.log('Error getting questions: ' + (<Error>error).stack);
+        console.error('Error getting questions: ' + (<Error>error).stack);
       }
     );
   }

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
@@ -324,7 +324,7 @@ export class QuestionExtrasComponent implements OnInit {
       (response: number) => {
         this.myQuestion.answer_Id = response;
       },
-      error => console.log('Error saving response: ' + (<Error>error).message)
+      error => console.error('Error saving response: ' + (<Error>error).message)
     );
   }
 
@@ -415,7 +415,7 @@ export class QuestionExtrasComponent implements OnInit {
             this.myQuestion.hasObservation = (this.extras.observations.length > 0);
             this.myQuestion.answer_Id = obs.answer_Id;
           },
-          error => console.log('Error updating observations | ' + (<Error>error).message)
+          error => console.error('Error updating observations | ' + (<Error>error).message)
         );
 
       });

--- a/CSETWebNg/src/app/assessment/questions/questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.ts
@@ -325,7 +325,7 @@ export class QuestionsComponent implements AfterViewChecked, OnInit, AfterViewIn
           (<Error>error).name +
           (<Error>error).message
         );
-        console.log('Error getting questions: ' + (<Error>error).stack);
+        console.error('Error getting questions: ' + (<Error>error).stack);
       }
     );
   }

--- a/CSETWebNg/src/app/assessment/results/analytics/analytics.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analytics/analytics.component.ts
@@ -72,8 +72,8 @@ export class AnalyticsComponent implements OnInit {
                 this.analytics = data;
             },
             error => {
-                console.log('Error getting all documents: ' + (<Error>error).name + (<Error>error).message);
-                console.log('Error getting all documents: ' + (<Error>error).stack);
+                console.error('Error getting all documents: ' + (<Error>error).name + (<Error>error).message);
+                console.error('Error getting all documents: ' + (<Error>error).stack);
             });
     }
 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
@@ -91,7 +91,7 @@ export class EdmBlocksCompactComponent implements OnInit, OnChanges {
             }
           });
         },
-        error => console.log('RF Error: ' + (<Error>error).message)
+        error => console.error('RF Error: ' + (<Error>error).message)
       );
     }
   }

--- a/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
@@ -51,7 +51,7 @@ export class EdmHeatmapComponent implements OnInit, OnChanges {
           }
           this.scores = r;
         },
-        error => console.log('RF Error: ' + (<Error>error).message)
+        error => console.error('RF Error: ' + (<Error>error).message)
       );
     }
   }

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.ts
@@ -85,7 +85,7 @@ export class CmmcComplianceComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message);
+        console.error('Site Summary report load Error: ' + (<Error>error).message);
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.ts
@@ -90,7 +90,7 @@ export class CmmcGapsComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message)
+        console.error('Site Summary report load Error: ' + (<Error>error).message)
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.ts
@@ -88,7 +88,7 @@ export class CmmcLevelDrilldownComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('CMMC level drilldown load Error: ' + (<Error>error).message);
+         console.error('CMMC level drilldown load Error: ' + (<Error>error).message);
       }
     ), (finish) => { };
   }

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.ts
@@ -68,7 +68,7 @@ export class CmmcLevelResultsComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message)
+        console.error('Site Summary report load Error: ' + (<Error>error).message)
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.ts
@@ -87,7 +87,7 @@ export class CmmcGapsComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message)
+        console.error('Site Summary report load Error: ' + (<Error>error).message)
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.ts
@@ -55,7 +55,7 @@ export class SprsScoreComponent implements OnInit {
       error => {
         this.dataError = true;
         this.loading = false;
-        console.log('Site Summary report load Error: ' + (<Error>error).message);
+        console.error('Site Summary report load Error: ' + (<Error>error).message);
       });
   }
 

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.ts
@@ -52,7 +52,7 @@ export class MvraGapsComponent implements OnInit {
       },
       error => {
         this.errors = true;
-        console.log('Mvra Gaps load Error: ' + (<Error>error).message);
+        console.error('Mvra Gaps load Error: ' + (<Error>error).message);
       }
     ),
       (finish) => {

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.ts
@@ -53,7 +53,7 @@ export class MvraSummaryComponent implements OnInit {
       },
       error => {
         this.errors = true;
-        console.log('Mvra Gaps load Error: ' + (<Error>error).message);
+        console.error('Mvra Gaps load Error: ' + (<Error>error).message);
       }
     ),
       (finish) => {

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.ts
@@ -88,7 +88,7 @@ export class RraGapsComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message);
+        console.error('Site Summary report load Error: ' + (<Error>error).message);
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.ts
@@ -84,7 +84,7 @@ export class VadrGapsComponent implements OnInit {
       error => {
         this.dataError = true;
         this.initialized = true;
-        console.log('Site Summary report load Error: ' + (<Error>error).message);
+        console.error('Site Summary report load Error: ' + (<Error>error).message);
       }
     ), (finish) => {
     };

--- a/CSETWebNg/src/app/builder/add-question/add-question.component.ts
+++ b/CSETWebNg/src/app/builder/add-question/add-question.component.ts
@@ -68,7 +68,7 @@ export class AddQuestionComponent implements OnInit {
         this.groupheadings = data.groupHeadings;
         this.subcategories = data.subcategories;
       },
-      error => console.log('Categories load Error: ' + (<Error>error).message)
+      error => console.error('Categories load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.ts
+++ b/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.ts
@@ -82,7 +82,7 @@ export class ModuleAddCloneComponent implements OnInit {
       this.dialogRef.close(true);
     },
       error => {
-        console.log("Unable to get Custom Standards: " + (<Error>error).message);
+        console.error("Unable to get Custom Standards: " + (<Error>error).message);
         this.warning = true;
       });
   }

--- a/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
+++ b/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
@@ -146,7 +146,7 @@ export class RequirementDetailComponent implements OnInit {
         this.subcategories = data.subcategories;
         this.groupHeadings = data.groupHeadings;
       },
-      error => console.log('Categories load Error: ' + (<Error>error).message)
+      error => console.error('Categories load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.ts
+++ b/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.ts
@@ -81,7 +81,7 @@ export class RequirementListComponent implements OnInit {
         this.categories = data.categories;
         this.subcategories = data.subcategories;
       },
-      error => console.log('Categories load Error: ' + (<Error>error).message)
+      error => console.error('Categories load Error: ' + (<Error>error).message)
     );
   }
 
@@ -208,7 +208,7 @@ export class RequirementListComponent implements OnInit {
 
             this.setBuilderSvc.navRequirementDetail(r.requirementID);
           },
-            error => console.log(error.message)
+            error => console.error(error.message)
           );
 
         } else {

--- a/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.ts
+++ b/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.ts
@@ -56,7 +56,7 @@ export class AddRequirementComponent implements OnInit {
         this.subcategories = data.subcategories;
         this.groupHeadings = data.groupHeadings;
       },
-      error => console.log('Categories load Error: ' + (<Error>error).message)
+      error => console.error('Categories load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.ts
+++ b/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.ts
@@ -66,7 +66,7 @@ export class EditUserComponent implements OnInit {
         (data: SecurityQuestion[]) => {
           this.securityQuestions = data;
         },
-        error => console.log('Error retrieving security questions: ' + error.message)
+        error => console.error('Error retrieving security questions: ' + error.message)
       );
   }
 
@@ -79,7 +79,7 @@ export class EditUserComponent implements OnInit {
         (data: CreateUser) => {
           this.model = data;
         },
-        error => console.log('Error retrieving security questions: ' + error.message)
+        error => console.error('Error retrieving security questions: ' + error.message)
       );
   }
 
@@ -92,7 +92,7 @@ export class EditUserComponent implements OnInit {
         () => {
           this.auth.setUserInfo(this.model)
         },
-        error => console.log('Error updating the user information' + error.message)
+        error => console.error('Error updating the user information' + error.message)
       );
       this.dialog.close(this.model);
     }

--- a/CSETWebNg/src/app/helpers/jwt.interceptor.ts
+++ b/CSETWebNg/src/app/helpers/jwt.interceptor.ts
@@ -66,7 +66,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
 
             if (e.status === 401) {
-              console.log('Error 401! Ejecting to login page!');
+              console.error('Error 401! Ejecting to login page!');
             }
 
             if (e.status === 500 || (e.error && e.error.ExceptionMessage === 'JWT invalid')) {

--- a/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.ts
+++ b/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.ts
@@ -356,7 +356,7 @@ export class AssessmentComparisonAnalyticsComponent implements OnInit {
         this.populateIndustryOptions(this.demographicData.sectorId);
       },
       (error) =>
-        console.log("Demographic load Error: " + (<Error>error).message)
+        console.error("Demographic load Error: " + (<Error>error).message)
     );
   }
 
@@ -380,7 +380,7 @@ export class AssessmentComparisonAnalyticsComponent implements OnInit {
           (<Error>error).name +
           (<Error>error).message
         );
-        console.log("Error Getting Industry (cont): " + (<Error>error).stack);
+        console.error("Error Getting Industry (cont): " + (<Error>error).stack);
       }
     );
   }

--- a/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.ts
+++ b/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.ts
@@ -197,7 +197,7 @@ export class LoginAccessKeyComponent implements OnInit {
       (error) => {
         this.loginAccessKeyFailed = true;
         localStorage.removeItem('accessKey');
-        console.log(error);
+        console.error(error);
       }
     );
   }

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -143,7 +143,7 @@ export class LoginCsetComponent implements OnInit {
           }
 
           this.loading = false;
-          console.log('Error logging in: ' + (<Error>error).message);
+          console.error('Error logging in: ' + (<Error>error).message);
 
 
           // see if the password is expired

--- a/CSETWebNg/src/app/initial/register/register.component.ts
+++ b/CSETWebNg/src/app/initial/register/register.component.ts
@@ -110,7 +110,7 @@ export class RegisterComponent implements OnInit {
           data: { messageText: this.errorMessage }
         })
           .afterClosed().subscribe();
-        console.log('Error Creating User Account: ' + error.message);
+        console.error('Error Creating User Account: ' + error.message);
       });
   }
 
@@ -125,7 +125,7 @@ export class RegisterComponent implements OnInit {
           this.SecurityQuestions = data;
           this.model.securityQuestion1 = data[0].securityQuestion;
         },
-        error => console.log('Error retrieving security questions: ' + error.message)
+        error => console.error('Error retrieving security questions: ' + error.message)
       );
   }
 }

--- a/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.ts
+++ b/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.ts
@@ -143,7 +143,7 @@ export class ResetPassComponent implements OnInit {
 
     private handleError(msg: string, error: Response | any) {
         this.loading = false;
-        console.log(msg + (<Error>error).message);
-        console.log(msg + (<Error>error).stack);
+        console.error(msg + (<Error>error).message);
+        console.error(msg + (<Error>error).stack);
     }
 }

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
@@ -471,7 +471,7 @@ export class TopMenusComponent implements OnInit {
         // the update user request happened when the dialog's form was saved
         this.dialogRef = undefined;
       },
-      (error) => console.log(error.message)
+      (error) => console.error(error.message)
     );
   }
 

--- a/CSETWebNg/src/app/main.ts
+++ b/CSETWebNg/src/app/main.ts
@@ -32,4 +32,4 @@ if (environment.production) {
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule)
-    .catch(err => console.log(err));
+    .catch(err => console.error(err));

--- a/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
@@ -56,7 +56,7 @@ export class CisCommentsmarkedComponent implements OnInit {
         this.response = r;
         this.loading = false;
       },
-      error => console.log('Comments Marked Report Error: ' + (<Error>error).message)
+      error => console.error('Comments Marked Report Error: ' + (<Error>error).message)
     );
   }
 }

--- a/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
@@ -17,9 +17,7 @@ export class VadrGroupingBlockComponent implements OnInit {
   ) { }
 
 
-  ngOnInit(): void {
-    console.log(this.grouping);
-  }
+  ngOnInit(): void {   }
 
   /**
    * Sets the coloring of a cell based on its answer.

--- a/CSETWebNg/src/app/reports/cmmc/cmmc-alt-justifications/cmmc-alt-justifications.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc/cmmc-alt-justifications/cmmc-alt-justifications.component.ts
@@ -60,7 +60,6 @@ export class CmmcAltJustificationsComponent implements OnInit {
         // Build up alternate justifications list
         this.model.reportData.alternateList.forEach(matAns => {
           const domain = matAns.mat.question_Title.split('.')[0];
-          console.log(domain);
           const aElement = this.altJustList.find(e => e.cat === this.keyToCategory[domain]);
           if (!aElement) {
             this.altJustList.push({ cat: this.keyToCategory[domain], matAnswers: [matAns] });
@@ -81,7 +80,7 @@ export class CmmcAltJustificationsComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('CMMC Alternate Justifications Report Error: ' + (<Error>error).message)
+      error => console.error('CMMC Alternate Justifications Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/cmmc/cmmc-comments-marked/cmmc-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc/cmmc-comments-marked/cmmc-comments-marked.component.ts
@@ -57,12 +57,10 @@ export class CmmcCommentsMarkedComponent implements OnInit {
     this.maturitySvc.getCmmcReportData().subscribe(
       (r: any) => {
         this.model = r;
-        console.log(r)
 
         // Build up comments list
         this.model.reportData.comments.forEach(matAns => {
           const domain = matAns.mat.question_Title.split('.')[0];
-          console.log(domain);
           const cElement = this.commentsList.find(e => e.cat === this.keyToCategory[domain]);
           if (!cElement) {
             this.commentsList.push({ cat: this.keyToCategory[domain], matAnswers: [matAns] });
@@ -104,7 +102,7 @@ export class CmmcCommentsMarkedComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('CMMC Comments and Marked for Review Report Error: ' + (<Error>error).message)
+      error => console.error('CMMC Comments and Marked for Review Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/cmmc/cmmc-deficiency/cmmc-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc/cmmc-deficiency/cmmc-deficiency.component.ts
@@ -80,7 +80,7 @@ export class CmmcDeficiencyComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('CMMC Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('CMMC Deficiency Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/cmmc/executive-cmmc/executive-cmmc.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc/executive-cmmc/executive-cmmc.component.ts
@@ -92,7 +92,7 @@ export class ExecutiveCMMCComponent implements OnInit, AfterViewChecked {
     this.reportSvc.getReport('executivematurity').subscribe((r: any) => {
       this.response = r;
     },
-      error => console.log('Executive report load Error: ' + (<Error>error).message)
+      error => console.error('Executive report load Error: ' + (<Error>error).message)
     );
     this.columnWidthEmitter.subscribe(item => {
       $(".gridCell").css("width", `${item}px`)

--- a/CSETWebNg/src/app/reports/cmmc/sitesummary-cmmc/sitesummary-cmmc.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc/sitesummary-cmmc/sitesummary-cmmc.component.ts
@@ -76,7 +76,7 @@ export class SitesummaryCMMCComponent implements OnInit, AfterViewChecked, After
     this.reportSvc.getReport('sitesummarycmmc').subscribe((r: any) => {
       this.response = r;
     },
-      error => console.log('Site summary CMMC report load Error: ' + (<Error>error).message)
+      error => console.error('Site summary CMMC report load Error: ' + (<Error>error).message)
     );
     this.columnWidthEmitter.subscribe(item => {
       $(".gridCell").css("width", `${item}px`)

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
@@ -108,7 +108,7 @@ export class Cmmc2CommentsMarkedComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('CMMC 2.0 Comments and Marked for Review Report Error: ' + (<Error>error).message)
+      error => console.error('CMMC 2.0 Comments and Marked for Review Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
@@ -79,7 +79,7 @@ export class Cmmc2DeficiencyComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('CMMC 2.0 Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('CMMC 2.0 Deficiency Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
@@ -82,7 +82,7 @@ export class CommentsMfrComponent implements OnInit {
 
         this.loading = false;
       },
-      error => console.log('Comments Marked Report Error: ' + (<Error>error).message)
+      error => console.error('Comments Marked Report Error: ' + (<Error>error).message)
     );
 
     this.assessSvc.getOtherRemarks().subscribe((resp: any) => {

--- a/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
@@ -77,7 +77,7 @@ export class CompareReportMComponent implements OnInit, AfterViewChecked {
         this.response = r;
       },
 
-      error => console.log('Compare report load Error: ' + (<Error>error).message)
+      error => console.error('Compare report load Error: ' + (<Error>error).message)
     );
 
     this.populateCharts();

--- a/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
@@ -70,7 +70,7 @@ export class CompareReportComponent implements OnInit, AfterViewChecked {
         this.response = r;
       },
 
-      error => console.log('Compare report load Error: ' + (<Error>error).message)
+      error => console.error('Compare report load Error: ' + (<Error>error).message)
     );
 
     this.populateCharts(aggId);

--- a/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
@@ -149,7 +149,7 @@ export class CrrCommentsMarkedComponent implements OnInit {
 
         this.loading = false;
       },
-      (error) => console.log('CRR Comments Marked Report Error: ' + (<Error>error).message)
+      (error) => console.error('CRR Comments Marked Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
@@ -102,7 +102,7 @@ export class CrrDeficiencyComponent implements OnInit {
 
         this.loading = false;
       },
-      (error) => console.log('CRR Deficiency Report Error: ' + (<Error>error).message)
+      (error) => console.error('CRR Deficiency Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
@@ -59,7 +59,7 @@ export class EdmCommentsmarkedComponent implements OnInit {
         this.response = r;
         this.loading = false;
       },
-      error => console.log('Comments Marked Report Error: ' + (<Error>error).message)
+      error => console.error('Comments Marked Report Error: ' + (<Error>error).message)
     );
   }
   getQuestion(q) {

--- a/CSETWebNg/src/app/reports/edm-deficiency/edm-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/edm-deficiency/edm-deficiency.component.ts
@@ -58,7 +58,7 @@ export class EdmDeficiencyComponent implements OnInit {
         this.response = r;
         this.loading = false;
       },
-      error => console.log('Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('Deficiency Report Error: ' + (<Error>error).message)
     );
   }
   getQuestion(q) {

--- a/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.ts
@@ -63,19 +63,19 @@ export class EdmPerfMil1Component implements OnInit {
       (r: any) => {
         this.scores.set('RF', r);
       },
-      error => console.log('getEdmScores Error: ' + (<Error>error).message)
+      error => console.error('getEdmScores Error: ' + (<Error>error).message)
     );
     this.maturitySvc.getEdmScores('RMG').subscribe(
       (r: any) => {
         this.scores.set('RMG', r);
       },
-      error => console.log('getEdmScores Error: ' + (<Error>error).message)
+      error => console.error('getEdmScores Error: ' + (<Error>error).message)
     );
     this.maturitySvc.getEdmScores('SPS').subscribe(
       (r: any) => {
         this.scores.set('SPS', r);
       },
-      error => console.log('getEdmScores Error: ' + (<Error>error).message)
+      error => console.error('getEdmScores Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.ts
@@ -53,7 +53,7 @@ export class EdmPerfSummAllMilComponent implements OnInit, OnChanges {
       (r: any) => {
         this.scores = r;
       },
-      error => console.log('RF Error: ' + (<Error>error).message)
+      error => console.error('RF Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/edm/edm.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.ts
@@ -142,10 +142,10 @@ export class EdmComponent implements OnInit, AfterContentInit {
               this.displayName = this.assesmentInfo.assessment_Name;
             }
           },
-          error => console.log('Demographic load Error: ' + (<Error>error).message)
+          error => console.error('Demographic load Error: ' + (<Error>error).message)
         );
       },
-      error => console.log('Assesment Information Error: ' + (<Error>error).message)
+      error => console.error('Assesment Information Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
+++ b/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
@@ -79,7 +79,7 @@ export class ExecutiveSummaryComponent implements OnInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Executive report load Error: ' + (<Error>error).message)
+      error => console.error('Executive report load Error: ' + (<Error>error).message)
     );
 
 

--- a/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
@@ -70,7 +70,7 @@ export class GeneralDeficiencyComponent implements OnInit {
           this.response = r;
           this.loading = false;
         },
-        error => console.log('Deficiency Report Error: ' + (<Error>error).message)
+        error => console.error('Deficiency Report Error: ' + (<Error>error).message)
       );
     });
   }

--- a/CSETWebNg/src/app/reports/hydro/hydro-action-items-report/hydro-action-items-report.component.ts
+++ b/CSETWebNg/src/app/reports/hydro/hydro-action-items-report/hydro-action-items-report.component.ts
@@ -37,7 +37,7 @@ export class HydroActionItemsReportComponent implements OnInit {
   
         this.loadingCounter ++;
       },
-      error => console.log('Assessment Information Error: ' + (<Error>error).message)
+      error => console.error('Assessment Information Error: ' + (<Error>error).message)
     );
 
     this.reportSvc.getHydroActionItemsReport().subscribe(

--- a/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
@@ -67,7 +67,7 @@ export class ImrReportComponent implements OnInit {
       (resp: any) => {
         this.model.structure = resp;
       },
-      (error) => console.log('Error loading IMR report: ' + (<Error>error).message)
+      (error) => console.error('Error loading IMR report: ' + (<Error>error).message)
     );
 
     this.cmuSvc.getDomainCompliance().subscribe((resp: any) => {

--- a/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
+++ b/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
@@ -49,7 +49,7 @@ export class MvraReportComponent implements OnInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Executive report load Error: ' + (<Error>error).message)
+      error => console.error('Executive report load Error: ' + (<Error>error).message)
     );
   }
 }

--- a/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
+++ b/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
@@ -57,7 +57,7 @@ export class ObservationTearoutsComponent implements OnInit {
         var title = this.tSvc.translate('reports.observations tear-out sheets.tab title', { defaultTitle: this.configSvc.behaviors.defaultTitle });
         this.titleService.setTitle(title);
       },
-      error => console.log('Observation Tear Out Sheets report load Error: ' + (<Error>error).message)
+      error => console.error('Observation Tear Out Sheets report load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.ts
+++ b/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.ts
@@ -251,7 +251,7 @@ export class PdfReportsComponent implements OnInit, AfterViewInit {
           this.coverImage = "<img width='700' src='" + event.target.result + "'>";
         }
         reader.onerror = (event: any) => {
-          console.log("File could not be read: " + event.target.error.code);
+          console.error("File could not be read: " + event.target.error.code);
         };
       });
   }

--- a/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
+++ b/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
@@ -71,7 +71,7 @@ export class PhysicalSummaryComponent implements OnInit, AfterViewInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Physical Summary report load Error: ' + (<Error>error).message)
+      error => console.error('Physical Summary report load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
@@ -97,7 +97,7 @@ export class RraDeficiencyComponent implements OnInit {
         this.response.deficienciesList = basicList.concat(intermediateList).concat(advancedList);
         this.loading = false;
       },
-      error => console.log('Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('Deficiency Report Error: ' + (<Error>error).message)
     );
 
 
@@ -105,7 +105,7 @@ export class RraDeficiencyComponent implements OnInit {
       this.createAnswerDistribByGoal(r);
       this.createTopRankedGoals(r);
     },
-      error => console.log('RRA detail load Error: ' + (<Error>error).message)
+      error => console.error('RRA detail load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
@@ -114,7 +114,7 @@ export class RraReportComponent implements OnInit {
       this.createTopRankedGoals(r);
 
     },
-      error => console.log('Main RRA report load Error: ' + (<Error>error).message)
+      error => console.error('Main RRA report load Error: ' + (<Error>error).message)
     );
 
 
@@ -128,7 +128,7 @@ export class RraReportComponent implements OnInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Main RRA report load Error: ' + (<Error>error).message)
+      error => console.error('Main RRA report load Error: ' + (<Error>error).message)
     );
 
     this.tSvc.selectTranslate('core.rra.tab title', {}, { scope: 'reports' })

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
@@ -74,7 +74,7 @@ export class SdOwnerCommentsMfrComponent {
 
         this.loading = false;
       },
-      error => console.log('Comments Marked Report Error: ' + (<Error>error).message)
+      error => console.error('Comments Marked Report Error: ' + (<Error>error).message)
     );
 
     this.assessSvc.getOtherRemarks().subscribe((resp: any) => {

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
@@ -75,7 +75,7 @@ export class SecurityplanComponent implements OnInit {
           control.controlDescription = control.controlDescription.replace(/\r/g, '<br/>');
         });
       },
-      error => console.log('Security Plan report load Error: ' + (<Error>error).message)
+      error => console.error('Security Plan report load Error: ' + (<Error>error).message)
     );
 
     // Component Types (stacked bar chart)

--- a/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
+++ b/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
@@ -84,7 +84,7 @@ export class SiteDetailComponent implements OnInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Detail report load Error: ' + (<Error>error).message)
+      error => console.error('Detail report load Error: ' + (<Error>error).message)
     );
 
     // Populate charts

--- a/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
+++ b/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
@@ -93,7 +93,7 @@ export class SiteSummaryComponent implements OnInit, AfterViewInit {
       (r: any) => {
         this.response = r;
       },
-      error => console.log('Site Summary report load Error: ' + (<Error>error).message)
+      error => console.error('Site Summary report load Error: ' + (<Error>error).message)
     );
 
     // Populate charts

--- a/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
+++ b/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
@@ -95,7 +95,7 @@ export class TrendReportComponent implements OnInit, AfterViewChecked {
           this.nistSalA = v.justification;
         }
       },
-      error => console.log('Trend report load Error: ' + (<Error>error).message)
+      error => console.error('Trend report load Error: ' + (<Error>error).message)
     );
 
     // Populate charts

--- a/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
@@ -141,12 +141,12 @@ export class OpenEndedQuestionsComponent implements OnInit {
 
         },
         (error) => {
-          console.log(
+          console.error(
             "Error getting questions: " +
             (<Error>error).name +
             (<Error>error).message
           );
-          console.log("Error getting questions: " + (<Error>error).stack);
+          console.error("Error getting questions: " + (<Error>error).stack);
         }
       );
   }

--- a/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
@@ -69,7 +69,7 @@ export class VadrDeficiencyComponent implements OnInit {
         this.response.deficienciesList = this.response.deficienciesList.filter(x => x.mat.parent_Question_Id == null);
         this.loading = false;
       },
-      error => console.log('Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('Deficiency Report Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
@@ -109,7 +109,7 @@ export class VadrReportComponent implements OnInit {
         // remove any child questions - they are not Y/N
         this.response.deficienciesList = this.response.deficienciesList.filter(x => x.mat.parent_Question_Id == null);
       },
-      error => console.log('Deficiency Report Error: ' + (<Error>error).message)
+      error => console.error('Deficiency Report Error: ' + (<Error>error).message)
     );
 
     // Standards Summary (pie or stacked bar)
@@ -122,7 +122,7 @@ export class VadrReportComponent implements OnInit {
 
       this.createTopRankedGoals(r);
     },
-      error => console.log('Main RRA report load Error: ' + (<Error>error).message)
+      error => console.error('Main RRA report load Error: ' + (<Error>error).message)
     );
 
 
@@ -138,7 +138,7 @@ export class VadrReportComponent implements OnInit {
       (r: any) => {
         this.mainResponse = r;
       },
-      error => console.log('Main RRA report load Error: ' + (<Error>error).message)
+      error => console.error('Main RRA report load Error: ' + (<Error>error).message)
     );
   }
 

--- a/CSETWebNg/src/app/services/assessment.service.ts
+++ b/CSETWebNg/src/app/services/assessment.service.ts
@@ -457,7 +457,7 @@ export class AssessmentService {
           });
         },
         error =>
-          console.log(
+          console.error(
             'Unable to create new assessment: ' + (<Error>error).message
           )
       );
@@ -492,7 +492,6 @@ export class AssessmentService {
       this.getAssessmentToken(id).then(() => {
         this.getAssessmentDetail().subscribe((data: AssessmentDetail) => {
           this.assessment = data;
-
           this.applicationMode = this.assessment.applicationMode;
 
           if (this.assessment.baselineAssessmentId) {

--- a/CSETWebNg/src/app/services/cmmc-style.service.ts
+++ b/CSETWebNg/src/app/services/cmmc-style.service.ts
@@ -113,7 +113,7 @@ export class CmmcStyleService {
           window.dispatchEvent(new Event('resize'));
         }
       },
-      error => console.log('CMMC Style Service load Error: ' + (<Error>error).message)
+      error => console.error('CMMC Style Service load Error: ' + (<Error>error).message)
     ), (finish) => {
       observer.complete();
     };

--- a/CSETWebNg/src/app/services/hydro.service.ts
+++ b/CSETWebNg/src/app/services/hydro.service.ts
@@ -19,7 +19,6 @@ export class HydroService {
   ) { }
 
   getBulkSubCats(subCatIds: string[]) {
-    console.log(subCatIds)
     return this.http.get(this.configSvc.apiUrl + 'maturity/hydro/getBulkSubCatIds?subCatIds=' + subCatIds, headers);
   }
 

--- a/CSETWebNg/src/app/services/sal.service.ts
+++ b/CSETWebNg/src/app/services/sal.service.ts
@@ -171,8 +171,8 @@ export class SalService {
         this.selectedSAL = data;
       },
       error => {
-        console.log('Error setting sal level: ' + (<Error>error).name + (<Error>error).message);
-        console.log('Error setting sal level: ' + (<Error>error).stack);
+        console.error('Error setting sal level: ' + (<Error>error).name + (<Error>error).message);
+        console.error('Error setting sal level: ' + (<Error>error).stack);
       });
   }
 

--- a/CSETWebNg/src/app/services/version.service.ts
+++ b/CSETWebNg/src/app/services/version.service.ts
@@ -58,7 +58,7 @@ export class VersionService {
       }
     })
     error => {
-      console.log(error)
+      console.error(error)
     }
   }
 

--- a/CSETWebNg/src/main.ts
+++ b/CSETWebNg/src/main.ts
@@ -32,4 +32,4 @@ if (environment.production) {
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));


### PR DESCRIPTION
This pull request standardizes error logging across the codebase by replacing all instances of `console.log` used for error reporting with `console.error`. This change improves the clarity and visibility of error messages in the browser console, making debugging easier and ensuring errors are properly flagged in production environments.

**Error Logging Standardization**

* Replaced all `console.log` statements with `console.error` for error handling in service calls and observable subscriptions across multiple components, including `AssessmentDemographicsComponent`, `CsiServiceCompositionComponent`, `CsiServiceDemographicsComponent`, `FrameworkComponent`, `RequiredDocsComponent`, `SalGenComponent`, `SalNistComponent`, `SalSimpleComponent`, `SalsComponent`, `DiagramQuestionsComponent`, `MaturityQuestionsNestedComponent`, `QuestionExtrasComponent`, and others. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cL101-R119) [[2]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cL179-R179) [[3]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cL212-R213) [[4]](diffhunk://#diff-4b819d10430cadfdd8b40ba1b74cb2295ac839bb8ba9d7011e2969809091a5e4L49-R49) [[5]](diffhunk://#diff-4b819d10430cadfdd8b40ba1b74cb2295ac839bb8ba9d7011e2969809091a5e4L140-R140) [[6]](diffhunk://#diff-07200b9db0ff9ff95bf7dbc05536ceb4765789b37709a3e06df87fb8a7874532L103-R103) [[7]](diffhunk://#diff-07200b9db0ff9ff95bf7dbc05536ceb4765789b37709a3e06df87fb8a7874532L112-R112) [[8]](diffhunk://#diff-07200b9db0ff9ff95bf7dbc05536ceb4765789b37709a3e06df87fb8a7874532L121-R129) [[9]](diffhunk://#diff-76707046f90abf657b488ddb1a2df9ad5509828cad09ed7933fccd98b191cce0L58-R59) [[10]](diffhunk://#diff-a3c020bd876241583251de358894f26a212c35b7b2ff1b4aef470055c6290b3eL69-R70) [[11]](diffhunk://#diff-9d7c0e15c24d4d52c3b16d252daa893bde03a522d659333703e7425ee1e5dce2L108-R109) [[12]](diffhunk://#diff-9d7c0e15c24d4d52c3b16d252daa893bde03a522d659333703e7425ee1e5dce2L118-R119) [[13]](diffhunk://#diff-9d7c0e15c24d4d52c3b16d252daa893bde03a522d659333703e7425ee1e5dce2L133-R134) [[14]](diffhunk://#diff-7f68200e1c04823acba76d70ec06f2e09b5fd388215cfa4823bc7c65f84f1ca0L62-R72) [[15]](diffhunk://#diff-8fdaa1b77b2a7a51c3033fed813b33cefc03947c10db6275cea41220f0c54004L50-R51) [[16]](diffhunk://#diff-525609cd9cf12b78dcd4d1620cccb0ab82f7ef479d519dcb50f6fd2f318140e3L74-R75) [[17]](diffhunk://#diff-525609cd9cf12b78dcd4d1620cccb0ab82f7ef479d519dcb50f6fd2f318140e3L91-R92) [[18]](diffhunk://#diff-67b54bebf7ea6d24f15f4f4e8183f6a39fd8d67d406c5d774855e13e9fba4f1bL110-R110) [[19]](diffhunk://#diff-966c10c0117cdf775e942b374ac25ef87829dfae4a2c63a740be4d6ff2e72fe2L97-R97) [[20]](diffhunk://#diff-966c10c0117cdf775e942b374ac25ef87829dfae4a2c63a740be4d6ff2e72fe2L159-R159) [[21]](diffhunk://#diff-277f37b24ba2a400fc792db21c1b159e564db04704d2c28e36b211421d6c9cdfL327-R327) [[22]](diffhunk://#diff-710c3cc1949fa7a3b443b552dc1cc7977eaaec7657a04eb96b8f61afa748a2f2L96-R96) [[23]](diffhunk://#diff-022e9a3e17b130f117d2a8e9696ca5e9baf03e92cc458afd1ab45711364a8825L170-R170) [[24]](diffhunk://#diff-22bba8ad48fc86e4beaa57772bf893cf0a9fca43f3836cbb5df82b0eef92823aL187-L192) [[25]](diffhunk://#diff-b3cea08a2744489f9684136dca8f210ef194b681b2da43b95472d0df9b8913c0L82-R82) [[26]](diffhunk://#diff-a4ea8955385e1e33a778e6154bb8fa509b115a6f92c38a99cdfd3f94e77b8a08L101-R101) [[27]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL194-R194) [[28]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL314-R314)

**Minor Code Cleanup**

* Removed commented-out debugging code from `AssessmentComponent`, improving code readability.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
