### PR TITLE
Added dark mode to CPG Checklist result page

### DIFF
--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.scss
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.scss
@@ -28,12 +28,23 @@ div {
 
 .green-dollars {
     font-size: 1.2rem;
-    color: #5e8144;
+    color: #426825;
 }
 
 .gray-dollars {
     font-size: 1.2rem;
-    color: #c6cdb6;
+    color: #99999994;
+}
+
+:host-context(.dark-theme) {
+
+    .green-dollars {
+        color: #02ed31a0;
+    }
+
+    .gray-dollars {
+        color: #ffffff42;
+    }
 }
 
 .lmh {

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
@@ -28,17 +28,13 @@
     </div>
 
     <div *ngFor="let d of model?.domains">
-        <div class="cpg-domain-bar page-break" [style.color]="colorSvc.textColor(backgroundColor(d.groupingId))"
-            [style.background-color]="backgroundColor(d.groupingId)"
-            [style.borderColor]="backgroundColor(d.groupingId)">
+        <div class="cpg-domain-bar page-break" [class]="groupIdToClass[d.groupingId]">
             {{d.title}}
         </div>
 
         <table *ngFor="let q of parentQuestions(d)" class="cpg-table">
             <tr>
-                <th style="width: 45%;" [style.borderLeftColor]="backgroundColor(d.groupingId)"
-                    [style.color]="colorSvc.textColor(backgroundColor(d.groupingId))"
-                    [style.background-color]="backgroundColor(d.groupingId)">
+                <th style="width: 45%; border: 1px solid #ccc" [class]="groupIdToClass[d.groupingId]">
                     <div class="d-flex flex-row justify-content-between">
                         <div class="d-flex flex-row">
                             <div class="me-2 font-weight-bold">
@@ -57,13 +53,10 @@
                         </div>
                     </div>
                 </th>
-                <th style="width: 25%" [style.color]="colorSvc.textColor(backgroundColor(d.groupingId))"
-                    [style.background-color]="backgroundColor(d.groupingId)">
+                <th style="width: 25%; border: 1px solid #ccc" [class]="groupIdToClass[d.groupingId]">
                     {{t('reports.core.cpg.report.current assessment') | uppercase}}
                 </th>
-                <th style="width: 30%" [style.borderRightColor]="backgroundColor(d.groupingId)"
-                    [style.color]="colorSvc.textColor(backgroundColor(d.groupingId))"
-                    [style.background-color]="backgroundColor(d.groupingId)">
+                <th style="width: 30%; border: 1px solid #ccc" [class]="groupIdToClass[d.groupingId]">
                     {{t('reports.core.cpg.report.notes') | uppercase}}
                 </th>
             </tr>

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.scss
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.scss
@@ -22,8 +22,12 @@ SOFTWARE.
 
 */
 
+$near-white: #ffffffdd;
+$near-black: #000000d5;
+
+
 .cpg-domain-bar {
-    color: white;
+    color: $near-white;
     text-align: center;
     font-weight: bold;
     font-size: 1.2rem;
@@ -33,27 +37,27 @@ SOFTWARE.
     border-top: none !important;
 }
 
-.cpg-table {
+table.cpg-table {
     width: 100%;
     margin-bottom: 2rem;
 }
 
-.cpg-table th {
-    color: white;
+table.cpg-table th {
+    color: var(--text-primary);
     padding: 1rem .5rem;
     border-right: 1px solid white;
     font-size: .8rem;
 }
 
-.cpg-table th:first-child {
+table.cpg-table th:first-child {
     border-left: 1px solid #ccc;
 }
 
-.cpg-table th:last-child {
+table.cpg-table th:last-child {
     border-right: 1px solid #ccc;
 }
 
-.cpg-table td {
+table.cpg-table td {
     border: 1px solid #ccc;
     padding: 1rem .5rem;
     font-size: .8rem;
@@ -64,4 +68,146 @@ SOFTWARE.
     font-weight: bold;
     font-size: 1.05rem;
     margin-bottom: .3rem;
+}
+
+
+// FUNCION COLORS
+
+// CPG 1 (CSF 1) - light mode
+.csf1-func-id {
+    background-color: #355C9B;
+    border-color: #355C9B;
+    color: $near-white !important;
+}
+
+.csf1-func-pr {
+    background-color: #784390;
+    border-color: #784390;
+    color: $near-white !important;
+}
+
+.csf1-func-de {
+    background-color: #F7E24E;
+    border-color: #F7E24E;
+}
+
+.csf1-func-rs {
+    background-color: #D93A34;
+    border-color: #D93A34;
+}
+
+.csf1-func-rc {
+    background-color: #4CA056;
+    border-color: #4CA056;
+}
+
+
+
+// CPG 2 (CSF 2) - light mode
+.csf2-func-gv {
+    background-color: #f9f39b;
+    border-color: #f9f39b;
+    color: $near-black;
+}
+
+.csf2-func-id {
+    background-color: #4cb3e0;
+    border-color: #4cb3e0;
+    color: $near-black;
+}
+
+.csf2-func-pr {
+    background-color: #918cea;
+    border-color: #918cea;
+    color: $near-black;
+}
+
+.csf2-func-de {
+    background-color: #fab647;
+    border-color: #fab647;
+    color: $near-black;
+}
+
+.csf2-func-rs {
+    background-color: #e47677;
+    border-color: #e47677;
+    color: $near-black;
+}
+
+.csf2-func-rc {
+    background-color: #7ef49e;
+    border-color: #7ef49e;
+    color: $near-black;
+}
+
+
+.ssg-it-product-design {
+    background-color: #548235;
+    color: $near-white !important;
+}
+
+.ssg-it-software-dev {
+    background-color: #305496;
+    color: $near-white !important;
+}
+
+
+
+:host-context(.dark-theme) {
+
+    // CSF1
+    .csf1-func-id {
+        background-color: #2563EB;
+    }
+
+    .csf1-func-pr {
+        background-color: #7e22ce;
+    }
+
+
+    // CSF2
+    .csf2-func-gv {
+        background-color: #875d04;
+        border-color: #875d04;
+        color: $near-white;
+    }
+
+    .csf2-func-id {
+        background-color: #005479;
+        border-color: #005479;
+        color: $near-white;
+    }
+
+    .csf2-func-pr {
+        background-color: #47438f;
+        border-color: #47438f;
+        color: $near-white;
+    }
+
+    .csf2-func-de {
+        background-color: #d97706;
+        border-color: #d97706;
+        color: $near-white;
+    }
+
+    .csf2-func-rs {
+        background-color: #EF4444;
+        border-color: #EF4444;
+        color: $near-white;
+    }
+
+    .csf2-func-rc {
+        background-color: #059669;
+        border-color: #059669;
+        color: $near-white;
+    }
+
+
+    .ssg-it-product-design {
+        background-color: #548235;
+    }
+
+    .ssg-it-software-dev {
+        background-color: #305496;
+    }
 }

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.ts
@@ -47,6 +47,32 @@ export class CpgPracticeTableComponent implements OnInit {
 
   model: any;
 
+  groupIdToClass: Record<number, string> = {
+    // CSF 2.0
+    567: 'csf2-func-gv',
+    568: 'csf2-func-id',
+    569: 'csf2-func-pr',
+    570: 'csf2-func-de',
+    571: 'csf2-func-rs',
+    572: 'csf2-func-rc',
+
+    // CPG 1.0 (CSF1 colors)
+    200: 'csf1-func-id',
+    560: 'csf1-func-id',
+    201: 'csf1-func-pr',
+    561: 'csf1-func-pr',
+    202: 'csf1-func-de',
+    562: 'csf1-func-de',
+    203: 'csf1-func-rs',
+    563: 'csf1-func-rs',
+    204: 'csf1-func-rc',
+    564: 'csf1-func-rc',
+
+    // SSG - IT
+    565: 'ssg-it-software-dev',
+    566: 'ssg-it-product-design'
+  };
+
   /**
    * 
    */
@@ -59,7 +85,7 @@ export class CpgPracticeTableComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
-   // let modelId: number | null = null;
+    // let modelId: number | null = null;
 
     if (!!this.ssgModelId) {
       this.modelId = this.ssgModelId;
@@ -89,74 +115,5 @@ export class CpgPracticeTableComponent implements OnInit {
     }
 
     return null;
-  }
-
-  /**
-   * Returns the color for the CSF function of the group.
-   * This is specific to CPG grouping IDs.
-   * 
-   * The colors were slightly modified in CSF 2.0.
-   * 
-   * As SSG models are added to CSET the new grouping codes will be
-   * added to this logic.
-   */
-  backgroundColor(groupId: number): string {
-
-    // CPG 2.0
-    switch (groupId) {
-      case 567:
-        // govern
-        return this.colorSvc.nistCsfFuncColor('GV-2');
-      case 568:
-        // identify
-        return this.colorSvc.nistCsfFuncColor('ID-2');
-      case 569:
-        // protect
-        return this.colorSvc.nistCsfFuncColor('PR-2');
-      case 570:
-        return this.colorSvc.nistCsfFuncColor('DE-2');
-      case 571:
-        // respond
-        return this.colorSvc.nistCsfFuncColor('RS-2');
-      case 572:
-        // recover
-        return this.colorSvc.nistCsfFuncColor('RC-2');
-
-
-      // CPG 1.0
-      case 200:
-      case 560:
-        // identify
-        return this.colorSvc.nistCsfFuncColor('ID');
-      case 201:
-      case 561:
-        // protect
-        return this.colorSvc.nistCsfFuncColor('PR');
-      case 202:
-      case 562:
-        // detect
-        return this.colorSvc.nistCsfFuncColor('DE');
-      case 203:
-      case 563:
-        // respond
-        return this.colorSvc.nistCsfFuncColor('RS');
-      case 204:
-      case 564:
-        // recover
-        return this.colorSvc.nistCsfFuncColor('RC');
-
-
-      // SSG - IT
-      case 565:
-        // SSG - IT Software Development
-        return '#305496';
-      case 566:
-        // SSG - IT Product Design
-        return '#548235';
-
-
-      default:
-        return '#6BA443';
-    }
   }
 }

--- a/CSETWebNg/src/app/services/color.service.ts
+++ b/CSETWebNg/src/app/services/color.service.ts
@@ -90,50 +90,6 @@ export class ColorService {
   }
 
   /**
-   * Returns a standard HTML color string for the 
-   * specified function.  This will promote consistency
-   * anywhere CSF colors are displayed in CSET.
-   */
-  nistCsfFuncColor(func: string) {
-
-    // CSF 2.0 colors
-    if (func.endsWith('-2')) {
-      switch (func) {
-        case 'GV-2':
-          return '#f9f39b';
-        case 'ID-2':
-          return '#4cb3e0';
-        case 'PR-2':
-          return '#918cea';
-        case 'DE-2':
-          return '#fab647';
-        case 'RS-2':
-          return '#e47677';
-        case 'RC-2':
-          return '#7ef49e';
-        default:
-          return '#FFFFFF';
-      }
-    }
-
-    // CSF 1.0 colors
-    switch (func) {
-      case 'ID':
-        return '#355C9B';
-      case 'PR':
-        return '#784390';
-      case 'DE':
-        return '#F7E24E';
-      case 'RS':
-        return '#D93A34';
-      case 'RC':
-        return '#4CA056';
-      default:
-        return '#FFFFFF';
-    }
-  }
-
-  /**
    * Returns a hex color code of black or white,
    * depending on the specified background color.
    */


### PR DESCRIPTION
This pull request refactors how colors are applied to the CPG practice table and related components, moving from inline style logic and service methods to CSS class-based styling. This makes the codebase cleaner, improves maintainability, and enables better support for light and dark themes. The most significant changes are the introduction of CSS classes for domain colors, removal of color logic from TypeScript, and enhancements to the SCSS for theme support.

**Refactoring color logic and improving theme support:**

* Replaced inline style bindings for colors and backgrounds in `cpg-practice-table.component.html` with CSS class bindings using the new `groupIdToClass` mapping, simplifying the template and removing dependency on `backgroundColor` and `colorSvc.textColor`. [[1]](diffhunk://#diff-3b7bc338acb21b1075fd21fc1187e19c2931e82b2f0b38c8b5985bf68632d716L31-R37) [[2]](diffhunk://#diff-3b7bc338acb21b1075fd21fc1187e19c2931e82b2f0b38c8b5985bf68632d716L60-R59)
* Added a comprehensive set of CSS classes in `cpg-practice-table.component.scss` for each domain/function color, supporting both light and dark themes with appropriate color values.
* Introduced `groupIdToClass` mapping in `cpg-practice-table.component.ts` to associate domain/grouping IDs with their corresponding CSS classes, centralizing color assignment logic.
* Removed the `backgroundColor` method from `cpg-practice-table.component.ts` and the `nistCsfFuncColor` method from `color.service.ts`, as color logic is now handled via CSS classes instead of TypeScript. [[1]](diffhunk://#diff-f39a887b13a63e1c239e18ade4b1309344e6df0e4cb9cd7fc857cbdb79e6cabeL93-L161) [[2]](diffhunk://#diff-11201bb261edc8ee27a2e510a7534e349908bb089cc4cf6784e668b252df69f0L92-L135)

**General styling improvements:**

* Updated SCSS for table and domain bar elements to use new color variables (`$near-white`, `$near-black`) and improved CSS selectors for more consistent styling and easier theme management. [[1]](diffhunk://#diff-4dfda69813d376cf4a267f69d7c54819952028a8058993d02bcb2c8a47f67028R25-R30) [[2]](diffhunk://#diff-4dfda69813d376cf4a267f69d7c54819952028a8058993d02bcb2c8a47f67028L36-R60)
* Enhanced dollar amount color styling and added dark theme support in `cpg-cost-impact-complexity.component.scss`.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
