### PR TITLE
Moved assessor mode switch to consistent location

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -73,12 +73,8 @@
     <div class="row mb-4">
       <div class="col-6">
         <label for="name" class="form-label me-2">{{t('pcii requested')}}</label>
-        <input type="checkbox"
-        name="isPCII"
-        id="isPCII"
-        [checked]="assessment.is_PCII"
-        (change)="changeIsPCII(!assessment.is_PCII)"
-        class="tw:toggle">
+        <input type="checkbox" name="isPCII" id="isPCII" [checked]="assessment.is_PCII"
+          (change)="changeIsPCII(!assessment.is_PCII)" class="tw:toggle">
       </div>
       <div class="col-6" *ngIf="IsPCII">
         <label class="form-label" for="name">{{t('pcii number')}}</label>
@@ -100,23 +96,20 @@
     <div class="mt-4">
       <h4>{{ t('assessment settings') }}</h4>
 
-      <div *ngIf="this.configSvc.userIsCisaAssessor; else nonassessor" class="mb-3">
+      <div *ngIf="this.configSvc.userIsCisaAssessor; else nonassessor" class="mb-4">
         <label class="me-2">{{t('assessor workflow.control label')}}</label>
-        <input type="checkbox"
-               name="assessorMode"
-               id="assessorMode"
-               [checked]="assessment.assessorMode"
-               (change)="updateAssessorMode()"
-               class="tw:toggle">
+        <input type="checkbox" name="assessorMode" id="assessorMode" [checked]="assessment.assessorMode"
+          (change)="updateAssessorMode()" class="tw:toggle">
         <label class="form-label fst-italic">{{t('assessor workflow.assessor workflow explanation')}}</label>
       </div>
-      <ng-template #nonassessor class="mb-3">
+
+      <ng-template #nonassessor class="mb-4">
         <p>
           {{ t('assessor workflow.non assessor explanation') }}
         </p>
       </ng-template>
 
-      <div class="mb-5">
+      <div class="mb-4">
         <label class="form-label" for="techDomain">{{t('tech domain.label')}}</label>
         <select class="form-select" id="techDomain" tabindex="0" name="techDomain" (change)="updateDemographics()"
           [(ngModel)]="demographics.techDomain">
@@ -127,11 +120,18 @@
         </select>
       </div>
 
+      <div class="mb-4">
+        <label for="self-assessment" class="form-label tw:mr-3">{{ t('self assessment') }}</label>
+        <input type="checkbox" name="self-assessment" id="self-assessment" [(ngModel)]="demographics.selfAssessment"
+          [checked]="demographics.selfAssessment" (change)="updateDemographics()" class="tw:toggle">
+      </div>
+
     </div>
 
     <div class="mt-4">
       <app-assessment-contacts (triggerChange)="refreshContacts()"></app-assessment-contacts>
     </div>
+
     <hr class="w-100 hr-sal my-4" />
 
     <div *ngIf="showFacilitator()" class="mb-4">
@@ -142,13 +142,6 @@
         <option *ngFor="let contact of contacts" [value]="contact.assessmentContactId">{{contact.firstName}}
           {{contact.lastName}}</option>
       </select>
-      <div class="mt-4">
-        <label for="self-assessment" class="tw:mr-3">{{ t('self assessment') }}</label>
-        <input type="checkbox" name="self-assessment" id="self-assessment"
-          [(ngModel)]="demographics.selfAssessment" [checked]="demographics.selfAssessment"
-          (change)="updateDemographics()" class="tw:toggle">
-
-      </div>
     </div>
 
     <div class="row mb-4">

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
@@ -71,7 +71,8 @@
         </div>
 
         <!-- show SSG sector selection control for CPG2 assessments -->
-        <div class="row mb-4" *ngIf="assessSvc.assessment?.maturityModel?.modelId == 21 || assessSvc.assessment?.maturityModel?.modelId == 11">
+        <div class="row mb-4"
+            *ngIf="assessSvc.assessment?.maturityModel?.modelId == 21 || assessSvc.assessment?.maturityModel?.modelId == 11">
             <label class="form-label">{{ t('titles.ssg.1') }}</label>
             <app-ssg-selector [value]="demographicData.ssgSectorIds" [sectorList]="sectorsList"
                 (valueChange)="onChangeSsg($event)"></app-ssg-selector>
@@ -104,17 +105,8 @@
                 <option *ngFor="let contact of contacts" [ngValue]="contact.assessmentContactId">{{contact.firstName}}
                     {{contact.lastName}}</option>
             </select>
-          <div class="mt-4">
-            <span class="tw:mr-3">{{ t('self assessment') }}</span>
-
-            <input type="checkbox"
-                   name="self-assessment"
-                   id="self-assessment"
-                   [(ngModel)]="demographicData['selfAssessment']"
-                   (change)="update($event)"
-                   class="tw:toggle">
-          </div>
         </div>
+
         <div *ngIf="showOrganizationName()" class="mb-3">
             <label class="form-label" for="edmOrganizationName">{{t('org name')}}</label>
             <input class="form-control" autocomplete="off" tabindex="0" type="text" maxlength="150"

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -78,18 +78,14 @@
     <div class="mt-4">
         <h4>{{ t('assessment settings') }}</h4>
 
