### PR TITLE
fix(reports): add null safety checks for observation generation

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -1517,7 +1517,7 @@ namespace CSETWebCore.Business.Reports
             Observation obs = TinyMapper.Map<Observation>(oi.Finding);
             obs.ObservationTitle = oi.Finding.Summary;
             obs.ResolutionDate = oi.Finding.Resolution_Date;
-            obs.Importance = oi.Importance.Value;
+            obs.Importance = oi.Importance?.Value;
 
 
             // get the question identifier and text

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsUtils.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsUtils.cs
@@ -289,6 +289,11 @@ namespace CSETWebCore.Business.Reports
                     return;
 
                 case "Requirement":
+                    if (f.NewRequirement == null)
+                    {
+                        return;
+                    }
+
                     identifier = f.NewRequirement.Requirement_Title;
 
                     var parmSub = new ParameterSubstitution(_context, _tokenManager);
@@ -301,6 +306,11 @@ namespace CSETWebCore.Business.Reports
                     return;
 
                 case "Maturity":
+                    if (f.MaturityQuestion == null)
+                    {
+                        return;
+                    }
+
                     identifier = f.MaturityQuestion.Question_Title;
                     questionText = f.MaturityQuestion.Question_Text;
 


### PR DESCRIPTION
## Summary
Adds null safety checks to prevent null reference exceptions when generating observations in reports. These fixes handle cases where report data may have missing references for Importance, NewRequirement, or MaturityQuestion objects.

## Changes
- Added null-conditional operator (`?.`) for `Importance.Value` in `GenerateObservation` method
- Added null check for `NewRequirement` before accessing its properties in the "Requirement" case
- Added null check for `MaturityQuestion` before accessing its properties in the "Maturity" case

## Breaking Changes
None

## Test Plan
- [ ] Run `task test:backend` to verify all tests pass
- [ ] Verify reports generate correctly with complete data
- [ ] Test report generation with observations that have missing Importance values
- [ ] Test report generation with observations linked to missing requirements
- [ ] Test report generation with observations linked to missing maturity questions

## Related Issues
None

## Release Notes
Fixed null reference exceptions that could occur when generating observation reports with incomplete data references.

## Checklist
- [ ] Tests pass locally (`task test:backend`)
- [ ] Linting passes (`task lint:backend`)
- [x] Conventional commit format followed