### PR TITLE
Improves dark mode icons

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.html
@@ -22,38 +22,39 @@
 -------------------------->
 <div #questionExtras *transloco="let t" class="extras-block">
     <div class="d-flex justify-items-center">
-        <button *ngIf="myQuestion.is_Component" class="extras-button cursor-pointer"
+        <button *ngIf="myQuestion.is_Component" class="extras-button cursor-pointer icon-color"
             style="padding-left: 4px; padding-top: 4px" [class.active]="mode == 'COMPONENT'"
             (click)="toggleExtras('COMPONENT')" [matTooltip]="Components" matTooltipPosition="above">
             <svg viewBox="0 0 30 30" style="height: 31px; width: 31px; margin: auto;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.75)"
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.75)"
                     d="M28,7.566L28,16.38 28,23.15 28,31.962C28,33.637,26.625,35,24.936,35L7.633,35C6.732,35,5.921,34.611,5.36,33.994L4.678,33.316 4.575,33.316 2.957,31.713 2.314,31.076 2.314,30.969 1.069,29.731C0.951,29.631,0.839,29.52,0.739,29.403L0.727,29.394 0.73,29.394C0.276,28.863,0,28.18,0,27.432L0,18.62 0,11.848 0,3.036C0,1.361,1.372,0,3.062,0L8.052,0 8.052,0.095C6.725,0.427,5.738,1.619,5.738,3.036L5.738,3.201 5.738,4.311 5.738,19.02 7.646,17.401 9.751,19.02 9.751,4.311 9.751,3.201 9.751,3.036C9.751,1.361,11.123,0,12.812,0L20.367,0C22.052,0,23.429,1.361,23.429,3.036L23.429,11.848 23.429,18.62 23.429,27.432C23.429,29.107,22.057,30.47,20.367,30.47L4.913,30.47 6.167,31.713 7.213,32.751 22.668,32.751C24.357,32.751,25.729,31.388,25.729,29.713L25.729,20.901 25.729,15.085 25.729,14.128 25.729,5.317 25.729,4.639C27.033,4.987,28,6.165,28,7.566" />
             </svg>
         </button>
 
-        <button *ngIf="displayIcon('DETAIL') && !myQuestion.is_Component" class="extras-button cursor-pointer"
+        <button *ngIf="displayIcon('DETAIL') && !myQuestion.is_Component" class="extras-button cursor-pointer icon-color"
             style="padding-left: 7px; padding-top: 4px" [class.active]="mode == 'DETAIL'"
             (click)="toggleExtras('DETAIL')" [matTooltip]="t('tooltip.details standard')" matTooltipPosition="above">
             <svg viewBox="0 0 32 32" style="height: 31px; width: 31px; margin: auto;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.75)"
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.75)"
                     d="M28,7.566L28,16.38 28,23.15 28,31.962C28,33.637,26.625,35,24.936,35L7.633,35C6.732,35,5.921,34.611,5.36,33.994L4.678,33.316 4.575,33.316 2.957,31.713 2.314,31.076 2.314,30.969 1.069,29.731C0.951,29.631,0.839,29.52,0.739,29.403L0.727,29.394 0.73,29.394C0.276,28.863,0,28.18,0,27.432L0,18.62 0,11.848 0,3.036C0,1.361,1.372,0,3.062,0L8.052,0 8.052,0.095C6.725,0.427,5.738,1.619,5.738,3.036L5.738,3.201 5.738,4.311 5.738,19.02 7.646,17.401 9.751,19.02 9.751,4.311 9.751,3.201 9.751,3.036C9.751,1.361,11.123,0,12.812,0L20.367,0C22.052,0,23.429,1.361,23.429,3.036L23.429,11.848 23.429,18.62 23.429,27.432C23.429,29.107,22.057,30.47,20.367,30.47L4.913,30.47 6.167,31.713 7.213,32.751 22.668,32.751C24.357,32.751,25.729,31.388,25.729,29.713L25.729,20.901 25.729,15.085 25.729,14.128 25.729,5.317 25.729,4.639C27.033,4.987,28,6.165,28,7.566" />
             </svg>
         </button>
 
         <button *ngIf="true || displayIcon('SUPP')" id="btn_SUPP_{{ myQuestion.questionId }}"
