### PR TITLE
fix: assessment contacts email

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
@@ -206,7 +206,7 @@
             <label class="form-label" for="email">{{ t('contact.email') }}</label>
             <input class="form-control" type="email" autocomplete="off" maxlength="150" name="email" id="email"
               [(ngModel)]="contact.primaryEmail" #email="ngModel" [placeholder]="t('contact.email address')"
-              (keydown.esc)="abandonEdit()" matInput email>
+              (keydown.esc)="abandonEdit()" matInput email required>
 
             <div *ngIf="f.submitted && !email.valid" class="m-0 mt-2 alert alert-danger">Please enter a valid email
               address.</div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
@@ -110,9 +110,9 @@ export class ContactItemComponent implements OnInit {
   }
 
   isEmailValid() {
-    // allow blank/null emails as valid
-    if (!this.contact.primaryEmail) {
-      return true;
+    // require non-blank email
+    if (!this.contact.primaryEmail || this.contact.primaryEmail.trim() === '') {
+      return false;
     }
     return this.emailSvc.validAddress(this.contact.primaryEmail);
   }
@@ -226,7 +226,7 @@ export class ContactItemComponent implements OnInit {
   }
 
   existsDuplicateEmail(newEmail: string) {
-    if (!newEmail) {
+    if (!newEmail || newEmail.trim() === '') {
       return false;
     }
 


### PR DESCRIPTION
This pull request strengthens email validation for contact items by making the email field required in the UI and updating the validation logic to reject blank or whitespace-only emails. The changes ensure that users must enter a non-empty, valid email address for each contact.

**Email validation improvements:**

* The email input field in `contact-item.component.html` is now marked as `required`, enforcing the requirement at the form level.
* The `isEmailValid()` method in `contact-item.component.ts` now returns `false` for blank or whitespace-only emails, ensuring stricter validation.
* The `existsDuplicateEmail()` method in `contact-item.component.ts` is updated to treat blank or whitespace-only emails as non-duplicates, aligning with the stricter validation.