### PR TITLE
refactor(frontend): simplify report and resource library URL routing

### DIFF
--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
@@ -63,7 +63,7 @@ export class CompareAnalyticsComponent implements OnInit {
   }
 
   generateReport(reportType: string) {
-    const url = '/index.html?returnPath=report/' + reportType;
+    const url = '/report/' + reportType;
     window.open(url, "_blank");
   }
 }

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
@@ -90,7 +90,7 @@ export class TrendAnalyticsComponent implements OnInit {
   }
 
   generateReport(reportType: string) {
-    const url = '/index.html?returnPath=report/' + reportType;
+    const url = '/report/' + reportType;
     window.open(url, "_blank");
   };
 }

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
@@ -179,7 +179,7 @@ export class ReportsComponent implements OnInit, AfterViewInit {
    * and into their own sub-components.
    */
   clickReportLink(reportType: string) {
-    const url = '/index.html?returnPath=report/' + reportType;
+    const url = '/report/' + reportType;
     localStorage.setItem('REPORT-' + reportType.toUpperCase(), print.toString());
 
     window.open(url, '_blank');

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
@@ -101,7 +101,7 @@
 
 
     <div *ngIf="showResourceLibraryLink()">
-        <a mat-button class="navbar-menu-header ws-no-wrap" href="index.html?returnPath=resource-library"
+        <a mat-button class="navbar-menu-header ws-no-wrap" href="/resource-library"
             target="_blank">
             <span class="cset-icons-library fs-base-4 me-2 align-middle"></span>
             <span>{{t('menu.resource library')}}</span>

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
@@ -133,7 +133,7 @@ export class TopMenusComponent implements OnInit {
     // Resource Library
     this._hotkeysService.add(
       new Hotkey('alt+l', (event: KeyboardEvent): boolean => {
-        const url = 'index.html?returnPath=resource-library';
+        const url = '/resource-library';
         window.open(url, '_blank');
         return false; // Prevent bubbling
       })

--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
@@ -218,7 +218,7 @@ export class ModuleContentLaunchComponent implements OnInit {
    *
    */
   launchModelReport() {
-    const url = '/index.html?returnPath=report/module-content?mm=' + this.selectedModel;
+    const url = '/report/module-content?mm=' + this.selectedModel;
     window.open(url, '_blank');
   }
 
@@ -226,7 +226,7 @@ export class ModuleContentLaunchComponent implements OnInit {
    *
    */
   launchStandardReport() {
-    const url = '/index.html?returnPath=report/module-content?m=' + this.selectedStandard;
+    const url = '/report/module-content?m=' + this.selectedStandard;
     window.open(url, '_blank');
   }
 

--- a/CSETWebNg/src/app/services/report.service.ts
+++ b/CSETWebNg/src/app/services/report.service.ts
@@ -153,7 +153,7 @@ export class ReportService {
    * Opens a new window/tab
    */
   clickReportLink(reportType: string, print: boolean = false) {
-    const url = '/index.html?returnPath=report/' + reportType;
+    const url = '/report/' + reportType;
     localStorage.setItem('REPORT-' + reportType.toUpperCase(), print.toString());
     localStorage.setItem('report-confidentiality', this.confidentiality);
     window.open(url, '_blank');


### PR DESCRIPTION
## Summary
Simplifies URL routing in the Angular frontend by replacing the legacy `index.html?returnPath=` pattern with direct route URLs. This removes unnecessary indirection and cleans up the navigation logic.

## Commits
- `1dadf28` refactor(frontend): simplify report and resource library URL routing

## Changes
- Updated report generation URLs in compare-analytics and trend-analytics components
- Simplified report link handler in reports component
- Fixed resource library link and hotkey in top-menus component
- Updated module content launch URLs for model and standard reports
- Cleaned up report service click handler

## Breaking Changes
None

## Test Plan
- [ ] Verify report links open correctly from assessment results page
- [ ] Verify compare analytics report generation works
- [ ] Verify trend analytics report generation works
- [ ] Verify resource library link in top menu opens correctly
- [ ] Verify Alt+L hotkey opens resource library in new tab
- [ ] Verify module content reports launch correctly

## Related Issues
None

## Release Notes
Simplified internal URL routing for report and resource library links, removing legacy redirect patterns for cleaner navigation.

## Checklist
- [ ] Tests pass locally
- [ ] Linting passes
- [x] Conventional commit format followed