-            class="extras-button cursor-pointer" style="padding-left: 4px; padding-top: 4px"
+            class="extras-button cursor-pointer icon-color" style="padding-left: 4px; padding-top: 0px"
             [class.active]="mode == 'SUPP'" (click)="toggleExtras('SUPP')"
             [matTooltip]="t('tooltip.supplemental guidance')" matTooltipPosition="above">
-            <svg *ngIf="whichSupplementalIcon() == 'I'" viewBox="0 0 31 31" style="height: 31px; width: 31px;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.75)"
+
+            <svg *ngIf="whichSupplementalIcon() == 'I'" viewBox="0 0 31 31" style="height: 31px; width: 31px; margin-top: 4px">
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.75)"
                     d="M18.879,29.328C17.64,29.934 16.341,30.24 14.986,30.24 14.044,30.24 13.424,29.824 13.125,28.99 12.927,28.434 13.014,27.26 13.386,25.472L15.071,17.634C15.214,16.934 15.287,16.422 15.287,16.09 15.287,15.614 15.063,15.364 14.615,15.336L13.088,15.228C12.989,15.05 12.945,14.794 12.958,14.466 12.972,14.134 13.039,13.892 13.164,13.74 15.756,13.402 17.941,13.236 19.718,13.236 20.239,13.236 20.499,13.506 20.499,14.044 20.499,14.24 20.462,14.516 20.384,14.868 20.308,15.22 20.206,15.686 20.077,16.27 19.949,16.85 19.846,17.31 19.772,17.65L18.119,25.136C17.758,26.69 17.807,27.464 18.263,27.464 18.49,27.464 18.877,27.294 19.429,26.954 19.981,26.612 20.487,26.19 20.948,25.682 21.171,25.682 21.391,25.802 21.608,26.042 21.825,26.286 21.971,26.518 22.045,26.74 21.175,27.856 20.121,28.718 18.879,29.328 M16.841,5.47C17.307,4.998 17.962,4.764 18.804,4.764 19.538,4.764 20.133,5.024 20.592,5.546 21.052,6.068 21.281,6.652 21.281,7.296 21.281,7.856 21.028,8.388 20.518,8.896 20.008,9.406 19.363,9.66 18.582,9.66 17.849,9.66 17.26,9.404 16.812,8.888 16.365,8.374 16.142,7.788 16.142,7.126 16.142,6.496 16.375,5.942 16.841,5.47 M17.5,0C7.835,0 0,7.834 0,17.5 0,27.164 7.835,35 17.5,35 27.166,35 35,27.164 35,17.5 35,7.834 27.166,0 17.5,0" />
             </svg>
 
-            <svg *ngIf="whichSupplementalIcon() == 'G'" x="0px" y="0px"
+            <svg *ngIf="whichSupplementalIcon() == 'G'" x="0px" y="0px" class="icon-color"
                 style="height: 31px; width: 31px; margin: auto; margin-left: -2px" viewBox="0 0 120 120">
-                <circle fill="#044" cx="60" cy="60" r="53" />
+                <circle fill="currentColor" cx="60" cy="60" r="53" />
                 <g>
-                    <path fill="#FFFFFF" d="M81.174,83.004c-2.611,1.258-5.479,2.238-8.598,2.938c-3.121,0.701-6.713,1.053-10.777,1.053
+                    <path fill="var(--icon-accent)" d="M81.174,83.004c-2.611,1.258-5.479,2.238-8.598,2.938c-3.121,0.701-6.713,1.053-10.777,1.053
                   c-4.161,0-7.958-0.666-11.393-1.996c-3.436-1.33-6.386-3.193-8.853-5.588c-2.468-2.395-4.391-5.248-5.77-8.562
                   c-1.379-3.313-2.068-6.978-2.068-10.994c0-4.111,0.714-7.825,2.141-11.139c1.427-3.313,3.386-6.132,5.878-8.454
                   c2.491-2.322,5.431-4.112,8.817-5.37c3.386-1.257,7.062-1.887,11.031-1.887c4.111,0,7.873,0.593,11.283,1.778
@@ -71,51 +72,50 @@
             [class.active]="mode == 'CMNT'" (click)="toggleExtras('CMNT')"
             [matTooltip]="has('CMNT')==='inline' ? t('tooltip.comments with content'):t('tooltip.comment')"
             matTooltipPosition="above">
