### PR TITLE
Fixed a few issues with heading display

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
@@ -62,7 +62,7 @@ namespace CSETWebCore.Business.Demographic
             var dbSector = _context.DETAILS_DEMOGRAPHICS.FirstOrDefault(x => x.Assessment_Id == assessmentId && x.DataItemName == "SECTOR");
             
             // do nothing if the sector is not a candidate for upgrading
-            if (dbSector == null || !HSPD7ToPPD21SectorIds.ContainsKey((int)dbSector?.IntValue))
+            if (dbSector == null || dbSector.IntValue == null || !HSPD7ToPPD21SectorIds.ContainsKey((int)dbSector.IntValue))
             {
                 return null;
             }

--- a/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.html
@@ -20,63 +20,44 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 -------------------------->
-<ng-container *ngIf="isGroupingNameVisible()">
+<ng-container *ngIf="grouping.showTitleAsHeading">
     <div class="domain-group-heading">
         {{grouping.title}}
     </div>
     <div *ngIf="grouping.description?.length > 0" class="mb-4" [innerHTML]="grouping.description">
     </div>
-
 </ng-container>
 
 
-<!-- (applies to ACET only) indicates when all maturity filters turned off for this domain -->
-<div *ngIf="allDomainMaturityLevelsHidden()"
-    class="alert-warning mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-11a">
-    <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
-    <span class="fs-base-3 p-2 d-flex flex-column justify-content-center flex-11a">
-        All maturity filters are deselected for this domain. Select one or more maturity levels to view questions.
-    </span>
-</div>
+<ng-container *ngIf="grouping.visible">
 
-<ng-container *ngIf="!allDomainMaturityLevelsHidden()">
+    <div class="capability-group-heading"
+        *ngIf="grouping.questions.length == 0 && grouping.groupingType === 'Capability'">
+        {{grouping.title}}
+    </div>
 
-    <ng-container *ngIf="grouping.visible">
+    <div class="assessment-factor-group-heading"
+        *ngIf="grouping.questions.length == 0 && grouping.groupingType === 'Assessment Factor'">
+        {{grouping.title}}
+    </div>
 
-        <div class="capability-group-heading"
-            *ngIf="grouping.questions.length == 0 && grouping.groupingType === 'Capability'">
-            {{grouping.title}}
-        </div>
+    <div *ngFor="let sg of grouping.subGroupings">
+        <app-grouping-block [grouping]="sg"></app-grouping-block>
+    </div>
+    <div *ngIf="(grouping.questions.length > 0) && assessSvc.usesMaturityModel('VADR')">
+        <app-question-block-vadr #questionBlock [myGrouping]="grouping">
+        </app-question-block-vadr>
+    </div>
+    <div *ngIf="(grouping.questions.length > 0) && !assessSvc.usesMaturityModel('VADR')">
+        <app-question-block-maturity #questionBlock [myGrouping]="grouping">
+        </app-question-block-maturity>
+    </div>
 
-        <div class="assessment-factor-group-heading"
-            *ngIf="grouping.questions.length == 0 && grouping.groupingType === 'Assessment Factor'">
-            {{grouping.title}}
-        </div>
-
-        <div *ngFor="let sg of grouping.subGroupings">
-            <app-grouping-block [grouping]="sg"></app-grouping-block>
-        </div>
-        <div *ngIf="(grouping.questions.length > 0) && assessSvc.usesMaturityModel('VADR')">
-            <app-question-block-vadr #questionBlock [myGrouping]="grouping">
-            </app-question-block-vadr>
-        </div>
-        <div
-            *ngIf="(grouping.questions.length > 0) && !assessSvc.usesMaturityModel('VADR')">
-            <app-question-block-maturity #questionBlock [myGrouping]="grouping">
-            </app-question-block-maturity>
-        </div>
-
-        <div *ngIf="isDomain() && (assessSvc.usesMaturityModel('EDM') || assessSvc.usesMaturityModel('CRR'))"
-            class="mt-4">
-            <h5 for="DomainRemarks">Remarks - {{grouping.title}}</h5>
-            <textarea [(ngModel)]="grouping.domainRemark" id="DomainRemarks" name="DomainRemarks" class="form-control"
-                appAutoSize (blur)="submitTextComment(grouping)">
+    <div *ngIf="isDomain && showDomainRemarks" class="mt-4">
+        <h5 for="DomainRemarks">Remarks - {{grouping.title}}</h5>
+        <textarea [(ngModel)]="grouping.domainRemark" id="DomainRemarks" name="DomainRemarks" class="form-control"
+            appAutoSize (blur)="submitTextComment(grouping)">
             </textarea>
-        </div>
-
-    </ng-container>
-
+    </div>
 
 </ng-container>
-
-<div *ngIf="isDomain() && isGroupingNameVisible() && grouping.visible" class="mb-5"></div>

