### PR TITLE
Feature/update json export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 dist
 AGENTS.md
 CLAUDE.md
+WARP.md
 .claude/
 .serena/
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
@@ -85,13 +85,24 @@ namespace CSETWebCore.Business.AssessmentIO.Export
                 SelfAssessment = assessmentDetail.SelfAssessment
             };
 
+            // Build out the Sector details early so we can populate AssessmentJson
+            var sectorDetails = BuildSectorDetails(assessmentDetail);
+
+            // Populate sector/subsector fields on AssessmentJson
+            if (sectorDetails != null)
+            {
+                assessment.SectorId = sectorDetails.SectorId;
+                assessment.SectorName = sectorDetails.SectorName;
+                assessment.SubsectorId = sectorDetails.SelectedIndustryId;
+                assessment.SubsectorName = sectorDetails.SelectedIndustryName;
+            }
+
 
             var contacts = _contactBusiness.GetContacts(assessmentId);
             List<StandardQuestions> standardQuestions = null;
             QuestionResponse questionList = null;
             List<ModelJson> maturityModels = null;
             List<ComponentQuestion> componentQuestions = null;
-            SectorDetailsJson sectorDetails = null;
 
 
             var detailSections = new Dictionary<string, object>();
@@ -206,9 +217,6 @@ namespace CSETWebCore.Business.AssessmentIO.Export
             }
 
             object details = detailSections.Count > 0 ? detailSections : null;
-
-            // Build out the Sector details
-            sectorDetails = BuildSectorDetails(assessmentDetail);
 
             // Remove irrelevant data from the payload
             CleanData(assessmentDetail);

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
@@ -5,11 +5,7 @@
 // 
 ////////////////////////////////
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using CSETWebCore.Business.Maturity;
 using CSETWebCore.Business.Question;
 using CSETWebCore.Business.Reports;
 using CSETWebCore.DataLayer.Model;
@@ -18,8 +14,13 @@ using CSETWebCore.Interfaces.Contact;
 using CSETWebCore.Interfaces.Reports;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Gallery;
-using CSETWebCore.Model.Question;
 using CSETWebCore.Model.Maturity;
