### PR TITLE
Added heatmaps to CRE+ final reports

### DIFF
--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.ts
@@ -63,7 +63,7 @@ export class CrrResultsDetailComponent implements OnInit {
       case 'N':
         return 'red-score';
       case 'U':
-        return 'default-score';
+        return 'unanswered-score';
     }
   }
 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
@@ -105,7 +105,7 @@ export class EdmBlocksCompactComponent implements OnInit, OnChanges {
       case 'red': return 'red-score';
       case 'yellow': return 'yellow-score';
       case 'green': return 'green-score';
-      default: return 'default-score';
+      default: return 'unanswered-score';
     }
   }
 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
@@ -62,7 +62,7 @@ export class EdmHeatmapComponent implements OnInit, OnChanges {
       case 'yellow': return 'yellow-score';
       case 'green': return 'green-score';
       case 'lightgray': return 'light-gray-score'
-      default: return 'default-score';
+      default: return 'unanswered-score';
     }
   }
 }

--- a/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.ts
@@ -88,7 +88,7 @@ export class EdmQBlocksHorizontalComponent implements OnChanges {
       case 'red': return 'red-score';
       case 'yellow': return 'yellow-score';
       case 'green': return 'green-score';
-      default: return 'default-score';
+      default: return 'unanswered-score';
     }
   }
 

--- a/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.html
+++ b/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.html
@@ -20,19 +20,29 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 -------------------------->
-<div class="d-flex flex-row" style="font-size: .8rem;">
-     <div class="me-2">
-          <div class="d-flex flex-row">
-               <div class="green-score" style="width: 1rem; height: 1rem; margin: .2rem;">
-               </div> = Performed
+<div class="d-flex flex-row fs-smaller" *transloco="let t">
+     <div class="me-4">
+          <h6>{{ t('reports.core.heatmap.goal bars') }}</h6>
+          <div class="d-flex flex-row align-items-center" *ngFor="let item of goalLegend">
+               <div class="flex-shrink-0 d-flex flex-row flex-nowrap align-items-center">
+                    <div [class]="item.scoreColor + '-score'" style="width: 1rem; height: 1rem; margin: .2rem;"></div>
+                    <span>=</span>
+               </div>
+               <div class="flex-grow-1 ms-1">
+                    {{ t('reports.core.heatmap.' + item.scoreLabel) }}
+               </div>
           </div>
-          <div class="d-flex flex-row flex-nowrap">
-               <div class="yellow-score" style="width: 1rem; height: 1rem; margin: .2rem;">
-               </div> = Incompletely Performed
-          </div>
-          <div class="d-flex flex-row">
-               <div class="red-score" style="width: 1rem; height: 1rem; margin: .2rem;">
-               </div> = Not Performed
+     </div>
+     <div>
+          <h6>{{ t('reports.core.heatmap.question cells') }}</h6>
+          <div class="d-flex flex-row align-items-center" *ngFor="let item of questionLegend">
+               <div class="flex-shrink-0 d-flex flex-row flex-nowrap align-items-center">
+                    <div [class]="item.scoreColor + '-score'" style="width: 1rem; height: 1rem; margin: .2rem;"></div>
+                    <span>=</span>
+               </div>
+               <div class="flex-grow-1 ms-1">
+                    {{ item.scoreLabel }}
+               </div>
           </div>
      </div>
 </div>

--- a/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.ts
+++ b/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.ts
@@ -8,4 +8,16 @@ import { Component } from '@angular/core';
 })
 export class KeyDisplay1Component {
 
+  goalLegend = [
+    { scoreColor: 'green', scoreLabel: 'performed' },
+    { scoreColor: 'yellow', scoreLabel: 'incompletely performed' },
+    { scoreColor: 'red', scoreLabel: 'not performed' }
+  ];
+
+  questionLegend = [
+    { scoreColor: 'green', scoreLabel: 'Implemented' },
+    { scoreColor: 'blue', scoreLabel: 'In Progress' },
+    { scoreColor: 'gold', scoreLabel: 'Scoped' },
+    { scoreColor: 'red', scoreLabel: 'Not Implemented' },
+  ];
 }

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -598,6 +598,10 @@ table.cset-table {
   color: $primary-color;
 }
 