--- a/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.ts
@@ -44,6 +44,9 @@ export class GroupingBlockComponent implements OnInit {
 
   HIDEABLE_LEVELS = [0, 1];
 
+  isDomain = false;
+  showDomainRemarks = false;
+
   /**
    *
    */
@@ -61,6 +64,11 @@ export class GroupingBlockComponent implements OnInit {
   ngOnInit(): void {
     this.modelId = this.maturityFilteringService.assesmentSvc.assessment.maturityModel?.modelId;
     this.moduleBehavior = this.configSvc.getModuleBehavior(this.modelId);
+
+    this.grouping.showTitleAsHeading = this.isGroupingNameVisible();
+
+    this.isDomain = this.grouping.groupingType === 'Domain';
+    this.showDomainRemarks = this.assessSvc.usesMaturityModel('EDM') || this.assessSvc.usesMaturityModel('CRR');
   }
 
   /**
@@ -78,21 +86,20 @@ export class GroupingBlockComponent implements OnInit {
   }
 
   /**
-   * Indicates if the grouping is a domain
-   */
-  isDomain(): boolean {
-    return this.grouping.groupingType === 'Domain';
-  }
-
-  /**
    * Indicates if the grouping name header should be shown.
    * Invisible domains stay invisible.
    */
   isGroupingNameVisible(): boolean {
+    // this prevents a group title from being displayed as a header and in the blue expandable box
+    if (this.grouping.subGroupings.length == 0) {
+      return false;
+    }
+
+
     // look for a behavior to suppress the grouping name by its type
     if (this.moduleBehavior?.hasOwnProperty('hideTopLevelGroupingName')) {
-      if ((this.moduleBehavior.hideTopLevelGroupingName ?? false) 
-          && this.HIDEABLE_LEVELS.includes(this.grouping.groupingLevel)) {
+      if ((this.moduleBehavior.hideTopLevelGroupingName ?? false)
+        && this.HIDEABLE_LEVELS.includes(this.grouping.groupingLevel)) {
         return false;
       }
     }
@@ -108,12 +115,5 @@ export class GroupingBlockComponent implements OnInit {
     }
 
     return true;
-  }
-
-  /**
-   * Indicates if all domain maturity filters have been turned off for the domain
-   */
-  allDomainMaturityLevelsHidden(): boolean {
-    return false;
   }
 }

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -60,8 +60,8 @@ export class MaturityQuestionsComponent implements OnInit, AfterViewInit, OnDest
   groupingsAreMil = false;
 
   pageTitle: string = '';
-  moduleBehavior: ModuleBehavior;
-  modelId: number;
+  moduleBehavior?: ModuleBehavior;
+  modelId?: number;
   modelName: string = '';
   groupingTitle: string = '';
   questionsAlias: string = '';

--- a/CSETWebNg/src/app/models/questions.model.ts
+++ b/CSETWebNg/src/app/models/questions.model.ts
@@ -85,6 +85,9 @@ export interface QuestionGrouping {
 
     // in CRE+, groups can be 'selected' in order to be displayed in list
     selected: boolean;
+
+    // a flag to allow titles to be hidden in some cases for a cleaner layout
+    showTitleAsHeading: boolean;
 }
 
 export interface ACETDomain {


### PR DESCRIPTION
This pull request refactors the logic and UI for displaying grouping blocks and domain remarks in the assessment questions feature. The main improvements include better control over when grouping titles are shown, simplification of conditional rendering, and improved handling of domain remarks. Several redundant methods and UI elements have been removed for clarity and maintainability.

**UI logic and conditional rendering:**

* The logic for displaying grouping titles as headings is now controlled by a new `showTitleAsHeading` property on the `QuestionGrouping` interface, set during component initialization for cleaner layout control. [[1]](diffhunk://#diff-1fce5c9ef1622d67fcf0b6b8888c02bfd83341c9807aaf92d3584abd26c8a3f8R88-R90) [[2]](diffhunk://#diff-55a017d2316672ad818f861045c1cbabc52245e2b6d9eba81af4dab3d4f766c6R67-R71)
* The template now uses `grouping.showTitleAsHeading` instead of the `isGroupingNameVisible()` method, and unnecessary conditional containers and warning messages related to domain maturity filters have been removed.

**Domain remarks handling:**

* Domain remarks are now displayed using the new `isDomain` and `showDomainRemarks` flags, set in the component based on grouping type and maturity model, simplifying the template and making the logic more explicit. [[1]](diffhunk://#diff-55a017d2316672ad818f861045c1cbabc52245e2b6d9eba81af4dab3d4f766c6R47-R49) [[2]](diffhunk://#diff-55a017d2316672ad818f861045c1cbabc52245e2b6d9eba81af4dab3d4f766c6R67-R71) [[3]](diffhunk://#diff-1c85c990ca9e6ae77e1db6d6a9bdeaf94ee7475e6076b6782b2b665706ce2d39L63-L82)

**Code cleanup and simplification:**

* Redundant methods such as `isDomain()` and `allDomainMaturityLevelsHidden()` have been removed from the component, as their logic is now handled by properties initialized in `ngOnInit`. [[1]](diffhunk://#diff-55a017d2316672ad818f861045c1cbabc52245e2b6d9eba81af4dab3d4f766c6L80-R98) [[2]](diffhunk://#diff-55a017d2316672ad818f861045c1cbabc52245e2b6d9eba81af4dab3d4f766c6L112-L118)
* Type annotations for `moduleBehavior` and `modelId` have been made optional in `MaturityQuestionsComponent` to match their usage and initialization.

**Business logic fix:**

* In the backend sector upgrade logic, an additional null check for `IntValue` ensures robust handling when determining if a sector is a candidate for upgrading.Also fixed a bug in the SectorUpgrade class.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
