### PR TITLE
Fixed crashing when overriding component answers

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
@@ -116,10 +116,6 @@ namespace CSETWebCore.Api.Controllers
         [Route("api/ComponentQuestionList")]
         public IActionResult GetComponentQuestionsList([FromQuery] string skin, string group)
         {
-            if (skin == "RENEW")
-            {
-                new MalcolmBusiness(_context).VerificationAndValidation(_token.AssessmentForUser());
-            }
             var manager = new ComponentQuestionBusiness(_context, _assessmentUtil, _token, _questionRequirement);
             QuestionResponse resp = manager.GetResponse();
 

--- a/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.html
@@ -37,7 +37,7 @@
   [class.display-none]="!sg.visible">
 
   <!-- Questions within subcategory -->
-  <app-question-block #questionBlock [mySubCategory]="sg" (changeComponents)="updateComponentsOverride()">
+  <app-question-block #questionBlock [mySubCategory]="sg">
   </app-question-block>
 
 </div>

--- a/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.ts
@@ -24,25 +24,35 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Category } from '../../../models/questions.model';
 import { NavTreeNode } from '../../../services/navigation/navigation.service';
+import { QuestionsService } from '../../../services/questions.service';
+import { Subscription } from 'rxjs';
 
 @Component({
-    selector: 'app-category-block',
-    templateUrl: './category-block.component.html',
-    standalone: false
+  selector: 'app-category-block',
+  templateUrl: './category-block.component.html',
+  standalone: false
 })
 export class CategoryBlockComponent implements OnInit {
 
   @Input('myCategory') c: Category;
 
+  private componentOverrideSubscription: Subscription;
+
   /**
    * 
    */
-  constructor() { }
+  constructor(
+    public questionsSvc: QuestionsService
+  ) { }
 
   /**
    * 
    */
   ngOnInit() {
+    // listen for the override control's update event
+    this.componentOverrideSubscription = this.questionsSvc.componentOverrideEvent$.subscribe(() => {
+      this.updateComponentsOverride();
+    });
   }
 
   /**
@@ -81,7 +91,23 @@ export class CategoryBlockComponent implements OnInit {
         elementType: 'QUESTION-HEADING',
         children: []
       };
-      // componentname.children.push(heading);
     });
+  }
+
+  /**
+   * Broadcast the event
+   */
+  updateComponentsOverride() {
+    this.questionsSvc.emitComponentOverrideEvent(0);
+  }
+
+  /**
+   * 
+   */
+  ngOnDestroy() {
+    // Clean up the subscription
+    if (this.componentOverrideSubscription) {
+      this.componentOverrideSubscription.unsubscribe();
+    }
   }
 }

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
@@ -33,11 +33,12 @@ import { MatDialogRef, MatDialog } from '@angular/material/dialog';
 import { QuestionFiltersComponent } from '../../../dialogs/question-filters/question-filters.component';
 import { QuestionFilterService } from '../../../services/filtering/question-filter.service';
 import { ConfigService } from '../../../services/config.service';
