### PR TITLE
fix(frontend): append additional query params to returnPath

### DIFF
--- a/CSETWebNg/src/index.html
+++ b/CSETWebNg/src/index.html
@@ -64,8 +64,27 @@
             var libraryUrl = getParameterByName("libraryUrl");
             if (redirectid != null)
                 localStorage.setItem("redirectid", redirectid);
-            if (returnPath != null)
+            if (returnPath != null) {
+                // Collect any additional query params (like m, mm) that should be
+                // appended to returnPath for proper routing (e.g., module-content reports)
+                var knownParams = ['assessment_id', 'returnPath', 'apiUrl', 'libraryUrl'];
+                var queryString = window.location.search;
+                if (queryString && queryString.length > 1) {
+                    var additionalParams = [];
+                    var pairs = queryString.substring(1).split('&');
+                    for (var i = 0; i < pairs.length; i++) {
+                        var pair = pairs[i].split('=');
+                        var key = decodeURIComponent(pair[0]);
+                        if (knownParams.indexOf(key) === -1 && pair.length > 1) {
+                            additionalParams.push(pair[0] + '=' + pair[1]);
+                        }
+                    }
+                    if (additionalParams.length > 0) {
+                        returnPath = returnPath + '?' + additionalParams.join('&');
+                    }
+                }
                 localStorage.setItem("returnPath", returnPath);
+            }
             if (apiUrl != null)
                 localStorage.setItem("apiUrl", apiUrl);
             if (apiUrl != null)


### PR DESCRIPTION
## Summary

Fixes the Module Content report query parameters not being passed through to the Angular router after IIS URL rewriting. This is a follow-up fix to PR #5298.

## Problem

PR #5298 added `appendQueryString="true"` to preserve query parameters in the IIS rewrite. However, the query params were still being lost because:

1. IIS rewrites `/report/module-content?m=NIST_CSF` to `/index.html?returnPath=report/module-content&m=NIST_CSF`
2. `index.html` only stored `returnPath=report/module-content` in localStorage
3. The `m=NIST_CSF` parameter was ignored
4. When `app.component.ts` navigated, it used only the stored returnPath without the query params

## Solution

Modified `index.html` to:
1. Detect any additional query parameters beyond the known ones (`assessment_id`, `returnPath`, `apiUrl`, `libraryUrl`)
2. Append these additional params to returnPath before storing in localStorage
3. Store the complete path: `report/module-content?m=NIST_CSF`

Now `app.component.ts`'s `processParams()` function properly extracts the query parameters and passes them to the Angular router.

## Commits

- `fad0a03` fix(frontend): append additional query params to returnPath

## Changes

- Modified `CSETWebNg/src/index.html` to collect and append additional query params to returnPath

## Breaking Changes

None

## Test Plan

- [ ] Build the frontend: `task build:frontend`
- [ ] Deploy to an IIS environment
- [ ] Navigate to Module Content Launch page
- [ ] Select a standard (e.g., NIST CSF) and click launch
- [ ] Verify the report opens with content loaded
- [ ] Directly navigate to `/report/module-content?m=NIST_CSF` and verify it loads correctly
- [ ] Test with maturity models using `?mm=<modelId>` as well

## Related Issues

Follow-up to PR #5298

## Release Notes

Fixed Module Content report not loading content when accessed via direct URL with query parameters in production (IIS).

## Checklist

- [x] Conventional commit format followed
- [x] Compatible with older browsers (uses ES5-compatible code)