### PR TITLE
 Standardize star colors using the CSET blue

### DIFF
--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -248,7 +248,7 @@ export class MyAssessmentsComponent implements OnInit {
           const assessment = params.data;
           const percentage = this.getCompletionPercentage(assessment);
           const favoriteIcon = assessment.favorite ? 'favorite' : 'favorite_border';
-          const favoriteClass = assessment.favorite ? 'tw:text-amber-500' : 'tw:text-gray-400';
+          const favoriteClass = assessment.favorite ? 'star-favorite' : 'star-inactive';
           const reviewFlag = (assessment.markedForReview || assessment.altTextMissing);
           const flagClass = reviewFlag ? 'tw:text-orange-500' : 'tw:text-gray-400';
           const tooltipText = this.getProgressTooltip(assessment);

--- a/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
+++ b/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
@@ -129,7 +129,7 @@
                   class="btn btn-circle tw:bg-white tw:border-2 tw:border-gray-300 hover:tw:bg-gray-100 gallery-btn-favorite"
                   (click)="toggleFavorite($event, c)"
                   style="margin-right:5px;">
-            <i class="fa-solid fa-star tw:scale-125 tw:inline-block tw:text-amber-500"
+            <i class="fa-solid fa-star tw:scale-125 tw:inline-block star-favorite"
                style="text-shadow: 0 0 3px currentColor"></i>
           </button>
           <button *ngIf="c.isFavorite && c.gallery_Item_Guid==hoverIndex"
@@ -137,15 +137,15 @@
                   class="btn btn-circle tw:bg-white tw:border-2 tw:border-white gallery-btn-favorite"
                   (click)="toggleFavorite($event, c)"
                   style="margin-right:5px;">
-            <i class="fa-solid fa-star tw:scale-125 tw:inline-block tw:text-amber-500"
+            <i class="fa-solid fa-star tw:scale-125 tw:inline-block star-favorite"
                style="text-shadow: 0 0 3px currentColor"></i>
           </button>
           <button *ngIf="!c.isFavorite && c.gallery_Item_Guid==hoverIndex"
                   [matTooltip]="t('tooltip.add favorite')"
-                  class="btn btn-outline-light btn-circle gallery-btn-favorite"
+                  class="btn btn-outline-light btn-circle gallery-btn-info"
                   (click)="toggleFavorite($event, c)"
                   style="margin-right:5px;">
-            <i class="fa-solid fa-star tw:scale-125 tw:inline-block tw:text-amber-500"
+            <i class="fa-solid fa-star tw:scale-125 tw:inline-block"
                style="text-shadow: 0 0 3px currentColor"></i>
           </button>
           <button [matTooltip]="t('tooltip.view detail')"

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -4143,3 +4143,9 @@ h6.dropdown-header {
   padding: 0 1rem 1rem 1rem;
   margin-top: 1rem;
 }
+.gallery-btn-favorite:hover i.fa-star {
+  color: #005288 !important;
+}
+.star-favorite {
+  color: #005288 !important;
+}

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -4131,7 +4131,9 @@ h6.dropdown-header {
 .gallery-btn-info:hover {
   color:#015288 !important;
 }
-
+.gallery-btn-favorite:hover i.fa-star {
+  color: #005288 !important;
+}
 .newinstaller {
   position: relative;
   top: -15 !important;

--- a/CSETWebNg/src/styles.css
+++ b/CSETWebNg/src/styles.css
@@ -121,6 +121,13 @@
     --input-color: #ffffff !important;
     border-color: #015288 !important;
   }
+  .star-favorite {
+    color: #005288 !important;
+  }
+
+  .star-inactive {
+    color: #9ca3af !important;
+  }
 
 
 
@@ -132,8 +139,8 @@
   app-question-block ul, app-question-block-maturity ul {
     list-style-type: revert;
   }
-  
-  
+
+
   /* Support type attribute on lists */
   app-question-block ol[type="A"], app-question-block-maturity ol[type="A"] {
     list-style-type: upper-alpha !important;


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
- Aligned search bar with Categories menu using Tailwind padding classes
- Changed star icons from amber to CSET blue (#005288) to match header and improve visual separation from orange flag
- Created reusable `.star-favorite` CSS class for consistent star styling across all components
- Fixed favorite toggle to immediately update filtered view when unfavoriting items
- Added hover effect to gallery favorite button (star turns blue on hover)
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
