### PR TITLE
Refactored observations for JSON export

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
@@ -28,6 +28,8 @@ namespace CSETWebCore.Model.ExportJson
         public int? SubsectorId { get; set; }
         public string SubsectorName { get; set; }
 
+        public List<ObservationJson> Observations { get; set; }
+
 
     }
 
@@ -74,6 +76,8 @@ namespace CSETWebCore.Model.ExportJson
         public string QuestionText { get; set; }
         public int MaturityLevel { get; set; }
         public AnswerJson Answer { get; set; }
+
+        public List<ObservationJson> Observations { get; set; } = [];
 
         public List<MaturityQuestionJson> FollowupQuestions { get; set; } = [];
     }
@@ -124,6 +128,8 @@ namespace CSETWebCore.Model.ExportJson
         public string Title { get; set; }
 
         public AnswerJson Answer { get; set; }
+
+        public List<ObservationJson> Observations { get; set; } = [];
     }
 
 
@@ -133,14 +139,16 @@ namespace CSETWebCore.Model.ExportJson
     {
         public string AnswerText { get; set; }
         public string Comment { get; set; }
-        public List<ObservationJson> Observations { get; set; } = [];
     }
 
 
     public class ObservationJson
     {
         public int ObservationId { get; set; }
+        public int? AnswerId { get; set; }
+        public string Title { get; set; }
         public string Issue { get; set; }
+        public string Recommendations { get; set; }
     }
 
 


### PR DESCRIPTION
This pull request enhances the handling and export of assessment observations in the JSON export functionality. Observations are now more consistently and comprehensively included at both the assessment and answer levels, and the data model has been updated to support these changes. The most important changes are grouped below.

**Observation Handling Improvements:**

* Refactored observation retrieval: Introduced a new `GetObservations(int assessmentId)` method in `JSONAssessmentExportManager` to fetch both assessment-level and answer-level observations, replacing previous fragmented logic. Observations are now stored in `_assessmentObservations` and `_answerObservations` for reuse throughout the export process.
* Assessment-level observations are now directly included in the exported `AssessmentJson` object via the new `Observations` property. [[1]](diffhunk://#diff-3dc2f849e02a1a468109f697dcd5ff5dca2d183f217f65dd0d040eea10c41ae3R31-R32) [[2]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879R109-R112)
* Answer-level observations are now consistently added to questions and follow-up questions in both maturity and standards/requirements exports, ensuring observations are attached where relevant. [[1]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879R242-R248) [[2]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879R272-R280) [[3]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879L442-R460)

**Data Model Updates:**

* Added an `Observations` property to `AssessmentJson`, `MaturityQuestionJson`, and `StandardQuestionJson` to support direct inclusion of observations in the export. [[1]](diffhunk://#diff-3dc2f849e02a1a468109f697dcd5ff5dca2d183f217f65dd0d040eea10c41ae3R31-R32) [[2]](diffhunk://#diff-3dc2f849e02a1a468109f697dcd5ff5dca2d183f217f65dd0d040eea10c41ae3R80-R81) [[3]](diffhunk://#diff-3dc2f849e02a1a468109f697dcd5ff5dca2d183f217f65dd0d040eea10c41ae3R131-R132)
* Enhanced the `ObservationJson` class to include `AnswerId`, `Title`, and `Recommendations` fields, allowing for richer observation data and better association with answers.

**Code Cleanup:**

* Removed unused imports and obsolete code related to previous observation retrieval logic for better maintainability. [[1]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879L7) [[2]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879L20) [[3]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879L401-R425) [[4]](diffhunk://#diff-45e0477efb91ecdb63cf462825da8c46b3298835b3ccbef7d48b6fae237e7879L487-L496)

These changes improve the completeness and structure of exported assessment data, making observations more accessible and better integrated throughout the export process.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
