### PR TITLE
Fix styling for tables in dark mode

### DIFF
--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -512,102 +512,7 @@ label[required]::after {
   margin: 1em 0 .5em 2em;
 }
 
-// Dark mode
-.dark-theme,
-[data-theme="dark"],
-[data-bs-theme="dark"] {
 
-  .assessment-header {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-  }
-
-  ::ng-deep .mat-drawer-container {
-    background-color: var(--bg-primary) !important;
-  }
-
-  .white-panel {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-
-    &::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.3);
-
-      &:hover {
-        background: rgba(255, 255, 255, 0.4);
-      }
-    }
-
-  }
-
-  .white-panel-body-long {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-
-    &::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.3);
-
-      &:hover {
-        background: rgba(255, 255, 255, 0.4);
-      }
-    }
-  }
-
-  .white-panel-controls {
-    background-color: var(--bg-secondary);
-  }
-}
-
-.white-panel-controls {
-  background-color: var(--bg-secondary);
-  margin: 1em 1em 0em 1em;
-  padding: 2em 2em 0em 2em;
-  overflow-y: auto;
-  overflow-x: hidden;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-
-  // max-height: calc(100cqh - 310px);
-  // min-height: calc(100cqh - 310px);
-
-  color: $gray-800;
-  clip-path: margin-box;
-  //clip-path: inset(0 round 8px);
-}
-
-.white-panel-body {
-  background-color: $gray-50;
-  margin: 0em 1em .5em 1em;
-  padding: 2em;
-  overflow-y: auto;
-  overflow-x: hidden;
-  border-bottom-left-radius: 8px;
-  border-bottom-right-radius: 8px;
-
-  max-height: calc(100cqh - 420px);
-  min-height: calc(100cqh - 420px);
-
-  color: $gray-800;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
-  clip-path: margin-box;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-    border-radius: 8px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 8px;
-  }
-}
 
 .white-panel {
   background-color: $gray-50;
@@ -639,7 +544,7 @@ label[required]::after {
 }
 
 .white-panel-controls {
-  background-color: $gray-50;
+  background-color: var(--bg-secondary);
   margin: 1em 1em 0em 1em;
   padding: 1.5em 2em .5em 2em;
   overflow-y: auto;
@@ -715,6 +620,74 @@ label[required]::after {
   }
 }
 
+
+// Dark mode ---------------------------------------------------
+.dark-theme,
+[data-theme="dark"],
+[data-bs-theme="dark"] {
+
+  .assessment-header {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+  }
+
+  ::ng-deep .mat-drawer-container {
+    background-color: var(--bg-primary) !important;
+  }
+
+  .white-panel {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+
+  }
+
+  .white-panel-controls {
+    background-color: var(--bg-secondary);
+  }
+
+  .white-panel-body {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+  }
+
+  .white-panel-body-long {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+  }
+
+}
+
+// end dark mode -----------------------------------------------------------------
+
+
+
 .white-dialog {
   background-color: $white;
   color: $gray-800;
@@ -728,7 +701,6 @@ label[required]::after {
   border-radius: 4px;
   background-color: $primary-800;
   color: $gray-100;
-  //min-width: 130px;
 }
 
 .quick-info-stats-container,
@@ -740,10 +712,6 @@ label[required]::after {
   background-color: $gray-50;
   color: $gray-900;
 }
-
-// .content-height {
-//   height: calc(100vh - 131px);
-// }
 
 .no-padding {
   padding-right: 0 !important;
@@ -772,7 +740,7 @@ input[type="number"] {
 //       Basic table layout
 table.cset-table {
   width: 100%;
-  color: $primary-color;
+  color: var(--text-primary);
 }
 
 table.cset-table ul {
@@ -780,11 +748,11 @@ table.cset-table ul {
 }
 
 table.cset-table tr:nth-child(even) {
-  background: $gray-100;
+  background: rgb(var(--bg-primary) / 0.5);
 }
 
 table.cset-table tr:nth-child(odd) {
-  background: $gray-50;
+  background: rgb(var(--bg-primary) / 1.0);
 }
 
 table.cset-table td,
@@ -793,7 +761,7 @@ table.cset-table th {
 }
 
 table.cset-table th {
-  background-color: $secondary-color;
+  background-color: var(--bg-secondary);
   color: $gray-50;
   font-weight: 500;
 }
@@ -808,16 +776,16 @@ table.cset-table tr.total-row {
 
 table.assessment-summary {
   width: 100%;
-  color: $primary-color;
+  color: var(--text-primary);
 }
 
 // hide some columns in phone mode
 table.assessment-summary tr:nth-child(even) {
-  background: $gray-100;
+  background: rgb(var(--bg-primary) / 0.5);
 }
 
 table.assessment-summary tr:nth-child(odd) {
-  background: $gray-50;
+  background: rgb(var(--bg-primary) / 1.0);
 }
 
 table.assessment-summary th:nth-child(1) {
@@ -829,8 +797,8 @@ table.assessment-summary td {
 }
 
 table.assessment-summary th {
-  background-color: $secondary-color;
-  color: $gray-50;
+  background-color: var(--cset-primary);
+  color: $gray-100 !important;
   font-weight: 500;
   padding: .5rem;
 }
@@ -853,6 +821,10 @@ table.table-td-small td {
 // force transparent
 .table>:not(caption)>*>* {
   background-color: transparent !important;
+}
+
+.table.table td {
+  color: var(--text-primary);
 }
 
 /*
@@ -4368,7 +4340,7 @@ h6.dropdown-header {
 }
 
 .star-favorite {
-  color:var(--cset-primary);
+  color: var(--cset-primary);
 }
 
 .dark-theme .btn-app-mode,

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -511,6 +511,8 @@ label[required]::after {
   margin: 1em 0 .5em 2em;
 }
 
+
+
 .white-panel {
   background-color: $gray-50;
   margin: 1em 1em .5em 1em;
@@ -541,37 +543,6 @@ label[required]::after {
     border-radius: 8px;
   }
 }
-
-// Dark mode
-.dark-theme,
-[data-theme="dark"],
-[data-bs-theme="dark"] {
-
-  .assessment-header {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-  }
-
-  ::ng-deep .mat-drawer-container {
-    background-color: var(--bg-primary) !important;
-  }
-
-  .white-panel {
-    background-color: var(--bg-secondary);
-    color: var(--text-primary);
-    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
-
-    &::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.3);
-
-      &:hover {
-        background: rgba(255, 255, 255, 0.4);
-      }
-    }
-  }
-}
-
-
 
 .white-panel-controls {
   background-color: $gray-50;
@@ -650,6 +621,73 @@ label[required]::after {
   }
 }
 
+
+// Dark mode ---------------------------------------------------
+.dark-theme,
+[data-theme="dark"],
+[data-bs-theme="dark"] {
+
+  .assessment-header {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+  }
+
+  ::ng-deep .mat-drawer-container {
+    background-color: var(--bg-primary) !important;
+  }
+
+  .white-panel {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+  }
+
+  .white-panel-controls {
+    background-color: var(--bg-secondary);
+  }
+
+  .white-panel-body {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+  }
+
+  .white-panel-body-long {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.3);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+    }
+  }
+
+}
+
+// end dark mode -----------------------------------------------------------------
+
+
+
 .white-dialog {
   background-color: $white;
   color: $gray-800;
@@ -707,7 +745,7 @@ input[type="number"] {
 //       Basic table layout
 table.cset-table {
   width: 100%;
-  color: $primary-color;
+  color: var(--text-primary);
 }
 
 table.cset-table ul {
@@ -715,11 +753,11 @@ table.cset-table ul {
 }
 
 table.cset-table tr:nth-child(even) {
-  background: $gray-100;
+  background: rgb(var(--bg-primary) / 0.5);
 }
 
 table.cset-table tr:nth-child(odd) {
-  background: $gray-50;
+  background: rgb(var(--bg-primary) / 1.0);
 }
 
 table.cset-table td,
@@ -728,8 +766,8 @@ table.cset-table th {
 }
 
 table.cset-table th {
-  background-color: $secondary-color;
-  color: $gray-50;
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
   font-weight: 500;
 }
 
@@ -743,16 +781,16 @@ table.cset-table tr.total-row {
 
 table.assessment-summary {
   width: 100%;
-  color: $primary-color;
+  color: var(--text-primary);
 }
 
 // hide some columns in phone mode
 table.assessment-summary tr:nth-child(even) {
-  background: $gray-100;
+  background: rgb(var(--bg-primary) / 0.5);
 }
 
 table.assessment-summary tr:nth-child(odd) {
-  background: $gray-50;
+  background: rgb(var(--bg-primary) / 1.0);
 }
 
 table.assessment-summary th:nth-child(1) {
@@ -764,8 +802,8 @@ table.assessment-summary td {
 }
 
 table.assessment-summary th {
-  background-color: $secondary-color;
-  color: $gray-50;
+  background-color: var(--cset-primary);
+  color: $gray-100 !important;
   font-weight: 500;
   padding: .5rem;
 }
@@ -793,6 +831,10 @@ table.table-td-small td {
 // force transparent
 .table>:not(caption)>*>* {
   background-color: transparent !important;
+}
+
+.table.table td {
+  color: var(--text-primary);
 }
 
 /*


### PR DESCRIPTION
This pull request refactors the SCSS for both the `iod-layout` and `layout-main` components to standardize the use of CSS variables for colors and improve dark mode support. The changes replace hardcoded color values with CSS variables, unify dark mode styling blocks, and enhance table styling for better theme consistency.

**Theme and color variable refactoring:**

* Replaced hardcoded color values (e.g., `$primary-color`, `$secondary-color`, `$gray-50`, `$gray-100`) with CSS variables such as `var(--text-primary)`, `var(--bg-primary)`, and `var(--bg-secondary)` throughout both `iod-layout.component.scss` and `layout-main.component.scss`. This makes theme management easier and more consistent. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L775-R755) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L796-R764) [[3]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L811-R788) [[4]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L832-R801) [[5]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L710-R760) [[6]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L731-R770) [[7]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L746-R793) [[8]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L767-R806)

**Dark mode improvements:**

* Moved and standardized dark mode styling blocks for `.dark-theme`, `[data-theme="dark"]`, and `[data-bs-theme="dark"]` in both SCSS files. This includes background and text color changes for `.assessment-header`, `.mat-drawer-container`, `.white-panel`, `.white-panel-controls`, `.white-panel-body`, and `.white-panel-body-long`, ensuring consistent dark mode appearance. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L515-L610) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R623-R690) [[3]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L545-L575) [[4]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2R624-R690)

**Table styling updates:**

* Updated table row and header background colors to use CSS variables, improving theme adaptability and visual consistency for `.cset-table` and `.assessment-summary` tables. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L775-R755) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L796-R764) [[3]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L811-R788) [[4]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L832-R801) [[5]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L710-R760) [[6]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L731-R770) [[7]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L746-R793) [[8]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2L767-R806)
* Added a selector for `.table.table td` to ensure table cell text uses the primary text color variable. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267R826-R829) [[2]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2R836-R839)

**General cleanup:**

* Removed commented-out code and unnecessary blank lines for better readability and maintainability. [[1]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L731) [[2]](diffhunk://#diff-330c3e03c4664d7e8683e023e24ae3caef91ed38079640798593dc65a5736267L744-L747) [[3]](diffhunk://#diff-914e03eb8db92fd20da6f99f38d5b8e987b718bdb10a0047e34dacbf3b8d73a2R514-R515)

These changes will make it easier to maintain and update themes, especially dark mode, and ensure a consistent look and feel across the application.<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
