### PR TITLE
Fixed some light/dark header issues on CPG reports

### DIFF
--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.scss
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.scss
@@ -155,81 +155,69 @@ table.cpg-table td {
 
 :host-context(.dark-theme) {
 
-    table.cpg-table th * {
-        color: #ffffff;
+    .sub-header-1 {
+        color: $near-white;
     }
-
 
     // CSF2
-    .csf2-func-gv {
+    .cpg-table .csf2-func-gv, .cpg-table .csf2-func-gv * {
         background-color: #111111;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
-    .csf2-func-id {
+    .cpg-table .csf2-func-id, .cpg-table .csf2-func-id * {
         background-color: #203864;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
-    .csf2-func-pr {
+    .cpg-table .csf2-func-pr, .cpg-table .csf2-func-pr * {
         background-color: #7c7c7c;
         border-color: $near-white;
-        color: $near-white;
+        color: $white !important;
     }
 
-    .csf2-func-de {
+    .cpg-table .csf2-func-de, .cpg-table .csf2-func-de * {
         background-color: #a26527;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
-    .csf2-func-rs {
+    .cpg-table .csf2-func-rs, .cpg-table .csf2-func-rs * {
         background-color: #a21c3b;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
-    .csf2-func-rc {
+    .cpg-table .csf2-func-rc, .cpg-table .csf2-func-rc * {
         background-color: #54823b;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
 
-    .ssg-it-product-design {
+    .cpg-table .ssg-it-product-design, .cpg-table .ssg-it-product-design * {
         background-color: #548235;
         border-color: $near-white;
-        color: $near-white;
+        color: $near-white !important;
     }
 
-    .ssg-it-software-dev {
+    .cpg-table .ssg-it-software-dev, .cpg-table .ssg-it-software-dev * {
         background-color: #305496;
         border-color: $near-white;
-        color: $near-white;
-    }
-
-
-
-     // CSF1
-    .csf1-func-id {
-        background-color: #2563EB;
-    }
-
-    .csf1-func-pr {
-        background-color: #7e22ce;
+        color: $near-white !important;
     }
 }
 
 // Force light mode colors when inside report containers
 :host-context(.force-light-mode),
 :host-context(.light-mode-wrapper) {
-    table.cpg-table th * {
-        color: $white !important;
+    
+    .sub-header-1 {
+        color: $near-black;
     }
 
-    
     // CPG 2 (CSF 2) - light mode backgrounds
     .csf2-func-gv {
         background-color: #111111;

--- a/CSETWebNg/src/assets/i18n/reports/es.json
+++ b/CSETWebNg/src/assets/i18n/reports/es.json
@@ -374,7 +374,10 @@
                     "complexity": "Facilidad",
                     "low": "BAJO",
                     "medium": "MEDIO",
-                    "high": "ALTO"
+                    "high": "ALTO",
+                    "simple": "SENCILLA",
+                    "moderate": "MODERADA",
+                    "complex": "COMPLEJA"
                },
                "deficiency": {
                     "report title": "Informe Deficiencias - Objetivos de Rendimiento Cibernético (CPG)",

--- a/CSETWebNg/src/sass/_force-light-mode.scss
+++ b/CSETWebNg/src/sass/_force-light-mode.scss
@@ -13,17 +13,17 @@ body.dark-theme,
 body[data-theme="dark"],
 body[data-bs-theme="dark"] {
   &:has(.force-light-mode) {
-    background-color: #ffffff !important;
-    background: #ffffff !important;
-    color: rgba(0, 0, 0, 0.87) !important;
+    background-color: #ffffff;
+    background: #ffffff;
+    color: rgba(0, 0, 0, 0.87);
   }
 }
 
 // Additional brute force overrides
 html:has(.force-light-mode),
 html:has(.light-mode-wrapper) {
-  background-color: #ffffff !important;
-  background: #ffffff !important;
+  background-color: #ffffff;
+  background: #ffffff;
   min-height: 100%;
 
 
@@ -378,8 +378,8 @@ html[data-bs-theme="dark"]:has(.light-mode-wrapper) {
   .table thead th,
   table:not(.cset-table):not(.cset-table-4) th,
   table:not(.cset-table):not(.cset-table-4) thead th {
-    color: rgba(0, 0, 0, 0.87) !important;
-    background-color: transparent !important;
+    color: rgba(0, 0, 0, 0.87);
+    background-color: transparent;
   }
 
   // cset-table headers with dark backgrounds need white text
@@ -393,7 +393,9 @@ html[data-bs-theme="dark"]:has(.light-mode-wrapper) {
 .force-light-mode,
 .light-mode-wrapper {
   .table th,
-  .table thead th {
+  .table th *,
+  .table thead th,
+  .table thead th * {
     color: rgba(0, 0, 0, 0.87) !important;
     background-color: transparent !important;
   }
@@ -406,18 +408,9 @@ html[data-bs-theme="dark"]:has(.light-mode-wrapper) {
 
   // CPG practice table headers - need very high specificity to override component styles
   // The first header column (Security Practice) needs white text
-  table.cpg-table th {
+  table.cpg-table th, 
+  table.cpg-table th * {
     color: #ffffffdd !important; // near-white (default for most headers)
-  }
-
-  // CSF2 functions have lighter backgrounds and need dark text
-  table.cpg-table th.csf2-func-gv,
-  table.cpg-table th.csf2-func-id,
-  table.cpg-table th.csf2-func-pr,
-  table.cpg-table th.csf2-func-de,
-  table.cpg-table th.csf2-func-rs,
-  table.cpg-table th.csf2-func-rc {
-    color: #000000d5 !important; // near-black
   }
 
   // CSF1 functions with dark backgrounds need white text
@@ -437,9 +430,11 @@ html[data-bs-theme="dark"]:has(.light-mode-wrapper) {
 .dark-theme .force-light-mode,
 .dark-theme .light-mode-wrapper {
   .table th,
-  .table thead th {
-    color: rgba(0, 0, 0, 0.87) !important;
-    background-color: transparent !important;
+  .table th *,
+  .table thead th,
+  .table thead th * {
+    color: rgba(0, 0, 0, 0.87);
+    background-color: transparent;
   }
 
   table.cset-table th,
@@ -450,15 +445,6 @@ html[data-bs-theme="dark"]:has(.light-mode-wrapper) {
 
   table.cpg-table th {
     color: #ffffffdd !important;
-  }
-
-  table.cpg-table th.csf2-func-gv,
-  table.cpg-table th.csf2-func-id,
-  table.cpg-table th.csf2-func-pr,
-  table.cpg-table th.csf2-func-de,
-  table.cpg-table th.csf2-func-rs,
-  table.cpg-table th.csf2-func-rc {
-    color: #000000d5 !important;
   }
 
   table.cpg-table th.csf1-func-id,


### PR DESCRIPTION
This pull request focuses on improving the appearance and maintainability of the CPG practice table and related components, especially with regard to dark mode, light mode overrides, and internationalization. It streamlines and clarifies SCSS selectors for better specificity and consistency, removes redundant or overly specific rules, and expands Spanish language support.

**Styling and Theming Improvements:**

* Refactored SCSS selectors for `.cpg-table` in dark mode to use more specific selectors (e.g., `.cpg-table .csf2-func-gv, .cpg-table .csf2-func-gv *`) and enforced color overrides with `!important` for better consistency across nested elements. Also updated `.sub-header-1` color handling for both dark and light modes.
* Simplified and clarified force light mode and light mode override rules in `_force-light-mode.scss` by removing unnecessary `!important` flags, broadening selectors for table headers, and removing redundant or conflicting color overrides for CSF2 function headers. [[1]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L16-R26) [[2]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L381-R382) [[3]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L396-R398) [[4]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L409-L422) [[5]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L440-R437) [[6]](diffhunk://#diff-1425e8fb0308794aac10c975c900efe799cb50dc116ace36af83972cd9372612L455-L463)

**Internationalization:**

* Added Spanish translations for "simple", "moderate", and "complex" complexity levels to the `es.json` file, expanding the available options for report localization.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