+using CSETWebCore.Model.Question;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace CSETWebCore.Business.AssessmentIO.Export
 {
@@ -148,6 +149,19 @@ namespace CSETWebCore.Business.AssessmentIO.Export
             {
                 _reportsDataBusiness.SetReportsAssessmentId(assessment.Id);
                 maturityQuestions = _reportsDataBusiness.GetQuestionsList();
+
+
+
+                // RANDY
+                var biz = new MaturityBusiness(_context, null);
+                var lang = "en";
+                int groupingId = 0;
+                var fill = true;
+                var rkeResults = biz.GetMaturityQuestions(assessmentId, fill, groupingId, lang);
+
+
+
+
 
                 detailSections["maturityQuestions"] = maturityQuestions;
             }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/CompletionCounter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/CompletionCounter.cs
@@ -302,7 +302,7 @@ namespace CSETWebCore.Business.Question
         /// Based on the assessment's current state, returns a list of
         /// all maturity model IDs that are currently applicable/in scope.
         /// </summary>
-        private HashSet<int> DetermineInScopeModels(int assessmentId)
+        public HashSet<int> DetermineInScopeModels(int assessmentId)
         {
             HashSet<int> response = [];
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/RequirementBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/RequirementBusiness.cs
@@ -40,10 +40,10 @@ namespace CSETWebCore.Business.Question
         {
             _assessmentUtil = assessmentUtil;
             _questionRequirement = questionRequirement;
-            _tokenManager = tokenManager;
+            _tokenManager = tokenManager ?? throw new ArgumentNullException(nameof(tokenManager));
             _context = context;
 
-            _parmSub = new ParameterSubstitution(context, tokenManager);
+            _parmSub = new ParameterSubstitution(context, _tokenManager);
         }
 
         public void SetRequirementAssessmentId(int assessmentId)

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -109,7 +109,8 @@ namespace CSETWebCore.Business.Reports
 
             var query = from mq in _context.MATURITY_QUESTIONS.Include(x => x.Maturity_Level)
                         join a in _context.ANSWER on mq.Mat_Question_Id equals a.Question_Or_Requirement_Id
-                        join p in _context.MATURITY_QUESTION_PROPS on mq.Mat_Question_Id equals p.Mat_Question_Id
+                        join p in _context.MATURITY_QUESTION_PROPS on mq.Mat_Question_Id equals p.Mat_Question_Id into propGroup
+                        from p in propGroup.DefaultIfEmpty()
                         where a.Assessment_Id == _assessmentId
                             && mq.Maturity_Model_Id == targetModelId
                             && a.Question_Type == "Maturity"

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
@@ -1,0 +1,158 @@
+﻿//////////////////////////////// 
+// 
+//   Copyright 2025 Battelle Energy Alliance, LLC  
+// 
+// 
+////////////////////////////////
+
+using CSETWebCore.Model.Maturity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSETWebCore.Model.ExportJson
+{
+    public class AssessmentJson
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DateTime? CreatedDate { get; set; }
+        public bool SelfAssessment { get; set; }
+        public DateTime? AssessmentDate { get; set; }
+        public Guid AssessmentGuid { get; set; }
+
+        public int SectorId { get; set; }
+        public string SectorName { get; set; }
+        public int SubsectorId { get; set; }
+        public string SubsectorName { get; set; }
+
+
+    }
+
+    public class SectorDetailsJson
+    {
+        public int SectorId { get; set; }
+        public string SectorName { get; set; }
+        public int? SelectedIndustryId { get; set; }
+        public string SelectedIndustryName { get; set; }
+    }
+
+
+    ////// Maturity Model Content /////////////////////////////////////
+
+    public class ModelsJson
+    {
+        public List<ModelJson> Models { get; set; }
+    }
+
+
+    public class ModelJson
+    {
+        public int ModelId { get; set; }
+        public string ModelName { get; set; }
+        public string ModelTitle { get; set; }
+        public List<MaturityLevel> Levels { get; set; } = [];
+
+        public List<GroupingJson> Groupings { get; set; } = [];
+    }
+
+
+    public class GroupingJson
+    {
+        public int GroupingId { get; set; }
+        public string Title { get; set; }
+        public List<GroupingJson> Groupings { get; set; } = [];
+        public List<MaturityQuestionJson> Questions { get; set; } = [];
+    }
+
+
+    public class MaturityQuestionJson
+    {
+        public int QuestionId { get; set; }
+        public string QuestionText { get; set; }
+        public int MaturityLevel { get; set; }
+        public AnswerJson Answer { get; set; }
+
+        public List<MaturityQuestionJson> FollowupQuestions { get; set; } = [];
+    }
+
+
+    ////// Standards Content /////////////////////////////////////
+
+    /// <summary>
+    /// This is only included if the assessment contains standards
+    /// </summary>
+    public class StandardsJson
+    { 
+        public List<StandardJson> Standards { get; set; }
+
+        /// <summary>
+        /// Requirements Mode or Questions Mode
+        /// </summary>
+        public string Mode { get; set; }
+
+
+        /// <summary>
+        /// This property is only applicable for assessments in Questions Mode.
+        /// It should not show up when in Requirements Mode.
+        /// </summary>
+        public List<StandardQuestionJson> Questions { get; set; } = [];
+    }
+
+
+    public class StandardJson
+    {
+        public string SetName { get; set; }
+        public List<RequirementJson> Requirements { get; set; } = [];
+    }
+
+
+    public class RequirementJson
+    {
+        public int RequirementId { get; set; }
+        public string RequirementText { get; set; }
+    }
+
+
+    public class StandardQuestionJson
+    {
+        public int QuestionId { get; set; }
+        public string QuestionText { get; set; }
+
+        public AnswerJson Answer { get; set; }
+    }
+
+
+    ////// Shared between Maturity and Standards ///////////////////////
+
+    public class AnswerJson
+    {
+        public string AnswerText { get; set; }
+        public string Comment { get; set; }
+        public List<ObservationJson> Observations { get; set; } = [];
+    }
+
+
+    public class ObservationJson
+    {
+        public int ObservationId { get; set; }
+        public string Issue { get; set; }
+    }
+
+
+    public class ContactJson
+    {
+        public string UserId { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+        public string Phone { get; set; }
+        public string Role { get; set; }
+
+        public bool Invited { get; set; }
+        public bool IsPrimaryPoc { get; set; }
+        public bool IsSiteParticipant { get; set; }
+    }
+}

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
@@ -25,7 +25,7 @@ namespace CSETWebCore.Model.ExportJson
 
         public int SectorId { get; set; }
         public string SectorName { get; set; }
-        public int SubsectorId { get; set; }
+        public int? SubsectorId { get; set; }
         public string SubsectorName { get; set; }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentExportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentExportController.cs
@@ -151,7 +151,9 @@ namespace CSETWebCore.Api.Controllers
                     return BadRequest("An assessment identifier is required.");
                 }
 
-                var json = _jsonAssessmentExportManager.GetJson(resolvedAssessmentId, removePCII);
+                var lang = _token.GetCurrentLanguage();
+
+                var json = _jsonAssessmentExportManager.GetJson(resolvedAssessmentId, lang, removePCII);
                 var contents = Encoding.UTF8.GetBytes(json);
                 var fileName = $"assessment-{resolvedAssessmentId}.json";
                 return File(contents, "application/json", fileName);

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Startup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Startup.cs
@@ -189,6 +189,9 @@ namespace CSETWeb_ApiCore
                     provider.GetRequiredService<IContactBusiness>(),
                     provider.GetRequiredService<IReportsDataBusiness>(),
                     provider.GetRequiredService<IQuestionBusiness>(),
+                    provider.GetRequiredService<IAssessmentUtil>(),
+                    provider.GetRequiredService<IQuestionRequirementManager>(),
+                    provider.GetRequiredService<ITokenManager>(),
                     provider.GetRequiredService<CSETContext>()
                 ));
             services.AddScoped<IVersionBusiness, VersionBusiness>();


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on enhancing the JSON export functionality, improving dependency handling, and ensuring more robust data querying. The changes include the addition of new export model classes, updates to service registrations, and improvements in query joins and constructor safety.

**Export Functionality Enhancements**
* Added new export model classes in `ExportJson.cs` to support structured JSON output for assessments, maturity models, standards, answers, observations, and contacts. This provides a clear schema for assessment data export.
* Updated the `ExportAssessmentJson` endpoint to pass the current language to the JSON export manager, enabling language-aware exports.

**Dependency and Service Improvements**
* Registered additional required services (`IAssessmentUtil`, `IQuestionRequirementManager`, `ITokenManager`) in the dependency injection setup for the JSON export manager, ensuring all dependencies are available and reducing runtime errors.
* Improved constructor safety in `RequirementBusiness` by throwing an `ArgumentNullException` if `tokenManager` is not provided, and consistently using the validated token manager for parameter substitution.

**Data Query Robustness**
* Updated the maturity questions query to use a left join (`DefaultIfEmpty`) for `MATURITY_QUESTION_PROPS`, ensuring questions without associated properties are still included in results.

**API and Access Modifiers**
* Changed access modifier for `DetermineInScopeModels` from private to public to allow broader usage where maturity model scope determination is needed.