### PR TITLE
perf(reports): convert observations endpoints to async

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ObservationsToExcel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ObservationsToExcel.cs
@@ -3,6 +3,7 @@ using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Reports;
 
@@ -161,6 +162,153 @@ namespace CSETWebCore.Business.Reports
                     }
                 }
 
+
+                // Save the worksheet
+                worksheetPart.Worksheet.Save();
+                workbookPart.Workbook.Save();
+            }
+        }
+
+
+        /// <summary>
+        /// Async version of GenerateSpreadsheet that uses async database queries.
+        /// </summary>
+        public async Task GenerateSpreadsheetAsync(int assessmentId, MemoryStream ms)
+        {
+            // Define Excel column headers
+            var columnHeaders = new[] {
+                new ColDef("Contact", 24),
+                new ColDef("Observation Title", 25),
+                new ColDef("Question ID", 15),
+                new ColDef("Importance", 12),
+                new ColDef("Resolution Date", 26),
+                new ColDef("Issue", 32),
+                new ColDef("Impacts", 32),
+                new ColDef("Recommendations", 32),
+                new ColDef("Vulnerabilities", 32 )
+            };
+
+            // Get observations using async method
+            _report.SetReportsAssessmentId(assessmentId);
+            BasicReportData data = new BasicReportData();
+            data.information = _report.GetInformation();
+            data.Individuals = (await _report.GetObservationIndividualsAsync()).ToList();
+
+            // Create the Excel file
+            using (var spreadsheetDocument = SpreadsheetDocument.Create(ms, SpreadsheetDocumentType.Workbook))
+            {
+                // Add a WorkbookPart
+                var workbookPart = spreadsheetDocument.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+
+                // Define column widths
+                var columns = CreateColumns(columnHeaders);
+
+                // Add Stylesheet (for bold headers and text wrapping)
+                var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = CreateStylesheet();
+                stylesPart.Stylesheet.Save();
+
+                // Add a WorksheetPart
+                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+                worksheetPart.Worksheet = new Worksheet(columns, new SheetData());
+
+                // Add Sheets to the Workbook
+                var sheets = spreadsheetDocument.WorkbookPart.Workbook.AppendChild(new Sheets());
+                var sheet = new Sheet
+                {
+                    Id = spreadsheetDocument.WorkbookPart.GetIdOfPart(worksheetPart),
+                    SheetId = 1,
+                    Name = "Observations"
+                };
+
+                sheets.Append(sheet);
+
+                // Get the SheetData
+                var sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>();
+
+                // Create the header row
+                var headerRow = new Row();
+
+                foreach (var header in columnHeaders)
+                {
+                    var cell = new Cell
+                    {
+                        CellValue = new CellValue(header.HeaderText),
+                        DataType = CellValues.String,
+                        StyleIndex = 1
+                    };
+                    headerRow.Append(cell);
+                }
+                sheetData.Append(headerRow);
+
+                foreach (var ind in data.Individuals)
+                {
+                    foreach (var obs in ind.Observations)
+                    {
+                        var row = new Row();
+                        sheetData.Append(row);
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(ind.FullName),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.ObservationTitle),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.QuestionIdentifier),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.Importance),
+                            DataType = CellValues.String
+                        });
+
+                        string resolutionDateString = "";
+                        if (obs.ResolutionDate != null)
+                        {
+                            resolutionDateString = obs.ResolutionDate.ToString();
+                        }
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(resolutionDateString),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.Issue),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.Impact),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.Recommendations),
+                            DataType = CellValues.String
+                        });
+
+                        row.Append(new Cell
+                        {
+                            CellValue = new CellValue(obs.Vulnerabilities),
+                            DataType = CellValues.String
+                        });
+                    }
+                }
 
                 // Save the worksheet
                 worksheetPart.Worksheet.Save();

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -26,6 +26,7 @@ using Nelibur.ObjectMapper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 
@@ -606,6 +607,51 @@ namespace CSETWebCore.Business.Reports
         }
 
 