+table.cset-table ul {
+  list-style: unset !important;
+}
+
 table.cset-table tr:nth-child(even) {
   background: $gray-100;
 }
@@ -3287,7 +3291,7 @@ table.td-text-start td {
 }
 
 .b-none {
-  border: none;
+  border: none !important;
 }
 
 .b-primary {

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -603,6 +603,10 @@ table.cset-table {
   color: $primary-color;
 }
 
+table.cset-table ul {
+  list-style: unset !important;
+}
+
 table.cset-table tr:nth-child(even) {
   background: $gray-100;
 }
@@ -3306,7 +3310,7 @@ table.td-text-start td {
 }
 
 .b-none {
-  border: none;
+  border: none !important;
 }
 
 .b-primary {

--- a/CSETWebNg/src/app/layout/styles-base.scss
+++ b/CSETWebNg/src/app/layout/styles-base.scss
@@ -2936,7 +2936,7 @@ table.td-text-start td {
 }
 
 .b-none {
-  border: none;
+  border: none !important;
 }
 
 .b-primary {

--- a/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
@@ -32,7 +32,7 @@ export class VadrGroupingBlockComponent implements OnInit {
       case 'N':
         return 'red-score';
       case 'U':
-        return 'default-score';
+        return 'unanswered-score';
     }
   }
 }

--- a/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.ts
@@ -79,7 +79,7 @@ export class CmuResultsDetailComponent implements OnChanges {
       case 'N':
         return 'red-score';
       case 'U':
-        return 'default-score';
+        return 'unanswered-score';
     }
   }
 

--- a/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.html
@@ -21,7 +21,7 @@
   SOFTWARE.
 -------------------------->
 <!-- answer distrib bar chart with ONLY CRE+ AND MIL ANSWERS -->
-<div class="my-4 px-3" style="border: 1px solid #ddd">
+<!-- <div class="my-4 px-3" style="border: 1px solid #ddd">
      <h2 class="text-center">
           {{chartTitle}}
      </h2>
@@ -40,7 +40,7 @@
                {{chartFooter1}}
           </em>
      </p>
-</div>
+</div> -->
 
 
 <!-- pie chart of all answers -->

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
@@ -37,8 +37,12 @@
           {{ `reports.core.cre.final reports.${modelId}.only selected` | transloco }}
      </p>
 
+      <p>
+          <app-key-display-1></app-key-display-1>
+     </p>
+
      <table class="w-100 cset-table">
-          <tr>
+          <tr class="d-none">
                <th>Number</th>
                <th>Question Text</th>
                <th>Rating</th>
@@ -49,6 +53,12 @@
                          <h1 class="mt-2 mb-0">
                               {{domain.title}}
                          </h1>
+                    </td>
+               </tr>
+
+               <tr>
+                    <td colspan="3" class="b-none">
+                         <app-heatmap [scores]="dictHeatmaps[domain.groupingId].children" [showGoalLabels]="false"></app-heatmap>
                     </td>
                </tr>
 

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.html
@@ -20,7 +20,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 -------------------------->
-<table class="cset-table">
+<table class="cset-table fs-smaller td-padding-point-4-rem">
      <tr>
           <th>
                MIL Level

