### PR TITLE
Fixed diagram inventory checkboxes

### DIFF
--- a/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
@@ -21,7 +21,7 @@
   SOFTWARE.
 -------------------------->
 <div>
-    <div class="white-panel">
+    <div class="white-panel-body avail-h-minus" style="--offset: 305px">
         <div class="row">
             <div class="col-12">
                 <h4>Network Diagram</h4>

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.html
@@ -42,10 +42,9 @@
         </option>
       </select>
     </td>
-    <td style="padding-left: 20px">
-      <input type="checkbox" name="{{ component.label }}" id="{{ component.label }}" class="checkbox-custom mt-1"
-        [(ngModel)]="component.hasUniqueQuestions" [disabled]="true" [checked]="component.hasUniqueQuestions">
-      <label for="{{ component.label }}" class="checkbox-custom-label" style="justify-content: space-around;"></label>
+    <td class="text-center">
+      <i *ngIf="!component.hasUniqueQuestions" class="far fa-square fa-lg"></i>
+      <i *ngIf="component.hasUniqueQuestions" class="far fa-square-check fa-lg"></i>
     </td>
     <td>{{component.sal}}</td>
     <td>{{component.criticality}}</td>

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.html
@@ -38,7 +38,7 @@
 
     <div class="row stretch mb-3">
       <div class="col-12">
-        <mat-tab-group class="mb-3 scrollable-tabs">
+        <mat-tab-group class="mb-3">
           <mat-tab *ngIf="showVulnerabilitiesTab()" label="Vulnerabilities">
             <app-diagram-vulnerabilities (componentsChange)="onChange($event)"></app-diagram-vulnerabilities>
           </mat-tab>


### PR DESCRIPTION
This pull request introduces several UI improvements to the diagram-related components in the assessment module. The main focus is on enhancing the layout, visual clarity, and user experience of the component inventory and diagram information panels.

Layout and Styling Improvements:

* Changed the container class and added a custom style to the main diagram info panel for better spacing and layout consistency (`diagram-info.component.html`).
* Removed the `scrollable-tabs` class from the `mat-tab-group` in the component inventory, likely to simplify the tab appearance or behavior (`diagram-inventory.component.html`).

Component Inventory Table Enhancements:

* Replaced the disabled checkbox for unique questions with icon-based indicators, using a checked or unchecked square icon for clearer, non-interactive visual feedback (`diagram-components.component.html`).<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