+        /// <summary>
+        /// Async version of GetQuestionsForEachStandard.
+        /// </summary>
+        public async Task<List<StandardQuestions>> GetQuestionsForEachStandardAsync(CancellationToken cancellationToken = default)
+        {
+            var dblist = await (from a in _context.AVAILABLE_STANDARDS
+                                join b in _context.NEW_QUESTION_SETS on a.Set_Name equals b.Set_Name
+                                join c in _context.Answer_Questions on b.Question_Id equals c.Question_Or_Requirement_Id
+                                join q in _context.NEW_QUESTION on c.Question_Or_Requirement_Id equals q.Question_Id
+                                join h in _context.vQUESTION_HEADINGS on q.Heading_Pair_Id equals h.Heading_Pair_Id
+                                join s in _context.SETS on b.Set_Name equals s.Set_Name
+                                where a.Selected == true && a.Assessment_Id == _assessmentId
+                                && c.Assessment_Id == _assessmentId
+                                orderby s.Short_Name, h.Question_Group_Heading, c.Question_Number
+                                select new SimpleStandardQuestions()
+                                {
+                                    ShortName = s.Short_Name,
+                                    Answer = c.Answer_Text,
+                                    CategoryAndNumber = h.Question_Group_Heading + " #" + c.Question_Number,
+                                    Question = q.Simple_Question,
+                                    QuestionId = q.Question_Id
+                                }).ToListAsync(cancellationToken);
+
+            List<StandardQuestions> list = new List<StandardQuestions>();
+            string lastshortname = "";
+            List<SimpleStandardQuestions> qlist = new List<SimpleStandardQuestions>();
+            foreach (var a in dblist)
+            {
+                if (a.ShortName != lastshortname)
+                {
+                    qlist = new List<SimpleStandardQuestions>();
+                    list.Add(new StandardQuestions()
+                    {
+                        Questions = qlist,
+                        StandardShortName = a.ShortName
+                    });
+                }
+                lastshortname = a.ShortName;
+                qlist.Add(a);
+            }
+
+            return list;
+        }
+
+
         public async Task<List<StandardQuestions>> GetStandardQuestionAnswers(int assessId)
         {
             // Call FillEmptyQuestionsForAnalysis (still needed as SP call)
@@ -875,6 +921,35 @@ namespace CSETWebCore.Business.Reports
             }
 
             return l;
+        }
+
+
+        /// <summary>
+        /// Async version of GetComponentQuestions with optimized projection.
+        /// Projects directly to ComponentQuestion without intermediate mapping.
+        /// </summary>
+        public async Task<List<ComponentQuestion>> GetComponentQuestionsAsync(CancellationToken cancellationToken = default)
+        {
+            var results = await _context.Answer_Components_Exploded
+                .AsNoTracking()
+                .Where(c => c.Assessment_Id == _assessmentId)
+                .OrderBy(c => c.ComponentName)
+                .ThenBy(c => c.QuestionText)
+                .Select(c => new ComponentQuestion
+                {
+                    Answer = c.Answer_Text,
+                    ComponentName = c.ComponentName,
+                    Component_Symbol_Id = c.Component_Symbol_Id,
+                    Question = c.QuestionText,
+                    QuestionId = c.Question_Id,
+                    LayerName = c.LayerName,
+                    SAL = c.SAL,
+                    Zone = c.ZoneName,
+                    IsOverride = (c.Answer_Id != null)
+                })
+                .ToListAsync(cancellationToken);
+
+            return results;
         }
 
 
@@ -1480,6 +1555,110 @@ namespace CSETWebCore.Business.Reports
             var standardQuestions = GetQuestionsForEachStandard();
             var componentQuestions = GetComponentQuestions();
 