--- a/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.ts
@@ -69,7 +69,7 @@ export class EdmDomainDetailComponent implements OnInit {
       case 'N':
         return 'red-score';
       case 'U':
-        return 'default-score';
+        return 'unanswered-score';
     }
   }
 

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.scss
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.scss
@@ -35,6 +35,17 @@
 }
 
 .score-cell {
+  font-size: .6rem;
+  padding: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.5rem;
+  border-radius: 3px;
+  height: 1.5rem;
+}
+
+.score-cell_large {
   font-size: small;
   padding: 4px;
   display: flex;

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
@@ -12,7 +12,13 @@ export class HeatmapComponent implements OnInit {
    * An array of groupings, typically the goals within a domain.
   */
   @Input()
-  scores: any[];
+  scores!: any[];
+
+  /**
+   * Optional - host page can suppress goal labels
+   */
+  @Input()
+  showGoalLabels = true;
 
   /**
    * Optional - host page can suppress question labels
@@ -46,15 +52,19 @@ export class HeatmapComponent implements OnInit {
    * @param score 
    * @returns 
    */
-  applyScoreStyle(element) {
-    element.children?.forEach(child => {
+  applyScoreStyle(element: any) {
+    element.children?.forEach((child: any) => {
       this.applyScoreStyle(child);
     });
 
     const color = element.color?.toLowerCase() || 'lightgray';
     element.scoreClass = this.colorToClassMap[color];
 
-    // hide question labels
+    // suppress goal label
+    if (!this.showGoalLabels && !element.questionId) {
+      element.title = '';
+    }
+    // suppress question label
     if (!this.showQuestionLabels && element.questionId && element.questionId !== 0) {
       element.title = '';
     }

--- a/CSETWebNg/src/app/reports/reports.scss
+++ b/CSETWebNg/src/app/reports/reports.scss
@@ -261,6 +261,16 @@ div.disclaimer-blurb {
   border-bottom: 1px solid #ddd !important;
 }
 
+.fs-small {
+  font-size: 0.9rem !important;
+  line-height: 1rem;
+}
+
+.fs-smaller {
+  font-size: 0.8rem !important;
+  line-height: 0.9rem;
+}
+
 
 /* ---- common display container widget ---- */
 .cset-container {
@@ -491,6 +501,10 @@ table.td-align-top td {
 
 table.td-padding-half-rem td {
   padding: .5rem;
+}
+
+table.td-padding-point-4-rem td {
+  padding: .4rem;
 }
 
 .shaded-red td {
@@ -1457,7 +1471,7 @@ h1.pageHeader {
   color: #fff;
 }
 
-.light-gray-score {
+.light-gray-score, .unanswered-score {
   background-color: #d3d3d3;
   border: 1px solid #d3d3d3;
   color: #000;
@@ -1827,7 +1841,7 @@ div.function-statement {
   padding-bottom: 1em;
 }
 
-.no-border {
+.no-border, .b-none {
   border: none !important;
 }
 

--- a/CSETWebNg/src/assets/i18n/reports/en.json
+++ b/CSETWebNg/src/assets/i18n/reports/en.json
@@ -867,7 +867,9 @@
                "p1": "This section's answers are color-coded to show their status, with the summary bar reflecting overall performance based on the combined results.",
                "performed": "Performed",
                "incompletely performed": "Incompletely Performed",
-               "not performed": "Not Performed"
+               "not performed": "Not Performed",
+               "goal bars": "Goal Bars",
+               "question cells": "Question Cells"
           }
      },
      "all": {

--- a/CSETWebNg/src/sass/styles.scss
+++ b/CSETWebNg/src/sass/styles.scss
@@ -2674,7 +2674,7 @@ table.td-text-start td {
 }
 
 .b-none {
-  border: none;
+  border: none !important;
 }
 
 .b-primary {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the reporting and results display components, with a focus on consistent styling, enhanced legends, and better internationalization support. The most significant changes include standardizing the CSS class for unanswered scores, refactoring the key display and heatmap components to be more dynamic and translatable, and improving table and font styling across the app.

**Score Styling and Consistency**
* Changed the CSS class for unanswered scores from `default-score` to `unanswered-score` across all relevant components, ensuring consistent visual representation for unanswered items. [[1]](diffhunk://#diff-3adb3242c7cac9298186b8a4bc5e5ea528ef991de4e9e76f6f22e98975b24286L66-R66) [[2]](diffhunk://#diff-9638d36d6821ff762254230bab95cead4e189834a9fa8696a55f9f1cb0244f12L108-R108) [[3]](diffhunk://#diff-c7d5da848e91533cd4f8d37885aa5c9e7b6603862528c968146144816efcfa61L65-R65) [[4]](diffhunk://#diff-6235ad101b82e4f678f6f1dfac3446bf60130ea150c7bb43313a28f35f02030bL91-R91) [[5]](diffhunk://#diff-dd9d0cd3e69493b05fb8f997ace26cee3f58717d93c6815afc72c08a98211d91L35-R35) [[6]](diffhunk://#diff-28bb40b4ce2d12a460bf26ca3246e40bbaf86253e761ca1e9e4ccce6bddd5d1aL82-R82) [[7]](diffhunk://#diff-107c65c827858e872c4016c11d8b2d0ba5610b98c3a7ea1bb0977802909f9d09L83-R94) [[8]](diffhunk://#diff-62a1c6fb2119c4980f10241efbb61f0c67e76cf7d216138ab133690bf863235eL72-R72)
* Updated `.light-gray-score` CSS to also apply to `.unanswered-score` for unified styling.

**Legend and Key Display Refactoring**
* Refactored `key-display-1.component.html` and its TypeScript to dynamically generate legends for goal bars and question cells, using translation keys for improved internationalization. [[1]](diffhunk://#diff-45c2b3d565927ac76cc632122f1e6829b2b3dcbe028d9a40bf844bc509c57480L23-R45) [[2]](diffhunk://#diff-39270f80a4403c1a7bd14b4790863bfd0c448b49b530f5147f225861e19cfbf0R11-R22) [[3]](diffhunk://#diff-b28c4d96e39bb4c85e978238528c6c6018b6e03fb99ab6e6071a1b0e4a5cbde0L870-R872)
* Added the key display component to the CRE final report grid for clearer legend presentation.

**Heatmap Component Enhancements**
* Modified `HeatmapComponent` to accept a `showGoalLabels` input, allowing host components to suppress goal labels, and updated logic to support this option. [[1]](diffhunk://#diff-757a9e4141b6685c91a751629d6265906223276f80ef1d649f772b5c56840f8bL15-R21) [[2]](diffhunk://#diff-757a9e4141b6685c91a751629d6265906223276f80ef1d649f772b5c56840f8bL49-R67)
* Improved heatmap cell styling for better readability and alignment.
* Integrated heatmap display into the CRE final report grid, including dynamic heatmap data loading and dictionary mapping. [[1]](diffhunk://#diff-abf47b12dcde3fa1d7dde4d8493e01a8d8c31bd2b126012c29a57af9e7bf3c0aR59-R64) [[2]](diffhunk://#diff-107c65c827858e872c4016c11d8b2d0ba5610b98c3a7ea1bb0977802909f9d09L37-R45) [[3]](diffhunk://#diff-107c65c827858e872c4016c11d8b2d0ba5610b98c3a7ea1bb0977802909f9d09L58-R74)

**Table and Font Styling Updates**
* Added new utility classes for smaller font sizes and table cell padding, and ensured `.b-none` uses `!important` for border removal across multiple stylesheets. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L3290-R3294) [[2]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L3309-R3313) [[3]](diffhunk://#diff-dfc77ca4f030e359faa89e9785039973d62e86818a1db3a5bc0903b7de9c8e9aL2939-R2939) [[4]](diffhunk://#diff-96499b3533144c00403898311a65670ce61f5741e6266c8e06956f98b66f1f89R264-R273) [[5]](diffhunk://#diff-96499b3533144c00403898311a65670ce61f5741e6266c8e06956f98b66f1f89R506-R509) [[6]](diffhunk://#diff-96499b3533144c00403898311a65670ce61f5741e6266c8e06956f98b66f1f89L1830-R1844)
* Updated table styling for explanation and report components to use new classes for improved appearance.

**Internationalization Improvements**
* Expanded translation keys in `reports/en.json` to cover new legend labels and section headers, supporting dynamic and translatable UI elements.

These changes collectively enhance the user experience by making the UI more consistent, accessible, and adaptable to different languages.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