+import { lastValueFrom } from 'rxjs';
 
 @Component({
-    selector: 'app-diagram-questions',
-    templateUrl: './diagram-questions.component.html',
-    standalone: false
+  selector: 'app-diagram-questions',
+  templateUrl: './diagram-questions.component.html',
+  standalone: false
 })
 export class DiagramQuestionsComponent implements OnInit {
 
@@ -88,30 +89,27 @@ export class DiagramQuestionsComponent implements OnInit {
   /**
    * Retrieves the complete list of questions
    */
-  loadQuestions() {
-    const magic = this.navSvc.getMagic();
-    this.questionsSvc.getComponentQuestionsList().subscribe(
-      (response: QuestionResponse) => {
-        this.questionsSvc.questions = response;
-        this.categories = response.categories;
-        this.loaded = true;
+  async loadQuestions() {
+    try {
+      const response: QuestionResponse = await lastValueFrom(this.questionsSvc.getComponentQuestionsList());
 
-        this.completionSvc.structure = response;
-        this.completionSvc.setQuestionArray();
+      this.questionsSvc.questions = response;
+      this.categories = response.categories;
+      this.loaded = true;
 
-        this.refreshQuestionVisibility();
-      },
-      error => {
-        console.error(
-          'Error getting questions: ' +
-          (<Error>error).name +
-          (<Error>error).message
-        );
-        console.error('Error getting questions: ' + (<Error>error).stack);
-      }
-    );
+      this.completionSvc.structure = response;
+      this.completionSvc.setQuestionArray();
+
+      this.refreshQuestionVisibility();
+    } catch (error) {
+      console.error(
+        'Error getting questions: ' +
+        (<Error>error).name +
+        (<Error>error).message
+      );
+      console.error('Error getting questions: ' + (<Error>error).stack);
+    }
   }
-
 
   /**
    * Controls the mass expansion/collapse of all subcategories on the screen.
@@ -126,8 +124,8 @@ export class DiagramQuestionsComponent implements OnInit {
   }
 
   /**
- *
- */
+   *
+   */
   showFilterDialog() {
     this.filterDialogRef = this.dialog.open(QuestionFiltersComponent);
     this.filterDialogRef.componentInstance.filterChanged.asObservable().subscribe(() => {
@@ -141,11 +139,11 @@ export class DiagramQuestionsComponent implements OnInit {
   }
 
   /**
-  * Re-evaluates the visibility of all questions/subcategories/categories
-  * based on the current filter settings.
-  * Also re-draws the sidenav category tree, skipping categories
-  * that are not currently visible.
-  */
+    * Re-evaluates the visibility of all questions/subcategories/categories
+    * based on the current filter settings.
+    * Also re-draws the sidenav category tree, skipping categories
+    * that are not currently visible.
+    */
   refreshQuestionVisibility() {
     this.filterSvc.evaluateFiltersForCategories(this.categories);
   }

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
@@ -216,6 +216,9 @@ export class QuestionExtrasComponent implements OnInit {
     if (this.extras?.is_Component) {
       this.myQuestion.is_Component = true;
       this.toggleComponent = true;
+      if (this.mode == 'DETAIL') {
+        this.mode = 'COMPONENT';
+      }
     }
   }
 

--- a/CSETWebNg/src/app/assessment/questions/questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.ts
@@ -123,7 +123,7 @@ export class QuestionsComponent implements AfterViewChecked, OnInit, AfterViewIn
 
     //clear out the navigation overrides
     //then call the get overrides questions api
-    //and refressh overrides navigation
+    //and refresh overrides navigation
     this.questionsSvc.getQuestionListOverridesOnly().subscribe((data: QuestionResponse) => {
       this.refreshQuestionVisibility();
     });

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
@@ -77,8 +77,8 @@
               </div>
               <div *ngIf="q.answer_Text === 'A'">
                 <textarea appAutoSize class="form-control" style="height: 80px; width: 100%; min-height: 72px;"
-                  [placeholder]="t('answer-options.placeholders.alt justification')"
-                  [(ngModel)]="q.altAnswerText" (change)="storeAnswer(q, 'A')"></textarea>
+                  [placeholder]="t('answer-options.placeholders.alt justification')" [(ngModel)]="q.altAnswerText"
+                  (change)="storeAnswer(q, 'A')"></textarea>
               </div>
             </td>
           </tr>
@@ -86,7 +86,7 @@
       </div>
     </div>
   </mat-dialog-content>
-  <mat-dialog-actions class="ps-4 p-1" style="margin-bottom:15px;">
+  <mat-dialog-actions class="p-3 pt-0 mb-0 d-flex justify-content-end flex-11a">
     <button class="btn btn-primary" (click)="close()">{{t('buttons.ok')}}</button>
   </mat-dialog-actions>
 </div>

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
@@ -51,7 +51,8 @@ export class ComponentOverrideComponent {
     public questionsSvc: QuestionsService,
     public utilitiesSvc: Utilities,
     @Inject(MAT_DIALOG_DATA) public data: any) {
-    dialog.beforeClosed().subscribe(() => dialog.close(this.questionChanged));
+    dialog.beforeClosed().subscribe(() => this.broadcastQuestionOverride());
+
     this.questionsSvc.getOverrideQuestions(data.myQuestion.questionId,
       data.component_Symbol_Id).subscribe((x: any) => {
         this.questions = x;
@@ -117,14 +118,16 @@ export class ComponentOverrideComponent {
       });
 
     this.questionChanged = true;
-    this.questionsSvc.questionOverrideSubject.next(true);
   }
 
+  broadcastQuestionOverride() {
+    this.questionsSvc.questionOverrideSubject.next(true);
+  }
 
   close() {
     return this.dialog.close(this.questionChanged);
   }
-
+  
   applyHeight() {
     const styles = { 'max-height': window.screen.availHeight };
     return styles;

--- a/CSETWebNg/src/app/services/questions.service.ts
+++ b/CSETWebNg/src/app/services/questions.service.ts
@@ -27,11 +27,9 @@ import { Injectable } from '@angular/core';
 import { Answer, DefaultParameter, ParameterForAnswer, Category, SubCategoryAnswers, QuestionResponse, SubCategory, Question } from '../models/questions.model';
 import { ConfigService } from './config.service';
 import { AssessmentService } from './assessment.service';
-import { QuestionFilterService } from './filtering/question-filter.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { TranslocoService } from '@jsverse/transloco';
 import { LinebreakPipe } from '../helpers/linebreak.pipe';
-import { AnswerOptionConfig } from '../models/module-config.model';
 import { tap } from 'rxjs/operators';
 
 const headers = {
@@ -65,6 +63,12 @@ export class QuestionsService {
    */
   public autoLoadSuppCheckboxState = false;
 
+  /**
+   * Components override update subject
+   */
+  private componentOverrideEventSubject = new Subject<any>();
+  componentOverrideEvent$ = this.componentOverrideEventSubject.asObservable();
+
 
   /**
    *
@@ -73,8 +77,6 @@ export class QuestionsService {
     private http: HttpClient,
     private configSvc: ConfigService,
     private tSvc: TranslocoService,
-    private assessmentSvc: AssessmentService,
-    private questionFilterSvc: QuestionFilterService,
     public linebreakPipe: LinebreakPipe,
     private assessSvc: AssessmentService
   ) { }
@@ -120,8 +122,8 @@ export class QuestionsService {
   /**
    *
    */
-  getComponentQuestionsList() {
-    return this.http.get(this.configSvc.apiUrl + 'componentquestionlist?skin=' + this.configSvc.installationMode, headers);
+  getComponentQuestionsList(): Observable<QuestionResponse> {
+    return this.http.get<QuestionResponse>(this.configSvc.apiUrl + 'componentquestionlist?skin=' + this.configSvc.installationMode, headers);
   }
 
   /**
@@ -510,5 +512,9 @@ export class QuestionsService {
     searchStr = searchStr.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 
     return origString.replace(new RegExp(searchStr, 'gi'), replaceStr);
+  }
+
+  emitComponentOverrideEvent(data: any) {
+    this.componentOverrideEventSubject.next(data);
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to the component override functionality and refactors how question data is loaded and updated in the Angular frontend. The changes focus on decoupling event handling for component overrides, improving resource management, and modernizing asynchronous code for better maintainability and performance.

**Component Override Event Handling:**
* Added a new event system using RxJS `Subject`/`Observable` in `QuestionsService` to broadcast component override updates, replacing the previous direct method calls and output event bindings. This enables a more scalable and decoupled approach for notifying components about override changes. [[1]](diffhunk://#diff-84a1b69c8e465d8ba1a15fa351cec08e60842ab6763829948cede1f509221be4R66-R71) [[2]](diffhunk://#diff-84a1b69c8e465d8ba1a15fa351cec08e60842ab6763829948cede1f509221be4R516-R519) [[3]](diffhunk://#diff-0730a03bed310e4b37e5a31b104c564d02c07cb7ec6eb5e922a7a31794468faeR39-R55) [[4]](diffhunk://#diff-0730a03bed310e4b37e5a31b104c564d02c07cb7ec6eb5e922a7a31794468faeL84-R112) [[5]](diffhunk://#diff-057e8298fad59119aec43df8de77776231d04e9d7ca4e6746d197d02d5a086b8L40-R40)
* Updated `ComponentOverrideComponent` to broadcast override changes using the new event system, ensuring that all relevant components are notified when an override occurs. [[1]](diffhunk://#diff-c3ed61bfd004d0937a6af355357eb657007810dc0160f6eefa32d23576ab5974L54-R55) [[2]](diffhunk://#diff-c3ed61bfd004d0937a6af355357eb657007810dc0160f6eefa32d23576ab5974L120-R125)

**Asynchronous Data Loading Improvements:**
* Refactored `DiagramQuestionsComponent` to use `async/await` and `lastValueFrom` for loading questions, improving error handling and code readability. [[1]](diffhunk://#diff-67b54bebf7ea6d24f15f4f4e8183f6a39fd8d67d406c5d774855e13e9fba4f1bR36) [[2]](diffhunk://#diff-67b54bebf7ea6d24f15f4f4e8183f6a39fd8d67d406c5d774855e13e9fba4f1bL91-R95) [[3]](diffhunk://#diff-67b54bebf7ea6d24f15f4f4e8183f6a39fd8d67d406c5d774855e13e9fba4f1bL103-L115)

**Resource Management and Cleanup:**
* Implemented subscription cleanup in `CategoryBlockComponent` via `ngOnDestroy` to prevent memory leaks from lingering RxJS subscriptions. [[1]](diffhunk://#diff-0730a03bed310e4b37e5a31b104c564d02c07cb7ec6eb5e922a7a31794468faeR39-R55) [[2]](diffhunk://#diff-0730a03bed310e4b37e5a31b104c564d02c07cb7ec6eb5e922a7a31794468faeL84-R112)

**Minor UI and Logic Enhancements:**
* Improved UI consistency in the component override dialog actions and ensured correct mode switching in `QuestionExtrasComponent` when toggling component questions. [[1]](diffhunk://#diff-6f5109ae4e849a360472b6b904c5b164aa7d7e8df9fe3b709fda8cc5bc7dc9a1L80-R89) [[2]](diffhunk://#diff-277f37b24ba2a400fc792db21c1b159e564db04704d2c28e36b211421d6c9cdfR219-R221)
* Fixed a comment typo in `QuestionsComponent`.

**API and Type Improvements:**
* Updated `getComponentQuestionsList` in `QuestionsService` to return a typed `Observable<QuestionResponse>`, enhancing type safety and clarity.

**Backend Cleanup:**
* Removed unused code in the backend controller related to the `RENEW` skin, simplifying the API logic.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
