### PR TITLE
update: restoredb sql script

### DIFF
--- a/backup/restoredb.sql
+++ b/backup/restoredb.sql
@@ -1,11 +1,16 @@
-ALTER DATABASE CSETWeb
+ALTER DATABASE CSETWebTest
 SET SINGLE_USER
 WITH ROLLBACK IMMEDIATE
 GO
 
-RESTORE DATABASE CSETWeb
-FROM DISK = '/var/opt/mssql/backup/CSETWeb.bak'
+RESTORE DATABASE CSETWebTest
+FROM DISK = '/var/opt/mssql/backup/CSETWebTest.bak'
 WITH REPLACE,
-MOVE 'CSETWeb' TO '/var/opt/mssql/data/CSETWeb.mdf',
-MOVE 'CSETWeb_Log' TO '/var/opt/mssql/data/CSETWeb_Log.ldf'
+MOVE 'CSETWebTest' TO '/var/opt/mssql/data/CSETWebTest.mdf',
+MOVE 'CSETWebTest_Log' TO '/var/opt/mssql/data/CSETWebTest_Log.ldf'
+GO
+
+-- Return database to MULTI_USER after restore to allow client connections
+ALTER DATABASE CSETWebTest
+SET MULTI_USER
 GO


### PR DESCRIPTION
This pull request updates the database restore script to target the `CSETWebTest` database instead of the original `CSETWeb` database. The changes ensure that the restore process and all related file paths are correctly aligned with the test database, and improve usability by resetting the database to allow client connections after the restore.

**Database target and restore process:**

* Changed all references from `CSETWeb` to `CSETWebTest`, including the database name, backup file, and data/log file paths, to ensure the script operates on the test database.

**Usability improvements:**

* Added a command to set the database back to `MULTI_USER` mode after the restore, allowing client connections to resume.