-            <svg viewBox="0 0 32 32" style="height: 31px; width: 32px;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.8)"
+            <svg viewBox="0 0 32 32" style="height: 31px; width: 32px;" class="icon-color">
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.8)"
                     d="M5.523,11.864C5.523,10.271 6.6,9.151 8.173,9.151 9.746,9.151 10.869,10.271 10.869,11.864 10.869,13.413 9.79,14.576 8.219,14.576 6.556,14.576 5.523,13.413 5.523,11.864 M14.827,11.864C14.827,10.271 15.905,9.151 17.478,9.151 19.05,9.151 20.174,10.271 20.174,11.864 20.174,13.413 19.094,14.576 17.523,14.576 15.861,14.576 14.827,13.413 14.827,11.864 M24.132,11.864C24.132,10.271 25.209,9.151 26.782,9.151 28.355,9.151 29.478,10.271 29.478,11.864 29.478,13.413 28.399,14.576 26.828,14.576 25.165,14.576 24.132,13.413 24.132,11.864 M0,3.332L0,20.394C0,22.227,1.565,23.726,3.477,23.726L7.42,23.726 7.42,33 15.455,23.726 31.524,23.726C33.436,23.726,35,22.227,35,20.394L35,3.332C35,1.499,33.436,0,31.524,0L3.477,0C1.565,0,0,1.499,0,3.332" />
-                <circle cx="27" cy="7" r="6" stroke="#fff" stroke-width="1" fill="#900" [style.display]="has('CMNT')"
-                    class="test" />
+                <circle cx="27" cy="7" r="6" class="red-dot" [style.display]="has('CMNT')" />
             </svg>
         </button>
 
-        <button *ngIf="displayIcon('DOCS')" class="extras-button cursor-pointer"
+        <button *ngIf="displayIcon('DOCS')" class="extras-button cursor-pointer icon-color"
             style="padding-top: 4px; padding-left: 4px;" [class.active]="mode == 'DOCS'" (click)="toggleExtras('DOCS')"
             [matTooltip]="has('DOCS')==='inline'? t('tooltip.artifacts documents with content'):t('tooltip.artifacts documents')"
             matTooltipPosition="above">
             <svg viewBox="0 0 25 30" style="height: 31px; width: 31px;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.7)"
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.7)"
                     d="M19.495,0L19.495,8.726 28.221,8.726z M0,0.202L0,35 28.02,35 28.02,11.522 16.7,11.522 16.7,0.202z M5.729,16.483L22.08,16.483 22.08,19.558 5.729,19.558z M5.729,21.654L22.08,21.654 22.08,24.728 5.729,24.728z M5.729,26.825L22.08,26.825 22.08,29.899 5.729,29.899z" />
-                <circle cx="23" cy="7" r="6" stroke="#fff" stroke-width="1" fill="#900" [style.display]="has('DOCS')" />
+                <circle cx="23" cy="7" r="6" class="red-dot" [style.display]="has('DOCS')" />
             </svg>
         </button>
 
-        <button *ngIf="displayIcon('REFS')" class="extras-button cursor-pointer"
+        <button *ngIf="displayIcon('REFS')" class="extras-button cursor-pointer icon-color"
             style="padding-top: 4px; padding-left: 5px;" [class.active]="mode == 'REFS'" (click)="toggleExtras('REFS')"
             [matTooltip]="t('tooltip.references')" matTooltipPosition="above">
             <svg viewBox="0 0 30 30" style="height: 31px; width: 31px;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(.4)"
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(.4)"
                     d="M27,20.681L20,20.681 20,4.681 27,4.681z M17,60.681L30,60.681 30,0.681 17,0.681z M45.974,20.131L39.182,21.827 35.307,6.303 42.098,4.607z M31.427,3.149L45.96,61.362 58.573,58.213 44.039,0z M10,20.681L3,20.681 3,4.681 10,4.681z M0,60.681L13,60.681 13,0.681 0,0.681z" />
             </svg>
         </button>
 
