### PR TITLE
refactor(datalayer): remove unused usp_GetQuestionsWithFeedback stored procedure wrapper

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
@@ -423,27 +423,6 @@ namespace CSETWebCore.DataLayer.Model
 
 
         /// <summary>
-        /// Executes stored procedure usp_GetQuestionsWithFeedbacks.
-        /// </summary>
-        /// <param name="assessment_id"></param>
-        /// <returns></returns>
-        public virtual IList<usp_GetQuestionsWithFeedback> usp_GetQuestionsWithFeedbacks(Nullable<int> assessment_id)
-        {
-            if (!assessment_id.HasValue)
-                throw new ApplicationException("sql parameters may not be null");
-
-            IList<usp_GetQuestionsWithFeedback> rval = null;
-            this.LoadStoredProc("usp_GetQuestionsWithFeedback")
-                .WithSqlParam("assessment_id", assessment_id)
-                .ExecuteStoredProc((handler) =>
-                {
-                    rval = handler.ReadToList<usp_GetQuestionsWithFeedback>();
-                });
-            return rval;
-        }
-
-
-        /// <summary>
         /// Executes stored procedure usp_GetTop5Areas.
         /// </summary>
         /// <param name="aggregation_id"></param>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/FeedbackDisplayContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/FeedbackDisplayContainer.cs
@@ -1,14 +1,5 @@
 ﻿namespace CSETWebCore.DataLayer.Model
 {
-    public partial class usp_GetQuestionsWithFeedback
-    {
-        public string Feedback { get; set; }
-        public string QuestionText { get; set; }
-        public int QuestionOrRequirementId { get; set; }
-        public int AnswerId { get; set; }
-        public string SetName { get; set; }
-    }
-
     public partial class FeedbackDisplayContainer
     {
         public string FeedbackBody { get; set; }


### PR DESCRIPTION
## Summary

Remove the unused `usp_GetQuestionsWithFeedback` stored procedure wrapper and its result class from the data layer. This continues the ongoing effort to clean up unused stored procedure code from the codebase.

## Changes

- Remove `usp_GetQuestionsWithFeedbacks` method from `CSETContext.cs`
- Delete `usp_GetQuestionsWithFeedback` result class that was only used by the removed SP wrapper
- Preserve `FeedbackDisplayContainer` class in its own file as it remains in use elsewhere

## Breaking Changes

None

## Test Plan

- [ ] Run `task build:backend` to verify the solution builds successfully
- [ ] Run `task test:backend` to verify all unit tests pass
- [ ] Verify no references to `usp_GetQuestionsWithFeedback` remain in the codebase

## Related Issues

None

## Release Notes

Internal cleanup: Removed unused stored procedure wrapper code from the data layer.

## Checklist

- [ ] Tests pass locally (`task test:backend`)
- [ ] Linting passes (`task lint:backend`)
- [ ] Conventional commit format followed