### PR TITLE
fix(config): add missing report/ prefix in IIS rewrite rule

### DIFF
--- a/CSETWebNg/src/web.config
+++ b/CSETWebNg/src/web.config
@@ -74,7 +74,7 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
           </conditions>
-          <action type="Redirect" url="/index.html?returnPath={R1}" appendQueryString="true" />
+          <action type="Redirect" url="/index.html?returnPath=report/{R1}" appendQueryString="true" />
         </rule>
       </rules>
     </rewrite>


### PR DESCRIPTION
## Summary
Fixes reports not working in production after PR #5268 simplified report URLs.

## Commits
- `bba6c6b` fix(config): add missing report/ prefix in IIS rewrite rule

## Changes
- Updated the Reports rewrite rule in `web.config` to include the `report/` prefix in the `returnPath` redirect URL

## Root Cause
The Reports rewrite rule in `web.config` was matching `/report/(.+)` and redirecting to `/index.html?returnPath={R1}`. The capture group only captured what comes AFTER `report/`, so navigating to `/report/executive` redirected to `/index.html?returnPath=executive` (missing the `report/` prefix). Angular then tried to navigate to `/executive` instead of `/report/executive`.

This worked before PR #5268 because report links used `/index.html?returnPath=report/executive` directly, bypassing the rewrite rule.

## Breaking Changes
None

## Test Plan
- [ ] Deploy to a test IIS instance
- [ ] Verify report links open correctly from assessment results page
- [ ] Verify compare analytics report generation works  
- [ ] Verify trend analytics report generation works
- [ ] Verify module content reports launch correctly

## Related Issues
Regression from PR #5268

## Release Notes
Fixed reports not opening in production due to incorrect IIS URL rewrite rule.

## Checklist
- [x] Conventional commit format followed