-        <button *ngIf="displayIcon('OBSV')" class="extras-button cursor-pointer"
+        <button *ngIf="displayIcon('OBSV')" class="extras-button cursor-pointer icon-color"
             style="padding-top: 1px; padding-left: 8px;" [class.active]="mode == 'OBSV' " (click)="toggleExtras('OBSV')"
             [matTooltip]="has('OBSV')==='inline'? t('tooltip.'+observationOrIssue().toLowerCase()+'s with content')
                 : t('tooltip.'+observationOrIssue().toLowerCase()+'s')" matTooltipPosition="above">
             <svg viewBox="0 3 26 33" xmlns="http://www.w3.org/2000/svg" style="height: 31px; width: 20px;">
-                <path fill="#044" stroke="transparent" stroke-width="0" transform="scale(1)"
+                <path fill="currentColor" stroke="transparent" stroke-width="0" transform="scale(1)"
                     d="M17.479,17.533L17.118,17.717C16.347,18.107,15.869,18.82,15.869,19.575L15.869,19.924 15.85,19.924 15.85,26.23 8.852,26.23 8.852,19.453C8.852,18.707,8.403,18.023,7.657,17.624L7.304,17.438C4.463,15.923 2.763,13.335 2.763,10.511 2.763,8.331 3.774,6.279 5.615,4.729 7.453,3.177 9.894,2.328 12.487,2.328 15.077,2.328 17.517,3.177 19.355,4.727 21.195,6.276 22.203,8.329 22.203,10.511 22.203,13.411 20.439,16.037 17.479,17.533 M17.047,10.111L14.794,11.241C14.76,11.177 13.964,9.66 12.343,9.66 10.71,9.66 9.879,11.19 9.844,11.254L7.604,10.093C7.668,9.973 9.152,7.13 12.343,7.13 15.546,7.13 16.986,9.986 17.047,10.111 M21.307,3.081C18.948,1.093 15.814,0 12.487,0 5.601,0 0,4.716 0,10.511 0,14.137 2.179,17.462 5.829,19.406 5.829,19.406 5.987,19.489 6.086,19.543L6.086,19.924 6.019,19.924 6.019,31.583C6.019,32.084,6.424,32.49,6.925,32.49L8.168,32.49 8.803,32.49 9.172,32.49 9.172,34.093C9.172,34.594,9.578,35,10.079,35L14.891,35C15.392,35,15.798,34.594,15.798,34.093L15.798,32.49 15.85,32.49 17.728,32.49C18.228,32.49,18.634,32.084,18.634,31.583L18.634,26.654 18.634,19.924 18.634,19.667C18.737,19.613 18.904,19.532 18.904,19.532 22.702,17.607 24.97,14.236 24.97,10.511 24.97,7.708 23.668,5.066 21.307,3.081" />
-                <circle cx="20" cy="7" r="6" stroke="#fff" stroke-width="1" fill="#900" [style.display]="has('OBSV')" />
+                <circle cx="20" cy="7" r="7" class="red-dot" [style.display]="has('OBSV')" />
             </svg>
         </button>
 
-        <button *ngIf="displayIcon('FDBK')" class="extras-button cursor-pointer"
+        <button *ngIf="displayIcon('FDBK')" class="extras-button cursor-pointer icon-color"
             style="padding-top: 0px; padding-left: 2px;" [class.active]="mode == 'FDBK'" (click)="toggleExtras('FDBK')"
             [matTooltip]="has('FDBK')==='inline'?t('tooltip.feedback with content'):t('tooltip.feedback')"
             matTooltipPosition="above">
             <svg style="height: 31px; width: 31px;" viewBox="44 44 33 33">
-                <path id="Bubble" fill="#004444" d="M69.051,51.771h-0.027l-2.75,4.554h0.834c0.369,0,0.668,0.298,0.668,0.666
+                <path id="Bubble" fill="currentColor" d="M69.051,51.771h-0.027l-2.75,4.554h0.834c0.369,0,0.668,0.298,0.668,0.666
       s-0.299,0.667-0.668,0.667h-1.64l-1.072,1.775h2.712c0.369,0,0.668,0.299,0.668,0.667s-0.299,0.667-0.668,0.667H63.59l-1.074,1.778
       h4.592c0.369,0,0.668,0.298,0.668,0.665c0,0.368-0.299,0.667-0.668,0.667h-5.481l-3.513,2.792l-2.095,1.664l0.49-2.63l0.34-1.826
       h-3.956c-0.369,0-0.667-0.299-0.667-0.667c0-0.367,0.297-0.665,0.667-0.665h4.204l0.24-1.289l0.033-0.179l0.094-0.155l0.093-0.154