-        <div *ngIf="this.configSvc.userIsCisaAssessor" class="mb-3">
+        <div *ngIf="this.configSvc.userIsCisaAssessor" class="mb-4">
             <label class="me-2">{{t('assessor workflow.control label')}}</label>
-          <input type="checkbox"
-                 name="assessorMode"
-                 id="assessorMode"
-                 [checked]="assessment.assessorMode"
-                 (change)="updateAssessorMode()"
-                 class="tw:toggle">
+            <input type="checkbox" name="assessorMode" id="assessorMode" [checked]="assessment.assessorMode"
+                (change)="updateAssessorMode()" class="tw:toggle">
             <label class="form-label fst-italic">{{t('assessor workflow.assessor workflow explanation')}}</label>
         </div>
 
-        <div class="mb-5">
+        <div class="mb-4">
             <label class="form-label" for="techDomain">{{t('tech domain.label')}}</label>
             <select class="form-select" id="techDomain" tabindex="0" name="techDomain" (change)="updateDemographics()"
                 [(ngModel)]="demographics.techDomain">
@@ -98,6 +94,12 @@
                 <option value="IT">{{t('tech domain.it')}}</option>
                 <option value="OT+IT">{{t('tech domain.ot+it')}}</option>
             </select>
+        </div>
+
+        <div class="mb-4">
+            <label for="self-assessment" class="form-label tw:mr-3">{{ t('self assessment') }}</label>
+            <input type="checkbox" name="self-assessment" id="self-assessment"
+                [(ngModel)]="demographics.selfAssessment" (change)="updateDemographics()" class="tw:toggle">
         </div>
 
     </div>

--- a/CSETWebNg/src/styles.css
+++ b/CSETWebNg/src/styles.css
@@ -121,6 +121,7 @@
     --input-color: #ffffff !important;
     border-color: #015288 !important;
   }
+
   .star-favorite {
     color: #005288 !important;
   }
@@ -128,44 +129,22 @@
   .star-inactive {
     color: #9ca3af !important;
   }
-
-
-
-  /* restore list formatting that Tailwind got rid of */
-  app-question-block ol, app-question-block-maturity ol {
-    list-style-type: revert;
-  }
-
-  app-question-block ul, app-question-block-maturity ul {
-    list-style-type: revert;
-  }
-
-
-  /* Support type attribute on lists */
-  app-question-block ol[type="A"], app-question-block-maturity ol[type="A"] {
-    list-style-type: upper-alpha !important;
-  }
-
-  app-question-block ol[type="a"], app-question-block-maturity ol[type="a"] {
-    list-style-type: lower-alpha !important;
 }
 
 /* restore default list styling that tailwind removed */
-@layer base {
-  ol,
-  ul {
-    list-style: revert;
-  }
+ol,
+ul {
+  list-style: revert;
+}
 
-  ol[type="a"] {
-    list-style-type: lower-alpha;
-  }
+ol[type="a"] {
+  list-style-type: lower-alpha;
+}
 
-  ol[type="i"] {
-    list-style-type: lower-roman;
-  }
+ol[type="i"] {
+  list-style-type: lower-roman;
+}
 
-  ol[type="1"] {
-    list-style-type: decimal;
-  }
+ol[type="1"] {
+  list-style-type: decimal;
 }


### PR DESCRIPTION
This pull request primarily refactors the assessment configuration and demographics components to improve the UI layout and streamline the handling of the "self assessment" checkbox. It also cleans up redundant or conflicting CSS rules related to list formatting. The most important changes are outlined below.

**Assessment Configuration and Demographics UI Improvements**

* Moved the "self assessment" checkbox from the demographics section to the assessment settings section in both `assessment-config-iod.component.html` and `assessment-detail.component.html`, ensuring it is grouped logically with other assessment settings. [[1]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7R123-R134) [[2]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L145-L151) [[3]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafR99-R104) [[4]](diffhunk://#diff-882f17effcfab62f0b0ecb90df14b502877479b56995555cc679389f859c50c0L107-R109)
* Updated margin classes from `mb-3`/`mb-5` to `mb-4` for consistency across assessment settings sections and templates. [[1]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L103-R112) [[2]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL81-R88)
* Minor formatting improvements to checkbox and input elements for better code readability and maintainability. [[1]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L76-R77) [[2]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L103-R112) [[3]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL81-R88)

**CSS Cleanup and List Formatting**

* Removed redundant custom CSS rules for list styling in `src/styles.css` and restored default list formatting using the `@layer base` approach, resolving conflicts with Tailwind's resets. [[1]](diffhunk://#diff-8ff2fac27cbda8fe58b449e0c1721ca9ca1f338bc2bade3de9d40bd4fdaae8c5R124-L154) [[2]](diffhunk://#diff-8ff2fac27cbda8fe58b449e0c1721ca9ca1f338bc2bade3de9d40bd4fdaae8c5L171)

**Other Minor Improvements**

* Improved code formatting for conditional rendering in the demographics component for SSG sector selection.Moved it to a consistent location for both workflows

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
