### PR TITLE
feature: convert usp_CopyIntoSet_Delete stored procedure to LINQ

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -103,7 +103,7 @@ namespace CSETWebCore.Business.ModuleBuilder
         {
             try
             {
-                _context.usp_CopyIntoSet_Delete(setName);
+                DeleteCopiedSetData(setName);
                 foreach (string sourceSet in setNames)
                 {
                     _context.usp_CopyIntoSet(sourceSet, setName);
@@ -219,7 +219,44 @@ namespace CSETWebCore.Business.ModuleBuilder
 
         public void DeleteCopyToSet(string setName)
         {
-            _context.usp_CopyIntoSet_Delete(setName);
+            DeleteCopiedSetData(setName);
+        }
+
+
+        /// <summary>
+        /// Deletes all data associated with a copied custom set.
+        /// This replaces the usp_CopyIntoSet_Delete stored procedure.
+        /// </summary>
+        /// <param name="setName">The name of the set to delete data for</param>
+        private void DeleteCopiedSetData(string setName)
+        {
+            // Validate: cannot modify standard (non-custom) sets
+            var set = _context.SETS.FirstOrDefault(s => s.Set_Name == setName);
+            if (set != null && !set.Is_Custom)
+            {
+                throw new InvalidOperationException("Destination set is not a custom set. Standard sets cannot be modified.");
+            }
+
+            // Delete from all related tables in the correct order
+            _context.REQUIREMENT_SETS.RemoveRange(
+                _context.REQUIREMENT_SETS.Where(rs => rs.Set_Name == setName));
+
+            _context.REQUIREMENT_QUESTIONS_SETS.RemoveRange(
+                _context.REQUIREMENT_QUESTIONS_SETS.Where(rqs => rqs.Set_Name == setName));
+
+            _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.RemoveRange(
+                _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.Where(usch => usch.Set_Name == setName));
+
+            _context.NEW_QUESTION_SETS.RemoveRange(
+                _context.NEW_QUESTION_SETS.Where(nqs => nqs.Set_Name == setName));
+
+            _context.NEW_REQUIREMENT.RemoveRange(
+                _context.NEW_REQUIREMENT.Where(nr => nr.Original_Set_Name == setName));
+
+            _context.CUSTOM_STANDARD_BASE_STANDARD.RemoveRange(
+                _context.CUSTOM_STANDARD_BASE_STANDARD.Where(csbs => csbs.Custom_Questionaire_Name == setName));
+
+            _context.SaveChanges();
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
@@ -378,17 +378,6 @@ namespace CSETWebCore.DataLayer.Model
 
         }
 
-        public virtual void usp_CopyIntoSet_Delete(string setName)
-        {
-            this.LoadStoredProc("usp_CopyIntoSet_Delete")
-                     .WithSqlParam("DestinationSetName", setName)
-                     .ExecuteStoredProc((handler) =>
-                     {
-
-                     });
-        }
-
-
         /// <summary>
         /// Inserts missing skeleton ANSWER records for an assessment based on 
         /// its standard selection and SAL.  

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContextProcedures.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContextProcedures.cs
@@ -1033,33 +1033,6 @@ namespace CSETWebCore.DataLayer.Model
             return _;
         }
 
-        public virtual async Task<int> usp_CopyIntoSet_DeleteAsync(string destinationSetName, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default)
-        {
-            var parameterreturnValue = new SqlParameter
-            {
-                ParameterName = "returnValue",
-                Direction = System.Data.ParameterDirection.Output,
-                SqlDbType = System.Data.SqlDbType.Int,
-            };
-
-            var sqlParameters = new []
-            {
-                new SqlParameter
-                {
-                    ParameterName = "DestinationSetName",
-                    Size = 100,
-                    Value = destinationSetName ?? Convert.DBNull,
-                    SqlDbType = System.Data.SqlDbType.NVarChar,
-                },
-                parameterreturnValue,
-            };
-            var _ = await _context.Database.ExecuteSqlRawAsync("EXEC @returnValue = [dbo].[usp_CopyIntoSet_Delete] @DestinationSetName = @DestinationSetName", sqlParameters, cancellationToken);
-
-            returnValue?.SetValue(parameterreturnValue.Value);
-
-            return _;
-        }
-
         public virtual async Task<List<usp_countsForLevelsByGroupMaturityModelResult>> usp_countsForLevelsByGroupMaturityModelAsync(int? assessment_id, int? mat_model_id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default)
         {
             var parameterreturnValue = new SqlParameter

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/ICsetwebContextProcedures.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/ICsetwebContextProcedures.cs
@@ -45,7 +45,6 @@ namespace CSETWebCore.DataLayer.Model
         Task<List<usp_Assessments_For_UserResult>> usp_Assessments_For_UserAsync(int? user_Id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
         Task<int> usp_BuildCatNumbersAsync(int? assessment_id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
         Task<int> usp_CopyIntoSetAsync(string sourceSetName, string destinationSetName, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
-        Task<int> usp_CopyIntoSet_DeleteAsync(string destinationSetName, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
         Task<List<usp_countsForLevelsByGroupMaturityModelResult>> usp_countsForLevelsByGroupMaturityModelAsync(int? assessment_id, int? mat_model_id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
         Task<List<usp_getAnswerComponentOverridesResult>> usp_getAnswerComponentOverridesAsync(int? assessment_id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);
         Task<List<usp_getComponentsRankedCategoriesResult>> usp_getComponentsRankedCategoriesAsync(int? assessment_id, OutputParameter<int> returnValue = null, CancellationToken cancellationToken = default);

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/efpt.config.json
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/efpt.config.json
@@ -1164,10 +1164,6 @@
          "ObjectType": 1
       },
       {
-         "Name": "[dbo].[usp_CopyIntoSet_Delete]",
-         "ObjectType": 1
-      },
-      {
          "Name": "[dbo].[usp_CopyIntoSet]",
          "ObjectType": 1
       },

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.UpgradeLibrary/VersionUpgrader/SQL/12404_to_12405.sql
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.UpgradeLibrary/VersionUpgrader/SQL/12404_to_12405.sql
@@ -277,3 +277,8 @@ GO
 IF OBJECT_ID('dbo.clean_out_requirements_mode', 'P') IS NOT NULL
     DROP PROCEDURE dbo.clean_out_requirements_mode;
 GO
+
+-- usp_CopyIntoSet_Delete (replaced with LINQ equivalent in ModuleBuilderBusiness.cs)
+IF OBJECT_ID('dbo.usp_CopyIntoSet_Delete', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.usp_CopyIntoSet_Delete;
+GO


### PR DESCRIPTION
## Summary
Converts the `usp_CopyIntoSet_Delete` stored procedure to a LINQ equivalent as part of the ongoing effort to reduce stored procedure dependencies and improve code maintainability.

## Commits
- `f879e931e` chore(database): add DROP statement for usp_CopyIntoSet_Delete
- `1641e812d` refactor(modulebuilder): replace usp_CopyIntoSet_Delete with LINQ
- `c2a6c6db9` chore(datalayer): remove usp_CopyIntoSet_Delete stored procedure wrapper

## Changes
- Added `DeleteCopiedSetData` private method in `ModuleBuilderBusiness.cs` that replicates the stored procedure logic
- Added validation to prevent accidental modification of non-custom standard sets
- Deletes from related tables in the correct dependency order:
  - REQUIREMENT_SETS
  - REQUIREMENT_QUESTIONS_SETS
  - UNIVERSAL_SUB_CATEGORY_HEADINGS
  - NEW_QUESTION_SETS
  - NEW_REQUIREMENT
  - CUSTOM_STANDARD_BASE_STANDARD
- Updated `SetBaseSets` and `DeleteCopyToSet` methods to use the new LINQ implementation
- Removed stored procedure wrapper from CSETContext.cs
- Removed generated async method from CsetwebContextProcedures.cs
- Removed interface declaration from ICsetwebContextProcedures.cs
- Removed procedure from efpt.config.json scaffold configuration
- Added DROP statement in database migration script (12404_to_12405.sql)

## Breaking Changes
None

## Test Plan
- [ ] Build the backend project to verify no compilation errors
- [ ] Test the Module Builder functionality:
  - Create a new custom set
  - Add base standards to the custom set
  - Modify the base standards selection (triggers delete + re-copy)
  - Verify the custom set reflects the new base standards correctly
- [ ] Verify standard (non-custom) sets cannot be accidentally modified

## Related Issues
Continues the stored procedure cleanup effort from PR #5240

## Release Notes
Internal refactoring to convert stored procedure to LINQ for improved maintainability. No user-facing changes.

## Checklist
- [ ] Tests pass locally
- [ ] Backend builds successfully
- [ ] Documentation updated (N/A - internal refactoring)
- [ ] Conventional commit format followed