@@ -124,8 +124,7 @@
       v12.326c0,1.338,1.089,2.428,2.426,2.428h2.757v5.701c0,0.281,0.178,0.534,0.444,0.627c0.074,0.025,0.148,0.037,0.222,0.037
       c0.198,0,0.39-0.087,0.519-0.246l4.955-6.119h9.205c1.338,0,2.426-1.09,2.426-2.428V54.196
       C71.477,52.858,70.389,51.771,69.051,51.771z" />
-                <circle cx="73" cy="58" r="6" stroke="#fff" stroke-width="1" fill="#900" [style.display]="has('FDBK')"
-                    class="test" />
+                <circle cx="73" cy="58" r="6" class="red-dot" [style.display]="has('FDBK')" />
                 <g id="Edit_Pencil">
                     <rect id="Eraser" x="68.775" y="44.493"
                         transform="matrix(-0.5161 0.8565 -0.8565 -0.5161 144.7513 10.3737)" fill="#004444" width="1.34"
@@ -344,10 +343,10 @@
                     <td>
                         <div class="text-nowrap">
                             <!-- Related Questions Button -->
-                            <button (click)="showRelatedQuestions(doc)" class="btn cset2-icons-q"
+                            <button (click)="showRelatedQuestions(doc)" class="btn cset2-icons-q icon-color"
                                 *ngIf="!tab?.isMaturity" [matTooltip]="t('tooltip.related questions')"
                                 matTooltipPosition="above" style="width: 46px; height: 46px; padding: 0; 
-                                    color: #285464; font-size: 1.5rem;
+                                    font-size: 1.5rem;
                                     cursor: pointer; background-color: transparent;
                                     display: inline-flex; align-items: center; justify-content: center;" tabindex="0">
                             </button>
@@ -356,15 +355,15 @@
                                 [matTooltip]="t('tooltip.delete document')" matTooltipPosition="above" style="width: 46px; height: 46px; padding: 0;
                                     margin-left: 1rem; margin-right: 1rem;
                                     display: inline-flex; align-items: center; justify-content: center;" tabindex="0">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 27 35">
-                                    <path fill="#285464"
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 27 35" class="icon-color">
+                                    <path fill="currentColor"
                                         d="M25.39,1.892L17.679,1.892 17.679,1.702C17.679,0.762,16.902,0,15.943,0L11.058,0C10.099,0,9.321,0.762,9.321,1.702L9.321,1.892 1.61,1.892C0.691,1.892,0,2.701,0,3.603L0,5.675 27,5.675 27,3.603C27,2.701,26.309,1.892,25.39,1.892 M21.857,10.405L17.679,10.405 17.679,31.531 21.857,31.531z M15.429,10.405L11.25,10.405 11.25,31.531 15.429,31.531z M9,10.405L4.821,10.405 4.821,31.531 9,31.531z M25.705,7.568L24.429,33.297C24.429,34.237,23.652,35,22.693,35L4.308,35C3.349,35,2.571,34.237,2.571,33.297L1.296,7.568z" />
                                 </svg>
                             </button>
                             <!-- Export/Copy Button -->
-                            <button (click)="download(doc)" class="btn cset-icons-export-up"
+                            <button (click)="download(doc)" class="btn cset-icons-export-up icon-color"
                                 [matTooltip]="t('tooltip.copy document')" matTooltipPosition="above" style="width: 46px; height: 46px; padding: 0;
-                                color: #285464; font-size: 1.5rem;
+                                font-size: 1.5rem;
                                 cursor: pointer; background-color: transparent;
                                 display: inline-flex; align-items: center; justify-content: center;" tabindex="0">
                             </button>
@@ -374,15 +373,15 @@
                                 matTooltipPosition="above" style="width: 46px; height: 46px; padding: 0;
                                     margin-left: 1rem;
                                     display: inline-flex; align-items: center; justify-content: center;">
