### PR TITLE
fix(frontend): correct returnPath URL rewrite rules in web.config

### DIFF
--- a/CSETWebNg/src/web.config
+++ b/CSETWebNg/src/web.config
@@ -50,7 +50,7 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
           </conditions>
-          <action type="Redirect" url="/index.html?returnPath={R1}" appendQueryString="true" />
+          <action type="Redirect" url="/index.html?returnPath={R:0}" appendQueryString="true" />
         </rule>
         <rule name="PrivacyWarning" stopProcessing="true">
           <match url="home/privacy-warning" />
@@ -74,7 +74,7 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
           </conditions>
-          <action type="Redirect" url="/index.html?returnPath=report/{R1}" appendQueryString="true" />
+          <action type="Redirect" url="/index.html?returnPath={R:0}" appendQueryString="true" />
         </rule>
       </rules>
     </rewrite>


### PR DESCRIPTION
## Summary
Fixes URL rewrite rules in web.config to properly preserve the full path when redirecting to index.html, enabling correct deep linking for tools and report routes.

## Commits
- `6ec290b` fix(frontend): correct returnPath URL rewrite rules in web.config

## Changes
- Changed `{R:1}` to `{R:0}` in the "AngularJS tools" rewrite rule (pattern: `tools/(.+)`)
- Changed `{R:1}` to `{R:0}` in the "Reports" rewrite rule (pattern: `report/(.+)`)

### Technical Details
- `{R:0}` captures the entire matched URL (e.g., `tools/some-tool` or `report/some-report`)
- `{R:1}` only captured the first regex group (e.g., `some-tool` or `some-report`), losing the prefix
- This fix ensures the returnPath query parameter contains the complete route path for proper navigation after redirect

## Breaking Changes
None

## Test Plan
- [ ] Navigate directly to a tools URL (e.g., `/tools/module-builder`) and verify redirect preserves the full path
- [ ] Navigate directly to a report URL (e.g., `/report/executive`) and verify redirect preserves the full path
- [ ] Verify the application correctly routes to the intended page after the redirect
- [ ] Test in IIS/IIS Express environment where web.config rewrite rules are active

## Related Issues
None

## Release Notes
Fixed deep linking for tools and report pages - direct URL navigation now correctly preserves the full path when redirecting through the Angular application.

## Checklist
- [ ] Tests pass locally
- [ ] Linting passes
- [x] Conventional commit format followed