### PR TITLE
fix: standalone auth to rely on local account flag

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/USERS.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/USERS.cs
@@ -48,6 +48,9 @@ public partial class USERS
     public bool CisaAssessorWorkflow { get; set; }
 
     [Required]
+    public bool IsLocalAccount { get; set; }
+
+    [Required]
     [StringLength(10)]
     public string Lang { get; set; }
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
@@ -6,11 +6,7 @@
 //////////////////////////////// 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Security.Principal;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
@@ -19,10 +15,8 @@ using CSETWebCore.Interfaces.User;
 using CSETWebCore.Model.Authentication;
 using CSETWebCore.Model.Contact;
 using CSETWebCore.Model.User;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.EntityFrameworkCore;
 
 namespace CSETWebCore.Helpers

--- a/backup/restoredb.sql
+++ b/backup/restoredb.sql
@@ -10,7 +10,3 @@ MOVE 'CSETWebTest' TO '/var/opt/mssql/data/CSETWebTest.mdf',
 MOVE 'CSETWebTest_Log' TO '/var/opt/mssql/data/CSETWebTest_Log.ldf'
 GO
 
--- Return database to MULTI_USER after restore to allow client connections
-ALTER DATABASE CSETWebTest
-SET MULTI_USER
-GO


### PR DESCRIPTION
This pull request refactors the handling of local user accounts in the authentication logic, moving away from using a hardcoded user ID and instead relying on a new `IsLocalAccount` property. This change improves maintainability and flexibility for local account management. The most important changes are grouped below.

**Local Account Handling and Authentication Logic:**

* Added a `[Required] bool IsLocalAccount` property to the `USERS` class to explicitly mark users as local accounts, replacing the previous reliance on a hardcoded user ID.
* Updated the standalone authentication flow in `UserAuthentication.cs` to search for users with `IsLocalAccount == true` rather than a specific user ID, and to set this property when creating new local users. [[1]](diffhunk://#diff-9ebcade970a177b99ef3480ac1dc6aef71daa703edce47d3f120abea8b657c2dL228-R238) [[2]](diffhunk://#diff-9ebcade970a177b99ef3480ac1dc6aef71daa703edce47d3f120abea8b657c2dL252-R279)
* Refactored token generation and assessment contact assignment to use the dynamically determined local user ID instead of the hardcoded value. [[1]](diffhunk://#diff-9ebcade970a177b99ef3480ac1dc6aef71daa703edce47d3f120abea8b657c2dL252-R279) [[2]](diffhunk://#diff-9ebcade970a177b99ef3480ac1dc6aef71daa703edce47d3f120abea8b657c2dL297-L318)
* Removed the unused constant `STANDALONE_USER_ID` from the authentication helper class, cleaning up legacy code.

**Database Script Cleanup:**

* Removed the step that returns the database to `MULTI_USER` mode after restore in the `restoredb.sql` script, likely to streamline restore operations in certain environments.