+
+
+            // First handle the 'assigned' Observations
+            foreach (var contact in acc)
+            {
+                Individual individual = new Individual()
+                {
+                    FullName = FormatName(contact.FirstName, contact.LastName)
+                };
+
+                var obsList = observations.Where(x => x.FC?.Assessment_Contact_Id == contact.Assessment_Contact_Id).ToList();
+
+                foreach (var m in obsList)
+                {
+                    var obs = GenerateObservation(m, standardQuestions, componentQuestions, findingContactsLookup, contactNamesDict);
+
+                    individual.Observations.Add(obs);
+                }
+
+                if (individual.Observations.Count > 0)
+                {
+                    individualList.Add(individual);
+                }
+            }
+
+
+            // Include any 'unassigned' Observations
+            var ind = new Individual();
+            ind.FullName = "Unassigned";
+
+            var unnasignedObs = observations.Where(x => x.FC == null).ToList();
+            foreach (var obs in unnasignedObs)
+            {
+                var observation = GenerateObservation(obs, standardQuestions, componentQuestions, findingContactsLookup, contactNamesDict);
+                ind.Observations.Add(observation);
+            }
+
+            if (ind.Observations.Count > 0)
+            {
+                individualList.Add(ind);
+            }
+
+            return individualList;
+        }
+
+
+        /// <summary>
+        /// Async version of GetObservationIndividuals.
+        /// Uses async database queries for better performance under load.
+        /// </summary>
+        public async Task<List<Individual>> GetObservationIndividualsAsync(CancellationToken cancellationToken = default)
+        {
+            List<Individual> individualList = [];
+
+            var observations = await (from f in _context.FINDING.AsNoTracking()
+                                      join fc in _context.FINDING_CONTACT on f.Finding_Id equals fc.Finding_Id into fc1
+                                      from fc in fc1.DefaultIfEmpty()
+                                      join a in _context.ANSWER on f.Answer_Id equals a.Answer_Id
+                                      join mq in _context.MATURITY_QUESTIONS on a.Question_Or_Requirement_Id equals mq.Mat_Question_Id into mq1
+                                      from mq in mq1.DefaultIfEmpty()
+                                      join nr in _context.NEW_REQUIREMENT on a.Question_Or_Requirement_Id equals nr.Requirement_Id into nr1
+                                      from nr in nr1.DefaultIfEmpty()
+                                      join ac in _context.ASSESSMENT_CONTACTS on fc.Assessment_Contact_Id equals ac.Assessment_Contact_Id into ac1
+                                      from ac in ac1.DefaultIfEmpty()
+                                      join i in _context.IMPORTANCE on f.Importance_Id equals i.Importance_Id into i1
+                                      from i in i1.DefaultIfEmpty()
+                                      where a.Assessment_Id == _assessmentId
+                                      select new ObservationIngredients()
+                                      {
+                                          Finding = f,
+                                          FC = fc,
+                                          Answer = a,
+                                          MaturityQuestion = mq,
+                                          NewRequirement = nr,
+                                          Importance = i
+                                      }).ToListAsync(cancellationToken);
+
+            var acc = await _context.ASSESSMENT_CONTACTS
+                .AsNoTracking()
+                .Where(x => x.Assessment_Id == _assessmentId)
+                .OrderBy(x => x.Assessment_Contact_Id)
+                .ToListAsync(cancellationToken);
+
+            // Batch load contact names into dictionary to avoid N+1 queries
+            var contactNamesDict = acc.ToDictionary(
+                c => c.Assessment_Contact_Id,
+                c => FormatName(c.FirstName, c.LastName)
+            );
+
+            // Batch load finding contacts for all findings to avoid N+1 queries
+            var findingIds = observations.Select(o => o.Finding.Finding_Id).Distinct().ToList();
+            var findingContactsLookup = await _context.FINDING_CONTACT
+                .AsNoTracking()
+                .Where(fc => findingIds.Contains(fc.Finding_Id))
+                .GroupBy(fc => fc.Finding_Id)
+                .ToDictionaryAsync(
+                    g => g.Key,
+                    g => g.Select(fc => fc.Assessment_Contact_Id).ToList(),
+                    cancellationToken
+                );
+
+            // Get any associated questions to get their display reference using async methods
+            var standardQuestions = await GetQuestionsForEachStandardAsync(cancellationToken);
+            var componentQuestions = await GetComponentQuestionsAsync(cancellationToken);
 
 
             // First handle the 'assigned' Observations

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Reports/IReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Reports/IReportsDataBusiness.cs
@@ -12,6 +12,7 @@ using CSETWebCore.Model.Diagram;
 using CSETWebCore.Model.Maturity;
 using CSETWebCore.Model.Question;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CSETWebCore.Interfaces.Reports
@@ -40,7 +41,9 @@ namespace CSETWebCore.Interfaces.Reports
         List<BasicReportData.RequirementControl> GetControls(string applicationMode);
         List<List<DiagramZones>> GetDiagramZones();
         List<StandardQuestions> GetQuestionsForEachStandard();
+        Task<List<StandardQuestions>> GetQuestionsForEachStandardAsync(CancellationToken cancellationToken = default);
         List<ComponentQuestion> GetComponentQuestions();
+        Task<List<ComponentQuestion>> GetComponentQuestionsAsync(CancellationToken cancellationToken = default);
         List<RankedCategories> GetTop5Categories();
         Task<List<RankedQuestions>> GetTop5QuestionsAsync();
         List<QuestionsWithAltJust> GetQuestionsWithAlternateJustification();
@@ -54,6 +57,7 @@ namespace CSETWebCore.Interfaces.Reports
         BasicReportData.OverallSALTable GetSals();
         BasicReportData.INFORMATION GetInformation();
         List<Individual> GetObservationIndividuals();
+        Task<List<Individual>> GetObservationIndividualsAsync(CancellationToken cancellationToken = default);
         GenSALTable GetGenSals();
         MaturityReportData.MaturityModel GetBasicMaturityModel();
         List<MaturityReportData.MaturityModel> GetMaturityModelData();

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsController.cs
@@ -20,8 +20,11 @@ using CSETWebCore.Model.Aggregation;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Demographic;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -476,61 +479,114 @@ namespace CSETWebCore.Api.Controllers
         /// </summary>
         [HttpGet]
         [Route("api/reports/observations/tearout")]
-        public IActionResult GetObservations()
+        public async Task<IActionResult> GetObservationsAsync()
         {
+            var stopwatch = Stopwatch.StartNew();
             int assessmentId;
+
             try
             {
                 assessmentId = _token.AssessmentForUser();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return Unauthorized(new { message = "User not authorized for assessment" });
+                return Unauthorized(new { message = "User not authorized for assessment", error = ex.Message });
             }
 
-            _report.SetReportsAssessmentId(assessmentId);
+            try
+            {
+                _report.SetReportsAssessmentId(assessmentId);
 
-            BasicReportData data = new BasicReportData();
-            data.information = _report.GetInformation();
-            data.Individuals = _report.GetObservationIndividuals();
-            return Ok(data);
+                var data = new BasicReportData();
+                data.information = _report.GetInformation();
+                data.Individuals = await _report.GetObservationIndividualsAsync();
+
+                return Ok(data);
+            }
+            catch (SqlException ex) when (ex.Number == -2) // SQL Server timeout
+            {
+                stopwatch.Stop();
+                return StatusCode(504, new
+                {
+                    message = "Database query timed out while generating observations report",
+                    assessmentId = assessmentId,
+                    elapsedMs = stopwatch.ElapsedMilliseconds
+                });
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                return StatusCode(500, new
+                {
+                    message = "Error generating observations report",
+                    error = ex.Message,
+                    assessmentId = assessmentId,
+                    elapsedMs = stopwatch.ElapsedMilliseconds
+                });
+            }
         }
 
 
         /// <summary>
-        /// Returns a file stream containing Observations in a CSV format.
+        /// Returns a file stream containing Observations in an Excel format.
         /// </summary>
         [HttpGet]
         [Route("api/reports/observations/excel")]
-        public IActionResult ExportObservationsCsv()
+        public async Task<IActionResult> ExportObservationsExcelAsync()
         {
+            var stopwatch = Stopwatch.StartNew();
             int assessmentId;
+
             try
             {
                 _report.SetToken(_token);
                 assessmentId = _token.AssessmentForUser();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return Unauthorized(new { message = "User not authorized for assessment" });
+                return Unauthorized(new { message = "User not authorized for assessment", error = ex.Message });
             }
 
-            string lang = _token.GetCurrentLanguage();
-
-            var info = _context.INFORMATION.Where(x => x.Id == assessmentId).FirstOrDefault();
-
-            // Generate the Excel file
-            using (var memoryStream = new MemoryStream())
+            try
             {
-                var otx = new ObservationsToExcel(_context, _report);
-                otx.GenerateSpreadsheet(assessmentId, memoryStream);
+                var info = await _context.INFORMATION
+                    .Where(x => x.Id == assessmentId)
+                    .FirstOrDefaultAsync();
 
-                // Return the file as a downloadable attachment
-                return File(
-                    memoryStream.ToArray(),
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    $"{info.Assessment_Name} - Observations.xlsx"
-                );
+                // Generate the Excel file
+                using (var memoryStream = new MemoryStream())
+                {
+                    var otx = new ObservationsToExcel(_context, _report);
+                    await otx.GenerateSpreadsheetAsync(assessmentId, memoryStream);
+
+                    // Return the file as a downloadable attachment
+                    return File(
+                        memoryStream.ToArray(),
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        $"{info?.Assessment_Name ?? "Assessment"} - Observations.xlsx"
+                    );
+                }
+            }
+            catch (SqlException ex) when (ex.Number == -2) // SQL Server timeout
+            {
+                stopwatch.Stop();
+                return StatusCode(504, new
+                {
+                    message = "Database query timed out while generating observations Excel export",
+                    assessmentId = assessmentId,
+                    elapsedMs = stopwatch.ElapsedMilliseconds
+                });
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                return StatusCode(500, new
+                {
+                    message = "Error generating observations Excel export",
+                    error = ex.Message,
+                    assessmentId = assessmentId,
+                    elapsedMs = stopwatch.ElapsedMilliseconds
+                });
             }
         }
 


### PR DESCRIPTION
## Summary
Converts the observations tearout and Excel export endpoints to use async database queries for better performance under load. This improves server responsiveness by not blocking threads during database operations.

## Changes
- Add `GenerateSpreadsheetAsync` to ObservationsToExcel for async Excel generation
- Add `GetObservationIndividualsAsync` with async database queries
- Add `GetQuestionsForEachStandardAsync` and `GetComponentQuestionsAsync` helper methods
- Update `IReportsDataBusiness` interface with new async method signatures
- Convert `GetObservations` and `ExportObservationsExcel` controller actions to async
- Add proper error handling with SQL timeout detection (504 status for timeouts)
- Add Stopwatch-based performance monitoring in error responses

## Breaking Changes
None - existing synchronous methods are preserved for backward compatibility.

## Test Plan
- [ ] Verify observations tearout endpoint returns data correctly: `GET /api/reports/observations/tearout`
- [ ] Verify observations Excel export works: `GET /api/reports/observations/excel`
- [ ] Confirm 401 is returned for unauthorized users
- [ ] Test error handling with invalid assessment IDs
- [ ] Verify no regressions in existing observation functionality

## Related Issues
Continues the async performance improvements from #5324.

## Release Notes
Improved performance of observations report endpoints by converting to async database operations. This reduces server thread blocking and improves responsiveness under concurrent load.

## Checklist
- [x] Conventional commit format followed
- [ ] Tests pass locally (`task test:backend`)
- [ ] Breaking changes documented