### PR TITLE
fix(frontend): preserve query params in report URL rewriting

### DIFF
--- a/CSETWebNg/src/web.config
+++ b/CSETWebNg/src/web.config
@@ -74,7 +74,7 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
             <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
           </conditions>
-          <action type="Rewrite" url="/index.html?returnPath={R:0}"  />
+          <action type="Rewrite" url="/index.html?returnPath={R:0}" appendQueryString="true" />
         </rule>
       </rules>
     </rewrite>


### PR DESCRIPTION
## Summary

Fixes the Module Content report redirect in production where query parameters (`?m=<setName>` or `?mm=<modelId>`) were being lost during IIS URL rewriting, causing the report to load with no content.

## Commits

- `96612fc` fix(frontend): preserve query params in report URL rewriting

## Changes

- Added `appendQueryString="true"` to the Reports rewrite rule in `CSETWebNg/src/web.config`

## Root Cause

The Reports rewrite rule was missing `appendQueryString="true"`:

```xml
<!-- Before (broken) -->
<action type="Rewrite" url="/index.html?returnPath={R:0}" />

<!-- After (fixed) -->
<action type="Rewrite" url="/index.html?returnPath={R:0}" appendQueryString="true" />
```

When a user navigated to `/report/module-content?m=NIST_CSF`:
1. IIS rewrote to `/index.html?returnPath=report/module-content` (query params lost!)
2. Angular loaded the component with no query parameters
3. Report displayed with no content

This worked in development because Angular's dev server handles routing directly without IIS.

## Breaking Changes

None

## Test Plan

- [ ] Build the frontend: `task build:frontend`
- [ ] Deploy to an IIS environment
- [ ] Navigate to Module Content Launch page
- [ ] Select a standard or maturity model and click launch
- [ ] Verify the report opens in a new tab with content loaded
- [ ] Directly navigate to `/report/module-content?m=NIST_CSF` and verify it loads correctly

## Related Issues

Related to PR #5275 which fixed a similar issue with the `report/` prefix being dropped.

## Release Notes

Fixed Module Content report not loading properly in production when accessed via direct URL with query parameters.

## Checklist

- [x] Conventional commit format followed
- [x] Change matches pattern used by other rules (resourcelib, import, tools)