### PR TITLE
refactor(ui): remove redundant h3 page headers from component templates

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.html
@@ -23,8 +23,6 @@
 <div *transloco="let t" >
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
 
-    <h3 class="mb-3">{{t('titles.assessment configuration')}}</h3>
-
     <div *ngIf="this.showUpgrade">
       <app-upgrade></app-upgrade>
     </div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div *transloco="let t">
   <div class="white-panel d-flex justify-content-start flex-column flex-11a">
-    <h3 class="mb-3">{{ t('titles.assessment information') }}</h3>
-
     <app-assessment-contacts *ngIf="showContacts()" class="mb-5 d-flex justify-content-end flex-00a"
       (triggerChange)="contactsUpdated()"></app-assessment-contacts>
 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.html
@@ -23,8 +23,6 @@
 <div>
      <div class="white-panel d-flex justify-content-start flex-column flex-11a"
           *transloco="let t; read: 'cmmc.level selection'">
-          <h3 class="wrap-text mb-3">{{'titles.cmmc target level selection' | transloco}}</h3>
-
           <p>
                {{t('para 1')}}
           </p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.html
@@ -23,7 +23,6 @@
 <div>
     <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial"
         *transloco="let t; read: 'tutorial.rra'">
-        <h3 class="wrap-text mb-3">{{t('title')}}</h3>
         <div *transloco="let k">
             <h5>{{k('titles.overview')}}</h5>
             <p>{{t('1')}}</p>

--- a/CSETWebNg/src/app/assessment/prepare/sals/sals.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sals.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <ng-container *transloco="let t">
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-    <h3 class="mb-3">{{t('titles.sal.security assurance level (sal)')}}</h3>
     <div class="me-0 d-flex flex-column flex-00a">
       <div class="mb-3">
         {{t('titles.sal.sal intro1')}}

--- a/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <div>
   <div class="white-panel d-flex flex-column justify-content-start flex-11a" id="analysisDiv" *transloco="let t">
-    <h3>{{t('titles.analysis dashboard')}}</h3>
     <div *ngIf="!initialized">
       <div class="spinner-container" style="margin-left: auto; margin-right: auto;">
         <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <div>
   <div class="white-panel d-flex flex-column justify-content-start flex-11a" *transloco="let t">
-    <h3 class="mb-2 flex-00a">{{t('titles.control priorities')}}</h3>
     <p class="mb-3 w-100">
       {{t('control priorities intro1')}}
     </p>

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
 <div class="white-panel d-flex flex-column justify-content-start flex-11a" *transloco="let t">
-  <h3>{{t('titles.ranked categories')}}</h3>
-
   <div *ngIf="!initialized">
     <div class="spinner-container" style="margin-left: auto; margin-right: auto;">
       <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
 <div class="white-panel d-flex flex-column justify-content-start flex-11a" *transloco="let t">
-  <h3>{{t('reports.core.results by category.title')}}</h3>
-
   <p>{{t('reports.core.results by category.text 1')}}</p>
 
   <div id="chart" class="mb-5">

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
   <div class="white-panel d-flex flex-column justify-content-start flex-11a" *transloco="let t">
-    <h3>{{t('titles.standards summary')}}</h3>
-
     <p>{{t('reports.standards summary text 1')}}</p>
 
     <div id="chart" class="mb-5" style="max-width: 300px; min-width: 300px; margin: 0 auto;">

--- a/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.html
@@ -1,6 +1,5 @@
 <div>
   <div class="white-panel oy-auto ox-auto d-flex flex-column flex-11a" *transloco="let t">
-    <h3 class="mb-3">{{t('analytics.title')}}</h3>
     <p>{{t('analytics.description 1')}}</p>
     <p>{{t('analytics.description 2')}}</p>
     <div class="container ps-0">

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
   <div class="white-panel h-0 d-flex flex-column flex-11a" *transloco="let t">