-                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none"
-                                    xmlns="http://www.w3.org/2000/svg" stroke="#285464" stroke-width="2"
+                                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" class="icon-color"
+                                    xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="2"
                                     stroke-linecap="round" stroke-linejoin="round">
                                     <circle cx="12" cy="12" r="10" />
                                     <path
                                         d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
                                     <path d="M2 12h20" />
                                     <g *ngIf="doc.isGlobal" transform="scale(0.5) translate(23, 23)">
-                                        <circle cx="12" cy="12" r="12" fill="#285464" />
+                                        <circle cx="12" cy="12" r="12" fill="currentColor" />
                                         <path d="M6 12l4 4 8-8" stroke="white" stroke-width="2" stroke-linecap="round"
                                             stroke-linejoin="round" />
                                     </g>

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -136,6 +136,7 @@ $validation-color: red;
 // Oranges
 $local-install-background-color: #ffc107;
 $bg-debug-highlight: #fbe1c2;
+$bg-debug-highlight-dark: #835825;
 $bc-filters-engaged: #f9ce15;
 
 // Answer Options
@@ -511,49 +512,53 @@ label[required]::after {
   margin: 1em 0 .5em 2em;
 }
 
- // Dark mode
-  .dark-theme, [data-theme="dark"], [data-bs-theme="dark"] {
+// Dark mode
+.dark-theme,
+[data-theme="dark"],
+[data-bs-theme="dark"] {
 
-    .assessment-header{
-      background-color: var(--bg-secondary);
-      color: var(--text-primary);
-    }
+  .assessment-header {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+  }
 
-    ::ng-deep .mat-drawer-container{
-      background-color: var(--bg-primary) !important;
-    }
+  ::ng-deep .mat-drawer-container {
+    background-color: var(--bg-primary) !important;
+  }
 
-    .white-panel {
-      background-color: var(--bg-secondary);
-      color: var(--text-primary);
-      scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+  .white-panel {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
 
-      &::-webkit-scrollbar-thumb {
-        background: rgba(255, 255, 255, 0.3);
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
 
-        &:hover {
-          background: rgba(255, 255, 255, 0.4);
-        }
-      }
-     
-    }
-     .white-panel-body-long{
-        background-color: var(--bg-secondary);
-        color: var(--text-primary);
-        scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-
-        &::-webkit-scrollbar-thumb {
-          background: rgba(255, 255, 255, 0.3);
-
-        &:hover {
-          background: rgba(255, 255, 255, 0.4);
-        }
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
       }
     }
-    .white-panel-controls{
-      background-color: var(--bg-secondary);
+
+  }
+
+  .white-panel-body-long {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
     }
   }
+
+  .white-panel-controls {
+    background-color: var(--bg-secondary);
+  }
+}
 
 .white-panel-controls {
   background-color: var(--bg-secondary);
@@ -1353,6 +1358,16 @@ table.td-align-top td {
   color: $white;
 }
 
+.dark-theme {
+  .btn-level {
+    background-color: $gray-700;
+  }
+
+  .btn-level:hover {
+    background-color: $gray-800;
+  }
+}
+
 .btn-geo {
   background-color: $gray-150;
   color: $primary-850;
@@ -1533,6 +1548,10 @@ ul.mat-tree-node {
   padding: 3px 4px;
   border-radius: 0.3rem;
   margin-left: .5rem;
+}
+
+.dark-theme .debug-highlight {
+  background-color: $bg-debug-highlight-dark;
 }
 
 /* --- spinner styles -- */
@@ -2543,17 +2562,43 @@ tooltip.glossary-definition.tooltip-left::after {
 }
 
 .extras-button.active {
-  background-color: $gray-50;
+  background-color: var(--bg-secondary);
   border: 3px solid $primary-450;
 }
 
 .extras-button:focus {
-  background-color: $gray-50;
+  background-color: var(--bg-secondary);
   border: 3px solid $primary-250;
 }
 
 .extras-button.empty {
   display: none;
+}
+
+.icon-color {
+  color: $primary-800;
+  --icon-accent: var(--bg-secondary)
+}
+
+.red-dot {
+  stroke: var(--bg-secondary);
+  stroke-width: 1;
+  fill: #cc0000;
+}
+
+
+.dark-theme {
+
+  .extras-button.active {
+    background-color: var(--bg-secondary);
+    border: 3px solid $primary-450;
+  }
+
+  .icon-color {
+    color: $gray-450;
+    --icon-accent: var(--bg-secondary)
+  }
+
 }
 
 .reqlabel {
@@ -2656,7 +2701,7 @@ ul.related-questions li {
 // Assessment Cpmponent
 ///////////////////////////////////////////////////////////////////////
 
-.mat-drawer{
+.mat-drawer {
   border-top-right-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
 }
@@ -4328,6 +4373,7 @@ h6.dropdown-header {
 .star-favorite {
   color: #005288 !important;
 }
+
 .dark-theme .btn-app-mode,
 [data-theme="dark"] .btn-app-mode,
 [data-bs-theme="dark"] .btn-app-mode {
@@ -4335,11 +4381,13 @@ h6.dropdown-header {
   border-color: var(--cset-primary);
   color: var(--text-primary);
 }
+
 .dark-theme .btn-app-mode:hover,
 [data-theme="dark"] .btn-app-mode:hover,
 [data-bs-theme="dark"] .btn-app-mode:hover {
   background-color: var(--bg-tertiary);
 }
+
 .dark-theme .btn-app-mode.active,
 [data-theme="dark"] .btn-app-mode.active,
 [data-bs-theme="dark"] .btn-app-mode.active {
@@ -4353,7 +4401,9 @@ h6.dropdown-header {
 [data-bs-theme="dark"] {
 
   // Default state - transparent background
-  .btn-yes, .btn-no, .btn-na,
+  .btn-yes,
+  .btn-no,
+  .btn-na,
   .answer-group .btn-alt,
   .answer-group .btn-u,
   .answer-group .btn-mfr {

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -135,6 +135,7 @@ $validation-color: red;
 // Oranges
 $local-install-background-color: #ffc107;
 $bg-debug-highlight: #fbe1c2;
+$bg-debug-highlight-dark: #835825;
 $bc-filters-engaged: #f9ce15;
 
 // Answer Options
@@ -542,14 +543,16 @@ label[required]::after {
 }
 
 // Dark mode
-.dark-theme, [data-theme="dark"], [data-bs-theme="dark"] {
+.dark-theme,
+[data-theme="dark"],
+[data-bs-theme="dark"] {
 
-  .assessment-header{
+  .assessment-header {
     background-color: var(--bg-secondary);
     color: var(--text-primary);
   }
 
-  ::ng-deep .mat-drawer-container{
+  ::ng-deep .mat-drawer-container {
     background-color: var(--bg-primary) !important;
   }
 
@@ -1295,6 +1298,12 @@ table.td-align-top td {
   color: $white;
 }
 
+.dark-theme {
+  .btn-level {
+    background-color: $gray-700;
+  }
+}
+
 .btn-geo {
   background-color: $gray-150;
   color: $primary-850;
@@ -1490,6 +1499,10 @@ ul.mat-tree-node {
   padding: 3px 4px;
   border-radius: 0.3rem;
   margin-left: .5rem;
+}
+
+.dark-theme .debug-highlight {
+  background-color: $bg-debug-highlight-dark;
 }
 
 /* --- spinner styles -- */
@@ -2487,17 +2500,43 @@ tooltip.glossary-definition.tooltip-left::after {
 }
 
 .extras-button.active {
-  background-color: $gray-50;
+  background-color: var(--bg-secondary);
   border: 3px solid $primary-450;
 }
 
 .extras-button:focus {
-  background-color: $gray-50;
+  background-color: var(--bg-secondary);
   border: 3px solid $primary-250;
 }
 
 .extras-button.empty {
   display: none;
+}
+
+.icon-color {
+  color: $primary-800;
+  --icon-accent: var(--bg-secondary)
+}
+
+.red-dot {
+  stroke: var(--bg-secondary);
+  stroke-width: 1;
+  fill: #cc0000;
+}
+
+
+.dark-theme {
+
+  .extras-button.active {
+    background-color: var(--bg-secondary);
+    border: 3px solid $primary-450;
+  }
+
+  .icon-color {
+    color: $gray-450;
+    --icon-accent: var(--bg-secondary)
+  }
+
 }
 
 .reqlabel {
@@ -2600,7 +2639,7 @@ ul.related-questions li {
 // Assessment Component
 ///////////////////////////////////////////////////////////////////////
 
-.mat-drawer{
+.mat-drawer {
   border-top-right-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
 }
@@ -4287,16 +4326,19 @@ h6.dropdown-header {
   border-color: var(--cset-primary);
   color: var(--text-primary);
 }
+
 .dark-theme .btn-app-mode:hover,
 [data-theme="dark"] .btn-app-mode:hover,
 [data-bs-theme="dark"] .btn-app-mode:hover {
   background-color: var(--bg-tertiary);
 }
+
 .btn-app-mode.active {
   background-color: #005288;
   color: #fff;
   border-color: #005288;
 }
+
 .dark-theme .btn-app-mode.active,
 [data-theme="dark"] .btn-app-mode.active,
 [data-bs-theme="dark"] .btn-app-mode.active {
@@ -4310,7 +4352,9 @@ h6.dropdown-header {
 [data-bs-theme="dark"] {
 
   // Default state - transparent background
-  .btn-yes, .btn-no, .btn-na,
+  .btn-yes,
+  .btn-no,
+  .btn-na,
   .answer-group .btn-alt,
   .answer-group .btn-u,
   .answer-group .btn-mfr {
@@ -4320,17 +4364,21 @@ h6.dropdown-header {
 
   // Hover and selected states
   .answer-group {
-    .btn-yes:hover, .btn-yes.answer-selected {
+
+    .btn-yes:hover,
+    .btn-yes.answer-selected {
       background-color: #006000;
       color: white;
     }
 
-    .btn-no:hover, .btn-no.answer-selected {
+    .btn-no:hover,
+    .btn-no.answer-selected {
       background-color: #d32f2f;
       color: white;
     }
 
-    .btn-na:hover, .btn-na.answer-selected {
+    .btn-na:hover,
+    .btn-na.answer-selected {
       background-color: #367190;
       color: white;
     }
@@ -4348,7 +4396,8 @@ h6.dropdown-header {
     .btn-mfr {
       border-color: var(--border-color);
 
-      &:hover, &.answer-selected {
+      &:hover,
+      &.answer-selected {
         background-color: #2c5c6d;
         color: white;
       }


### PR DESCRIPTION
This pull request updates the UI for question extras and related document actions to improve consistency and accessibility, particularly with icon colors and dark mode support. The changes primarily involve refactoring SVG icon coloring to use CSS classes and variables, adding new styles for dark mode, and ensuring visual indicators like notification dots are consistent across themes.

**UI and Icon Styling Improvements:**

* Replaced hardcoded SVG icon colors (e.g., `fill="#044"`, `fill="#285464"`) with the `icon-color` CSS class and `currentColor` to enable dynamic coloring via CSS and better dark mode support in `question-extras.component.html`. [[1]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L25-R57) [[2]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L74-R118) [[3]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L359-R366) [[4]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L377-R384)
* Updated notification dots on icons to use a new `.red-dot` CSS class for consistent appearance and theme adaptation, replacing previous inline styles and hardcoded colors. [[1]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L74-R118) [[2]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L127-R127) F84925e3L2543R2562)

**Dark Mode Enhancements:**

* Added new dark mode background color variables and extended dark theme CSS selectors for better theme handling in `iod-layout.component.scss`. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R139) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L515-R518)
* Added dark mode styles for `.btn-level` and `.debug-highlight` elements to ensure proper background colors and hover effects. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R1361-R1370) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R1553-R1556)
* Updated `.extras-button.active` and `.extras-button:focus` to use theme variables for background color in both light and dark modes.

**Code Consistency and Cleanup:**

* Removed inline color styles from buttons and SVGs, centralizing color management in CSS for easier maintenance and improved accessibility. [[1]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L347-R349) [[2]](diffhunk://#diff-678d9860be1946d68784428484cf9fea4094188ad86e4a15da9562c465e0abc5L359-R366)

**New CSS Utility Classes:**

* Introduced `.icon-color` and `.red-dot` classes for icons and notification dots to standardize their appearance and facilitate theme switching.

These changes collectively make the UI more visually consistent, easier to maintain, and better adapted for dark mode and accessibility.Ensures that the question extra icons display properly in dark mode by setting the correct color and background properties.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
