### PR TITLE
Fixed chart gridlines in dark mode

### DIFF
--- a/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.ts
@@ -27,6 +27,7 @@ import { AnalysisService } from '../../../../services/analysis.service';
 import { AssessmentService } from '../../../../services/assessment.service';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import Chart from 'chart.js/auto';
+import { ThemeService } from '../../../../services/theme.service';
 
 @Component({
     selector: 'app-components-ranked',

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.ts
@@ -28,13 +28,14 @@ import { AnalysisService } from '../../../../services/analysis.service';
 import { LayoutService } from '../../../../services/layout.service';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import { TranslocoService } from '@jsverse/transloco';
+import { ThemeService } from '../../../../services/theme.service';
 
 @Component({
-    selector: 'app-standards-ranked',
-    templateUrl: './standards-ranked.component.html',
-    // eslint-disable-next-line
-    host: { class: 'd-flex flex-column flex-11a' },
-    standalone: false
+  selector: 'app-standards-ranked',
+  templateUrl: './standards-ranked.component.html',
+  // eslint-disable-next-line
+  host: { class: 'd-flex flex-column flex-11a' },
+  standalone: false
 })
 export class StandardsRankedComponent implements OnInit {
   chartIsVisible = false;
@@ -47,7 +48,8 @@ export class StandardsRankedComponent implements OnInit {
     private tSvc: TranslocoService,
     public navSvc: NavigationService,
     private router: Router,
-    public layoutSvc: LayoutService
+    public layoutSvc: LayoutService,
+    public themeSvc: ThemeService
   ) { }
 
   ngOnInit() {
@@ -61,6 +63,14 @@ export class StandardsRankedComponent implements OnInit {
     if (this.chart) {
       this.chart.destroy();
     }
+
+    // Get the current theme colors for dark mode support
+    const isDark = this.themeSvc.isDarkMode();
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
+
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = this.themeSvc.updateAlpha(textColor, .2);
+
     this.initialized = false;
     this.dataRows = x.dataRows;
     this.dataRows.map(r => {

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.ts
@@ -29,13 +29,14 @@ import { AssessmentService } from '../../../../services/assessment.service';
 import { StandardService } from '../../../../services/standard.service';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import { LayoutService } from '../../../../services/layout.service';
+import { ThemeService } from '../../../../services/theme.service';
 
 @Component({
-    selector: 'app-standards-results',
-    templateUrl: './standards-results.component.html',
-    // eslint-disable-next-line
-    host: { class: 'd-flex flex-column flex-11a' },
-    standalone: false
+  selector: 'app-standards-results',
+  templateUrl: './standards-results.component.html',
+  // eslint-disable-next-line
+  host: { class: 'd-flex flex-column flex-11a' },
+  standalone: false
 })
 export class StandardsResultsComponent implements OnInit {
 
@@ -51,6 +52,7 @@ export class StandardsResultsComponent implements OnInit {
     public navSvc: NavigationService,
     private stdSvc: StandardService,
     private router: Router,
+    public themeSvc: ThemeService,
     public layoutSvc: LayoutService) { }
 
   ngOnInit() {
@@ -67,6 +69,14 @@ export class StandardsResultsComponent implements OnInit {
     if (tempChart) {
       tempChart.destroy();
     }
+
+    // Get the current theme colors for dark mode support
+    const isDark = this.themeSvc.isDarkMode();
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
+    
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = this.themeSvc.updateAlpha(textColor, .2);
+
     this.chart = new Chart('canvasStandardResult', {
       type: 'bar',
       data: {

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.ts
@@ -29,6 +29,7 @@ import { ConfigService } from '../../../../services/config.service';
 import { LayoutService } from '../../../../services/layout.service';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import { TranslocoService } from '@jsverse/transloco';
+import { ThemeService } from '../../../../services/theme.service';
 
 @Component({
     selector: 'app-standards-summary',
@@ -51,6 +52,7 @@ export class StandardsSummaryComponent implements OnInit, AfterViewInit {
     public navSvc: NavigationService,
     public configSvc: ConfigService,
     public layoutSvc: LayoutService,
+    public themeSvc: ThemeService,
     public tSvc: TranslocoService
   ) { }
 
@@ -74,6 +76,14 @@ export class StandardsSummaryComponent implements OnInit, AfterViewInit {
     if (tempChart) {
       tempChart.destroy();
     }
+
+    // Get the current theme colors for dark mode support
+    const isDark = this.themeSvc.isDarkMode();
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
+
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = this.themeSvc.updateAlpha(textColor, .2);
+
     if (this.dataSets.length > 1) {
       this.chart = new Chart('canvasStandardSummary', {
         type: 'bar',

--- a/CSETWebNg/src/app/initial/search-page/search-page.component.ts
+++ b/CSETWebNg/src/app/initial/search-page/search-page.component.ts
@@ -31,6 +31,7 @@ import Fuse from 'fuse.js';
 import { map } from 'lodash';
 import { ConfigService } from '../../services/config.service';
 import { NavigationService } from '../../services/navigation/navigation.service';
+import DOMPurify from 'dompurify';
 
 @Component({
   selector: 'app-search-page',
@@ -108,9 +109,12 @@ export class SearchPageComponent implements OnInit, AfterViewInit {
       (resp: any) => {
         resp.rows.forEach(element => {
           element.galleryItems.forEach(item => {
+            const cleanDesc = DOMPurify.sanitize(item.description);
+            dom.innerHTML = cleanDesc;
+
             // create a plainText property for the elipsis display in case a description has HTML markup
-            dom.innerHTML = item.description;
             item.plainText = dom.innerText;
+            
             this.galleryItems.push(item);
             this.galleryItemsTmp.push(item);
           })

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
@@ -29,6 +29,7 @@ import { ReportAnalysisService } from '../../services/report-analysis.service';
 import { AssessmentService } from '../../services/assessment.service';
 import { TranslocoService } from '@jsverse/transloco';
 import { AssessmentDetail } from '../../models/assessment-info.model';
+import DOMPurify from 'dompurify';
 
 
 @Component({
@@ -92,7 +93,7 @@ export class SecurityplanComponent implements OnInit {
 
       // Network Diagram
       this.reportSvc.getNetworkDiagramImage().subscribe(y => {
-        this.networkDiagramImage = this.sanitizer.bypassSecurityTrustHtml(y.diagram);
+        this.networkDiagramImage = DOMPurify.sanitize(y.diagram);
       });
     });
 

--- a/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
+++ b/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
@@ -32,6 +32,7 @@ import Chart from 'chart.js/auto';
 import { AssessmentService } from '../../services/assessment.service';
 import { TranslocoService } from '@jsverse/transloco';
 import { AssessmentDetail } from '../../models/assessment-info.model';
+import DOMPurify from 'dompurify';
 
 @Component({
   selector: 'site-detail',
@@ -113,7 +114,7 @@ export class SiteDetailComponent implements OnInit {
     });
 
     this.reportSvc.getNetworkDiagramImage().subscribe(x => {
-      this.networkDiagramImage = this.sanitizer.bypassSecurityTrustHtml(x.diagram);
+      this.networkDiagramImage = DOMPurify.sanitize(x.diagram);
     });
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {

--- a/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
+++ b/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
@@ -33,6 +33,7 @@ import { AssessmentService } from '../../services/assessment.service';
 import { TranslocoService } from '@jsverse/transloco';
 import Chart from 'chart.js/auto';
 import { AssessmentDetail } from '../../models/assessment-info.model';
+import DOMPurify from 'dompurify';
 
 @Component({
   selector: 'site-summary',
@@ -130,7 +131,8 @@ export class SiteSummaryComponent implements OnInit, AfterViewInit {
     });
 
     this.reportSvc.getNetworkDiagramImage().subscribe(x => {
-      this.networkDiagramImage = this.sanitizer.bypassSecurityTrustHtml(x.diagram);
+      console.log('x.diagram = ', x.diagram);
+      this.networkDiagramImage = DOMPurify.sanitize(x.diagram);
     });
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {

--- a/CSETWebNg/src/app/services/analysis.service.ts
+++ b/CSETWebNg/src/app/services/analysis.service.ts
@@ -27,6 +27,7 @@ import { ConfigService } from './config.service';
 import Chart from 'chart.js/auto';
 import { ChartService } from './chart.service';
 import { TranslocoService } from '@jsverse/transloco';
+import { ThemeService } from './theme.service';
 
 @Injectable({
   providedIn: 'root'
@@ -40,6 +41,7 @@ export class AnalysisService {
     private http: HttpClient,
     private configSvc: ConfigService,
     private chartSvc: ChartService,
+    public themeSvc: ThemeService,
     private tSvc: TranslocoService
   ) {
   }
@@ -331,6 +333,14 @@ export class AnalysisService {
     if (tempChart) {
       tempChart.destroy();
     }
+
+    // Get the current theme colors for dark mode support
+    const isDark = this.themeSvc.isDarkMode();
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
+
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = this.themeSvc.updateAlpha(textColor, .2);
+
     return new Chart(canvasId, {
       type: 'bar',
       data: {
@@ -382,6 +392,14 @@ export class AnalysisService {
     if (tempChart) {
       tempChart.destroy();
     }
+
+    // Get the current theme colors for dark mode support
+    const isDark = this.themeSvc.isDarkMode();
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
+
+    Chart.defaults.color = textColor;
+    Chart.defaults.borderColor = this.themeSvc.updateAlpha(textColor, .2);
+
     return new Chart(canvasId, {
       type: 'bar',
       data: {

--- a/CSETWebNg/src/app/services/chart.service.ts
+++ b/CSETWebNg/src/app/services/chart.service.ts
@@ -151,7 +151,7 @@ export class ChartService {
 
     // Get theme-aware colors
     const isDark = this.themeSvc.isDarkMode();
-    const textColor = isDark ? '#ffffff' : '#666666';
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
 
     var myOptions: any = {
       indexAxis: 'y',
@@ -240,7 +240,7 @@ export class ChartService {
 
     // Get the current theme colors for dark mode support
     const isDark = this.themeSvc.isDarkMode();
-    const textColor = isDark ? '#ffffff' : '#000000';
+    const textColor = isDark ? '#ffffffdd' : '#000000dd';
 
     return new Chart(canvasId, {
       type: 'doughnut',

--- a/CSETWebNg/src/app/services/file-export.service.ts
+++ b/CSETWebNg/src/app/services/file-export.service.ts
@@ -76,9 +76,12 @@ export class FileExportService {
     a.href = url;
 
     const contentDisposition = response.headers.get('Content-Disposition');
-    const filename = this.getFilenameFromContentDisposition(contentDisposition);
+    let filename = this.getFilenameFromContentDisposition(contentDisposition);
+
 
     a.download = filename;
+    a.style.display = 'none';
+
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -88,11 +91,35 @@ export class FileExportService {
    * Parses the filename from the Content-Disposition header contents.
    * If it can't find a filename, the file is named "downloaded_file" with no extension.
    */
-  private getFilenameFromContentDisposition(contentDisposition: string | null): string {
+  private getFilenameFromContentDispositionAAAAAA(contentDisposition: string | null): string {
     if (!contentDisposition) {
       return 'downloaded_file';
     }
     const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDisposition);
     return (matches != null && matches[1]) ? matches[1].replace(/['"]/g, '') : 'downloaded_file';
+  }
+
+  /**
+   * 
+   */
+  private getFilenameFromContentDisposition(contentDisposition: string | null): string {
+    if (!contentDisposition) {
+      return 'downloaded_file';
+    }
+
+    const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDisposition);
+    let filename = (matches != null && matches[1]) ? matches[1].replace(/['"]/g, '') : 'downloaded_file';
+
+    // Decode URL-encoded filenames
+    try {
+      filename = decodeURIComponent(filename);
+    } catch (e) {
+      // If decoding fails, use the original filename
+    }
+
+    // Sanitize the filename
+    filename = filename.replace(/[^a-zA-Z0-9_\-\.]/g, '_');
+
+    return filename;
   }
 }

--- a/CSETWebNg/src/app/services/gallery.service.ts
+++ b/CSETWebNg/src/app/services/gallery.service.ts
@@ -27,6 +27,7 @@ import { ConfigService } from './config.service';
 import { AssessmentService } from './assessment.service';
 import { NavigationService } from './navigation/navigation.service';
 import { AuthenticationService } from './authentication.service';
+import DOMPurify from 'dompurify';
 
 const headers = {
   headers: new HttpHeaders()
@@ -72,11 +73,13 @@ export class GalleryService {
         this.rows = this.galleryData.rows;
         this.testRow = this.rows[1];
 
-        // create a plainText property for the elipsis display in case a description has HTML markup
         const dom = document.createElement("div");
         this.rows.forEach(row => {
           row.galleryItems.forEach(item => {
-            dom.innerHTML = item.description;
+            const cleanDesc = DOMPurify.sanitize(item.description);
+            dom.innerHTML = cleanDesc;
+            
+            // create a plainText property for the elipsis display in case a description has HTML markup
             item.plainText = dom.innerText;
           });
         });

--- a/CSETWebNg/src/app/services/navigation/navigation.service.ts
+++ b/CSETWebNg/src/app/services/navigation/navigation.service.ts
@@ -32,6 +32,7 @@ import { NavTreeService } from './nav-tree.service';
 import { QuestionsService } from '../questions.service';
 import { ConstantsService } from '../constants.service';
 import { BehaviorSubject } from 'rxjs';
+import DOMPurify from 'dompurify';
 
 
 export interface NavTreeNode {
@@ -412,8 +413,8 @@ export class NavigationService implements OnDestroy, OnInit {
 
     // determine the route path
     const targetPath = targetNode.attributes['path'].value.replace('{:id}', this.assessSvc.id().toString());
-    this.router.navigateByUrl(targetPath);
-  //  this.router.navigate([targetPath]);
+    const cleanPath = DOMPurify.sanitize(targetPath);
+    this.router.navigateByUrl(cleanPath);
   }
 
   /**

--- a/CSETWebNg/src/app/services/theme.service.ts
+++ b/CSETWebNg/src/app/services/theme.service.ts
@@ -141,4 +141,45 @@ export class ThemeService {
       });
     }
   }
+
+  /**
+   * Returns a hex HTML color code with a new alpha (opacity) value applied.
+   * The input color code can be hex or rgba.
+   * @param color 
+   * @param newAlpha 
+   * @returns 
+   */
+  updateAlpha(color: string, newAlpha: number): string {
+    // Ensure the alpha value is between 0 and 1
+    newAlpha = Math.max(0, Math.min(1, newAlpha));
+
+    // Check if the color is in rgba format
+    const rgbaMatch = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*([\d\.]*)\)$/);
+
+    if (rgbaMatch) {
+      const [, r, g, b] = rgbaMatch;
+      return `rgba(${r}, ${g}, ${b}, ${newAlpha})`;
+    }
+
+    // Check if the color is in hex format
+    const hexMatch = color.match(/^#([0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{3})$/i);
+
+    if (hexMatch) {
+      let hexValue = hexMatch[1];
+
+      if (hexValue.length === 3) {
+        hexValue = hexValue.split('').map(char => char + char).join('');
+      }
+
+      if (hexValue.length === 6) {
+        hexValue += Math.round(newAlpha * 255).toString(16).padStart(2, '0');
+      } else if (hexValue.length === 8) {
+        hexValue = hexValue.slice(0, 6) + Math.round(newAlpha * 255).toString(16).padStart(2, '0');
+      }
+
+      return `#${hexValue}`;
+    }
+
+    throw new Error('Invalid color format');
+  }
 }


### PR DESCRIPTION
This pull request introduces several improvements focused on dark mode support for charts and enhanced sanitization of HTML content throughout the application. The most significant changes include consistent theme-aware chart styling, improved security for rendering HTML by using DOMPurify, and safer handling of file downloads and navigation paths.

**Dark Mode & Chart Theming**

* Added `ThemeService` to multiple components and services, and updated chart initialization logic to dynamically set `Chart.defaults.color` and `Chart.defaults.borderColor` based on the current theme, improving dark mode support across analysis and reporting components. (`components-ranked.component.ts`, `standards-ranked.component.ts`, `standards-results.component.ts`, `standards-summary.component.ts`, `analysis.service.ts`, `chart.service.ts`) [[1]](diffhunk://#diff-fb6a0acd92a648c5c46709e3cc32e8c8faf6e5ebb45dc2ef5b748387288c4808R30) [[2]](diffhunk://#diff-cdd1b94c38491bb6756ce82a8440138b04b1c8b4995e6d73c4dabdffdf72229eR31) [[3]](diffhunk://#diff-cdd1b94c38491bb6756ce82a8440138b04b1c8b4995e6d73c4dabdffdf72229eL50-R52) [[4]](diffhunk://#diff-cdd1b94c38491bb6756ce82a8440138b04b1c8b4995e6d73c4dabdffdf72229eR66-R73) [[5]](diffhunk://#diff-712140c20cd247414be05fdc4e5efc01db99e8092a8ad6c1ac57d879411eb2f7R32) [[6]](diffhunk://#diff-712140c20cd247414be05fdc4e5efc01db99e8092a8ad6c1ac57d879411eb2f7R55) [[7]](diffhunk://#diff-712140c20cd247414be05fdc4e5efc01db99e8092a8ad6c1ac57d879411eb2f7R72-R79) [[8]](diffhunk://#diff-da8ef67c76806feb624d7771dbec3440c5f8ac41f08666ef57b246be0ee0496eR32) [[9]](diffhunk://#diff-da8ef67c76806feb624d7771dbec3440c5f8ac41f08666ef57b246be0ee0496eR55) [[10]](diffhunk://#diff-da8ef67c76806feb624d7771dbec3440c5f8ac41f08666ef57b246be0ee0496eR79-R86) [[11]](diffhunk://#diff-f65cc94145c7a0d0f2055757940047f8c82826e8456330c44d3a524c836a4ad2R30) [[12]](diffhunk://#diff-f65cc94145c7a0d0f2055757940047f8c82826e8456330c44d3a524c836a4ad2R44) [[13]](diffhunk://#diff-f65cc94145c7a0d0f2055757940047f8c82826e8456330c44d3a524c836a4ad2R336-R343) [[14]](diffhunk://#diff-f65cc94145c7a0d0f2055757940047f8c82826e8456330c44d3a524c836a4ad2R395-R402) [[15]](diffhunk://#diff-68302564fb3e792a3091acb2ac0bd25feb1776f900e19def5bcdc490a31aa558L154-R154) [[16]](diffhunk://#diff-68302564fb3e792a3091acb2ac0bd25feb1776f900e19def5bcdc490a31aa558L243-R243)

**HTML Sanitization Enhancements**

* Replaced usage of Angular's `bypassSecurityTrustHtml` with `DOMPurify.sanitize` for rendering network diagrams in reporting components, reducing XSS risk. (`securityplan.component.ts`, `site-detail.component.ts`, `site-summary.component.ts`) [[1]](diffhunk://#diff-e340d09f0200c3d2b1f8a8b5cf4b38b48d640b731f477989228afe2d972b557cR32) [[2]](diffhunk://#diff-e340d09f0200c3d2b1f8a8b5cf4b38b48d640b731f477989228afe2d972b557cL95-R96) [[3]](diffhunk://#diff-056ff9cbceb596d8c9315a00fd381ccc602cf8e016e148be5bbb07800f39b0f2R35) [[4]](diffhunk://#diff-056ff9cbceb596d8c9315a00fd381ccc602cf8e016e148be5bbb07800f39b0f2L116-R117) [[5]](diffhunk://#diff-fa911eb71b743f7e56800f346f90fdf5646fa207315d25615ec48747cc6cc6c4R36) [[6]](diffhunk://#diff-fa911eb71b743f7e56800f346f90fdf5646fa207315d25615ec48747cc6cc6c4L133-R135)
* Applied `DOMPurify.sanitize` to gallery item descriptions in both the search page and gallery service to ensure only safe HTML is rendered and extracted for display. (`search-page.component.ts`, `gallery.service.ts`) [[1]](diffhunk://#diff-76b51133642a8fc7adc268c5b86c1718e5591f4e0bf07329d3022f18886d91c7R34) [[2]](diffhunk://#diff-76b51133642a8fc7adc268c5b86c1718e5591f4e0bf07329d3022f18886d91c7R112-R117) [[3]](diffhunk://#diff-afc2611b157ede111bd2711b104a5141ae1a8ff93e43688ace368d39fac1e65eR30) [[4]](diffhunk://#diff-afc2611b157ede111bd2711b104a5141ae1a8ff93e43688ace368d39fac1e65eL75-R82)
* Sanitized navigation paths before routing to prevent injection attacks. (`navigation.service.ts`) [[1]](diffhunk://#diff-5ab5912beb605063c03ec35104ebea538e6ee0e85a9bad12e311e3ec833e5a63R35) [[2]](diffhunk://#diff-5ab5912beb605063c03ec35104ebea538e6ee0e85a9bad12e311e3ec833e5a63L415-R417)

**File Download Security**

* Improved filename extraction and sanitization in `FileExportService` to safely decode and clean filenames from HTTP headers, preventing unsafe file names during downloads. (`file-export.service.ts`) [[1]](diffhunk://#diff-d4b9a88e28ac9bf4e79657e0cca6380929af54eb46c711dc9c4aa9786d84c0e4L79-R84) [[2]](diffhunk://#diff-d4b9a88e28ac9bf4e79657e0cca6380929af54eb46c711dc9c4aa9786d84c0e4L91-R124)

These changes collectively improve the application's accessibility, security, and user experience, especially for users utilizing dark mode and when interacting with dynamic HTML or file downloads.Also fixed a few vulnerabilities

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
