### PR TITLE
feat(docker): add runtime API configuration via environment variables

### DIFF
--- a/CSETWebNg/Dockerfile
+++ b/CSETWebNg/Dockerfile
@@ -20,6 +20,11 @@ FROM nginx:alpine
 COPY --from=build /var/www/dist/browser/ /usr/share/nginx/html
 COPY ./etc/nginx/default.conf /etc/nginx/conf.d/default.conf
 
+# Copy entrypoint script for runtime config injection (API_PORT, API_HOST)
+COPY ./etc/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
 EXPOSE 80 443
 
-CMD ["nginx", "-g", "daemon off;"]
+# Use entrypoint to inject env vars before starting nginx
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/CSETWebNg/etc/docker-entrypoint.sh
+++ b/CSETWebNg/etc/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+CONFIG_FILE="/usr/share/nginx/html/assets/settings/config.json"
+
+# Replace API port if API_PORT env var is set (default: 5000)
+if [ -n "$API_PORT" ]; then
+  sed -i 's/"port": "5000"/"port": "'"$API_PORT"'"/' "$CONFIG_FILE"
+fi
+
+# Replace API host if API_HOST env var is set (default: localhost)
+if [ -n "$API_HOST" ]; then
+  # Replace only the api.host, not app.host - target the line after "api": {
+  sed -i '/"api":/,/"library":/ s/"host": "localhost"/"host": "'"$API_HOST"'"/' "$CONFIG_FILE"
+fi
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,8 @@ services:
     tty: true
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    environment:
+      - API_PORT=${API_PORT:-5000}
     ports:
       # Override host ports via WEB_PORT / WEB_TLS_PORT without editing this file.
       - ${WEB_PORT:-4200}:80


### PR DESCRIPTION
## Summary

Adds runtime configuration capability for the frontend Docker container to configure the API endpoint (host and port) via environment variables at container startup, eliminating the need to rebuild the image when deploying to different environments.

## Commits

- `f010b13` feat(docker): add runtime API configuration via environment variables

## Changes

- **New entrypoint script** (`CSETWebNg/etc/docker-entrypoint.sh`): Injects `API_PORT` and `API_HOST` environment variables into the frontend's `config.json` at container startup using sed
- **Updated Dockerfile**: Uses the new entrypoint script instead of running nginx directly
- **Updated compose.yml**: Passes `API_PORT` environment variable to the frontend container (defaults to 5000)

## Breaking Changes

None

## Test Plan

- [ ] Build the frontend Docker image: `docker compose build web`
- [ ] Start with default settings: `docker compose up web` (should use port 5000)
- [ ] Test custom API port: `API_PORT=8080 docker compose up web` and verify config.json reflects port 8080
- [ ] Test custom API host: Add `API_HOST=api.example.com` environment variable and verify host is updated
- [ ] Verify nginx starts correctly and serves the frontend

## Release Notes

Frontend Docker container now supports runtime configuration of the API endpoint via `API_PORT` and `API_HOST` environment variables, enabling flexible deployment across different environments without image rebuilds.

## Checklist

- [x] Conventional commit format followed
- [ ] Tests pass locally
- [ ] Documentation updated (if needed)