### PR TITLE
Fix parameters issues

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/PARAMETERS.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/PARAMETERS.cs
@@ -20,6 +20,10 @@ public partial class PARAMETERS
     [StringLength(500)]
     public string Parameter_Name { get; set; }
 
+    [Required]
+    [StringLength(10)]
+    public string Lang { get; set; }
+
     [InverseProperty("Parameter")]
     public virtual ICollection<PARAMETER_ASSESSMENT> PARAMETER_ASSESSMENT { get; set; } = new List<PARAMETER_ASSESSMENT>();
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ParameterSubstitution.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ParameterSubstitution.cs
@@ -111,7 +111,7 @@ namespace CSETWebCore.Helpers
         /// 
         /// </summary>
         /// <returns></returns>
-        public List<ParameterToken> GetDefaultParametersForAssessment(List<RequirementPlus> reqs)
+        public List<ParameterToken> GetDefaultParametersForAssessment(List<RequirementPlus> reqs, string lang)
         {
             List<ParameterToken> pTokens = [];
 
@@ -122,7 +122,8 @@ namespace CSETWebCore.Helpers
             // get the 'base' parameter values (parameter_name) for the requirement
             var qBaseLevel = from p in _context.PARAMETERS
                              join r in _context.PARAMETER_REQUIREMENTS on p.Parameter_ID equals r.Parameter_Id
-                             where requirementIds.Contains(r.Requirement_Id)
+                             where requirementIds.Contains(r.Requirement_Id) 
+                                && p.Lang == lang
                              select new { p, r };
 
             foreach (var b in qBaseLevel)
@@ -134,7 +135,8 @@ namespace CSETWebCore.Helpers
             var qAssessLevel = from pa in _context.PARAMETER_ASSESSMENT
                                join p in _context.PARAMETERS on pa.Parameter_ID equals p.Parameter_ID
                                join pr in _context.PARAMETER_REQUIREMENTS on p.Parameter_ID equals pr.Parameter_Id
-                               where pa.Assessment_ID == _assessmentId
+                               where pa.Assessment_ID == _assessmentId 
+                                && p.Lang == lang
                                 && requirementIds.Contains(pr.Requirement_Id)
                                select new { p, pa, pr };
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
@@ -530,12 +530,14 @@ namespace CSETWebCore.Api.Controllers
         [Route("api/ParametersForAssessment")]
         public IActionResult GetDefaultParametersForAssessment()
         {
+            var lang = _token.GetCurrentLanguage();
+
             var rm = new RequirementBusiness(_assessmentUtil, _questionRequirement, _context, _token);
             var controls = rm.GetControls().Requirements.ToList();
 
             var parmSub = new ParameterSubstitution(_context, _token);
 
-            return Ok(parmSub.GetDefaultParametersForAssessment(controls));
+            return Ok(parmSub.GetDefaultParametersForAssessment(controls, lang));
         }
 
 

--- a/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.html
+++ b/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.html
@@ -62,7 +62,7 @@
             <div [class.display-none]="p.editMode" tabindex="1" class="sub-me" (focus)="edit(p)"
               (keydown.enter)="edit(p)" (click)="edit(p)">{{p.parameterValue}}</div>
             <input #editValue [class.display-none]="!p.editMode" id="edit-{{p.parameterId}}" tabindex="1"
-              style="width: 100%" (keydown.enter)="save(p)" (blur)="save(p)" [(ngModel)]="p.parameterValue" />
+              class="form-control w-100" (keydown.enter)="save(p)" (blur)="save(p)" [(ngModel)]="p.parameterValue" />
           </td>
         </tr>
       </table>

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -2246,10 +2246,6 @@ input[type="checkbox"]+label {
   padding: 3px 0;
 }
 
-.question-row ul {
-  list-style: unset;
-}
-
 .no-bottom-border {
   border-bottom: none;
 }
@@ -2977,6 +2973,20 @@ table.assessment-documents th {
   font-size: 1rem;
   color: $primary-550;
   margin-bottom: .2rem;
+}
+
+ol.alpha-bracket {
+  list-style-type: none;
+  counter-reset: list-counter;
+}
+
+ol.alpha-bracket li {
+  counter-increment: list-counter;
+  margin-bottom: 5px;
+}
+
+ol.alpha-bracket li::before {
+  content: "[" counter(list-counter, lower-alpha) "] ";
 }
 
 

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -2258,10 +2258,6 @@ input[type="checkbox"]+label {
   padding: 3px 0;
 }
 
-.question-row ul {
-  list-style: unset;
-}
-
 .no-bottom-border {
   border-bottom: none;
 }

--- a/CSETWebNg/src/styles.css
+++ b/CSETWebNg/src/styles.css
@@ -65,26 +65,27 @@
 /* Ensure Material buttons have proper visibility */
 .mat-button, .mat-icon-button {
   background-color: transparent !important;
-  color: rgba(0,0,0,0.87) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
 }
 
 .mat-raised-button {
   background-color: #fafafa !important;
-  color: rgba(0,0,0,0.87) !important;
+  color: rgba(0, 0, 0, 0.87) !important;
   box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
 }
 
 /* Fix Material button hover states */
 .mat-button:hover, .mat-icon-button:hover {
-  background-color: rgba(0,0,0,0.04) !important;
+  background-color: rgba(0, 0, 0, 0.04) !important;
 }
 
 .mat-raised-button:hover {
   background-color: #f5f5f5 !important;
 }
+
 /*!* Override DaisyUI's layered utilities with same layer and higher specificity *!*/
 @layer utilities {
-  @supports (color: color-mix(in lab,red,red)) {
+  @supports (color: color-mix(in lab, red, red)) {
     input[type="checkbox"].tw\:toggle:not(:checked) {
       --color-base-100: #e5e7eb !important;
       background-color: #9ca3af !important;
@@ -119,5 +120,38 @@
     --color-base-content: #ffffff !important;
     --input-color: #ffffff !important;
     border-color: #015288 !important;
+  }
+
+
+
+  /* restore list formatting that Tailwind got rid of */
+  app-question-block ol, app-question-block-maturity ol {
+    list-style-type: revert;
+  }
+
+  app-question-block ul, app-question-block-maturity ul {
+    list-style-type: revert;
+  }
+  
+  
+  /* Support type attribute on lists */
+  app-question-block ol[type="A"], app-question-block-maturity ol[type="A"] {
+    list-style-type: upper-alpha !important;
+  }
+
+  app-question-block ol[type="a"], app-question-block-maturity ol[type="a"] {
+    list-style-type: lower-alpha !important;
+  }
+
+  app-question-block ol[type="i"], app-question-block-maturity ol[type="i"] {
+    list-style-type: lower-roman !important;
+  }
+
+  app-question-block ol[type="I"], app-question-block-maturity ol[type="I"] {
+    list-style-type: upper-roman !important;
+  }
+
+  app-question-block ol[type="1"], app-question-block-maturity ol[type="1"] {
+    list-style-type: decimal !important;
   }
 }

--- a/build_core.sh
+++ b/build_core.sh
@@ -80,7 +80,7 @@ ts=$(date +%Y-%m-%d_%H.%M.%S)
 
 echo 'Beginning asynchronous build processes...'
 
-echo "Build folder timestamp: $ts"
+echo -e "\nBuild folder timestamp: $ts\n"
 
 build_ng $ts | sed "s/^/NG BUILD: /" &
 
@@ -102,4 +102,5 @@ echo 'All build processes complete.'
 date
 
 echo 'CSETWeb BUILD COMPLETE'
+echo -e "\nBuild folder timestamp: $ts\n"
 


### PR DESCRIPTION
This pull request introduces support for language-specific parameters in the assessment system and improves list formatting in the Angular frontend. The backend changes ensure that parameters are filtered by language, while the frontend updates restore and enhance list styling for better readability and consistency. Minor improvements are also made to input styling and build script output.

**Backend: Language-specific parameters**
* Added a required `Lang` property to the `PARAMETERS` model to support language filtering.
* Updated `GetDefaultParametersForAssessment` and related queries to filter parameters by the current language, ensuring only relevant parameters are returned. [[1]](diffhunk://#diff-9b8ead894f9172ef8d9ca5a5159e61a2000da40abf325051f7b6fa2145d7f88aL114-R114) [[2]](diffhunk://#diff-9b8ead894f9172ef8d9ca5a5159e61a2000da40abf325051f7b6fa2145d7f88aR126) [[3]](diffhunk://#diff-9b8ead894f9172ef8d9ca5a5159e61a2000da40abf325051f7b6fa2145d7f88aR139)
* Modified the API controller to pass the current language when retrieving default parameters for assessment.

**Frontend: List formatting improvements**
* Restored and enhanced list formatting in question blocks, including support for different list types (decimal, alpha, roman) and a new `alpha-bracket` style for ordered lists. [[1]](diffhunk://#diff-8ff2fac27cbda8fe58b449e0c1721ca9ca1f338bc2bade3de9d40bd4fdaae8c5R124-R156) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R2978-R2991)
* Removed custom list-style overrides that were no longer needed, allowing default styles to apply. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L2249-L2252) [[2]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L2261-L2264)

**UI and build script enhancements**
* Improved styling of editable parameter input fields for consistency with form controls.
* Updated build script output to better highlight the build folder timestamp. [[1]](diffhunk://#diff-1633ba5c4433dc153ce574c54d9c3d672dd94321be60fac2e2474de1262e5831L83-R83) [[2]](diffhunk://#diff-1633ba5c4433dc153ce574c54d9c3d672dd94321be60fac2e2474de1262e5831R105)<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
