### PR TITLE
fix(config): add missing report/ prefix in API IIS rewrite rule

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/IISUrlRewrite.xml
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/IISUrlRewrite.xml
@@ -62,7 +62,7 @@
         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
         <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
       </conditions>
-      <action type="Redirect" url="/index.html?returnPath={R:1}" appendQueryString="true" />
+      <action type="Redirect" url="/index.html?returnPath=report/{R:1}" appendQueryString="true" />
     </rule>
   </rules>
 </rewrite>


### PR DESCRIPTION
## Summary
Adds the missing `report/` prefix to the IIS URL rewrite rule in the API project's `IISUrlRewrite.xml`, fixing report routing in production deployments that use this configuration file.

## Commits
- `02bfca85d` fix(config): add missing report/ prefix in API IIS rewrite rule

## Changes
- Updated the "Reports" rewrite rule in `CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/IISUrlRewrite.xml` to include the `report/` prefix in the returnPath redirect URL
- Changed `/index.html?returnPath={R:1}` to `/index.html?returnPath=report/{R:1}`

## Breaking Changes
None

## Test Plan
- [ ] Deploy to a test IIS environment
- [ ] Navigate directly to `/report/executive` (or any report URL)
- [ ] Verify the redirect goes to `/index.html?returnPath=report/executive` instead of `/index.html?returnPath=executive`
- [ ] Confirm the Angular app correctly loads the report page

## Related Issues
Companion fix to PR #5272 which addressed the same issue in `CSETWebNg/src/web.config`

## Release Notes
Fixed report URL routing in production IIS deployments using the API project's IIS rewrite configuration. Previously, navigating directly to report URLs like `/report/executive` would redirect to the wrong route, breaking report generation.

## Checklist
- [x] Conventional commit format followed
- [x] Change is consistent with fix in PR #5272
- [ ] Tested in IIS deployment environment