-    <h3>{{t('titles.performance by domain')}}</h3>
-
     <div>
       <p>
         {{ t('cmmc.scoring.perf by domain desc', {targetLevel: targetLevel}) }}

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
     <div class="white-panel h-0 d-flex flex-column flex-11a" *transloco="let t">
-        <h3>{{t('titles.performance by level')}}</h3>
-
         <div *ngIf="loading">
             <div class="spinner-container" style="margin-left: auto; margin-right: auto;">
                 <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
      <div class="white-panel oy-auto d-flex flex-column flex-11a" *transloco="let t">
-          <h3>{{t('titles.cmmc scoring')}}</h3>
-
           <div *ngIf="loading">
                <div class="spinner-container" style="margin-left: auto; margin-right: auto;">
                     <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
      <div class="white-panel oy-auto d-flex flex-column flex-11a" *transloco="let t">
-          <h3>{{t('titles.cmmc scorecard')}}</h3>
-
           <p>
                {{t('cmmc.scoring.scorecard description')}}
           </p>

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
     <div class="white-panel h-0 d-flex flex-column flex-11a" *transloco="let t">
-        <h3>{{t('titles.goal performance')}}</h3>
-
         <div *ngIf="!initialized">
             <div class="spinner-container" style="margin-left: auto; margin-right: auto;">
                 <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
     <div class="white-panel h-0 d-flex flex-column flex-11a" *transloco="let t">
-        <h3>{{t('reports.core.rra.report.tiers')}}</h3>
-
         <p class="mb-4">{{t('reports.core.rra.assessment tiers summary')}}</p>
 
         <div class="mb-5">

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <div>
     <div class="white-panel d-flex flex-column flex-11a" *transloco="let t">
-        <h3 class="d-flex flex-column flex-00a">{{title}}</h3>
         <p>
             {{t('reports.core.rra.report.performance summary text')}}
         </p>

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.html
@@ -23,8 +23,6 @@
 <div *transloco="let t; read: 'reports'">
   <div class="white-panel oy-auto d-flex flex-column flex-11a">
     <div>
-      <h3>{{ 'titles.reports' | transloco }}</h3>
-
       <p>
         {{ t('assessment complete message').replace('{date}', lastModifiedTimestamp | localizeDate: 'GMT') }}
         {{ t('reports run prior message') }}

--- a/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.html
@@ -21,8 +21,6 @@
   SOFTWARE. 
 -------------------------->
 <div style="max-width:700px; padding-right:20px;" *transloco="let t">
-  <h3>{{t('reports.core.edm.summary results')}}</h3>
-
   <p>
     {{t('reports.core.edm.para 1')}}
   </p>


### PR DESCRIPTION
## Summary
Removes duplicate h3 title elements from 20 Angular component templates across the assessment prepare and results sections. These page titles are now displayed in the navigation/layout layer, eliminating visual duplication for users.

## Changes
- Removed redundant `<h3>` page headers from 20 component templates
- Assessment prepare components: assessment-info, assessment2-info, cmmc2-levels, tutorial-rra, sals
- Results analysis components: dashboard, ranked-questions, standards-ranked, standards-results, standards-summary, analytics-results
- CMMC2 results components: cmmc2-domain-results, cmmc2-level-results, cmmc2-scores, cmmc2-scorecard-page
- RRA results components: rra-gaps, rra-level-results, rra-summary-all
- Reports components: reports, edm-summary-results

## Breaking Changes
None

## Test Plan
- [ ] Navigate to each affected page and verify the title is displayed correctly (via navigation/layout)
- [ ] Verify no duplicate headers appear on any page
- [ ] Test in both light and dark mode
- [ ] Verify the pages display correctly across different screen sizes

## Related Issues
None

## Release Notes
Cleaned up page layout by removing duplicate page headers from component templates. Page titles are now consistently displayed through the navigation layer.

## Checklist
- [ ] Tests pass locally (`task test`)
- [ ] Linting passes (`task lint`)
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented
- [x] Conventional commit format followed