### PR TITLE
refactor(ui): remove additional redundant page headers from templates

### DIFF
--- a/CSETWebNg/package-lock.json
+++ b/CSETWebNg/package-lock.json
@@ -71,7 +71,7 @@
         "@electron/packager": "^19.0.1",
         "@tailwindcss/postcss": "^4.1.18",
         "autoprefixer": "^10.4.23",
-        "electron": "^39.2.7",
+        "electron": "^39.3.0",
         "postcss": "^8.5.6",
         "shx": "^0.4.0",
         "tailwindcss": "^4.1.18",
@@ -10585,9 +10585,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "39.2.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.2.7.tgz",
-      "integrity": "sha512-KU0uFS6LSTh4aOIC3miolcbizOFP7N1M46VTYVfqIgFiuA2ilfNaOHLDS9tCMvwwHRowAsvqBrh9NgMXcTOHCQ==",
+      "version": "39.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.3.0.tgz",
+      "integrity": "sha512-ZA2Cmu5Vs8zeuZBr71XWZ5vgm7lRDB9N50oV6ee7YocITyxRxx/apWFKY48Sxyn0gzVlX+6YQc3CS1PtYIkGUg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
@@ -24,7 +24,6 @@
     <div class="white-panel-body avail-h-minus" style="--offset: 305px">
         <div class="row">
             <div class="col-12">
-                <h4>Network Diagram</h4>
                 <p>
                     Building a diagram of your system's network allows CSET to include component-specific questions in your
                     final question set.

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div *transloco="let t" class="assess-component d-flex flex-column justify-content-start flex-11a">
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-    <h3 class="mb-3">{{t('titles.assessment configuration')}}</h3>
-
     <div *ngIf="this.showUpgrade">
       <app-upgrade></app-upgrade>
     </div>

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <ng-container *transloco="let t">
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-    <h3 class="mb-3">{{t('titles.critical service information')}}</h3>
-
     <app-csi-service-demographics></app-csi-service-demographics>
 
     <app-csi-service-composition></app-csi-service-composition>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
         <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial">
-                <h3 class="wrap-text mb-3">Cyber Infrastructure Survey (CIS) Tutorial</h3>
-
                 <div class="mb-4">
                         <h5>Overview</h5>
                         <p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.html
@@ -24,8 +24,6 @@
   <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial"
     *transloco="let t; read: 'tutorial.cmmc2'">
     <div>
-      <h3 class="wrap-text mb-3">{{t('title')}}</h3>
-
       <div>
         <h5>{{t('1')}}</h5>
         <p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.html
@@ -23,7 +23,6 @@
 <div>
     <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial"
         *transloco="let ttcpg; read: 'tutorial.cpg'">
-        <h3 class="wrap-text mb-3">{{ttcpg('title')}}</h3>
         <div *transloco="let t">
             <h5>{{t('titles.overview')}}</h5>
             <p>{{ttcpg('1')}}</p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
@@ -23,7 +23,6 @@
 <div>
     <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial"
         *transloco="let ttcpg; read: 'tutorial.cpg2'">
-        <h3 class="wrap-text mb-3">{{ttcpg('title')}}</h3>
         <div *transloco="let t">
             <h5>{{t('titles.overview')}}</h5>
             <p>{{ttcpg('1')}}</p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
         <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial">
-                <h3 class="wrap-text mb-3">CRR Tutorial</h3>
-
                 <h5>Overview</h5>
 
                 <p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.html
@@ -22,9 +22,6 @@
 -------------------------->
 <div>
 <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial">
-    <h3 class="wrap-text mb-3">External Dependencies Management (EDM) Tutorial</h3>
-
-
     <h5>Overview</h5>
 
     <p>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
 <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial">
-  <h3 class="wrap-text mb-3">Incident Management Review (IMR) Tutorial</h3>
-
   <div class="mb-4">
 
     <h5>Overview</h5>

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.html
@@ -23,7 +23,6 @@
 <div>
     <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial"
         *transloco="let t; read: 'tutorial.mvra'">
-        <h3 class="wrap-text mb-3">{{t('title')}}</h3>
         <div *transloco="let k">
             <h5>{{k('titles.overview')}}</h5>
             <p>{{t('1')}}</p>

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
@@ -46,11 +46,6 @@
     </div>
   </div>
   <div class="white-panel-body avail-h-minus tw:dark:bg-bg-secondary" style="--offset: 400px">
-    <div class="d-block mb-2">
-      <h3>
-        {{t('titles.diagram component questions')}}
-      </h3>
-    </div>
     <div *ngIf="!!categories && filterSvc.isFilterEngaged()" class="filters-engaged">{{t('filter-menu.showing only filtered')}}</div>
 
     <div *ngIf="!categories" class="w-100">

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
@@ -50,10 +50,6 @@
     <div class="flex-column flex-wrap justify-content-between align-items-start flex-11a mb-4">
 
       <div class="d-block mb-2">
-        <h3>{{ pageTitle }}</h3>
-
-        <h4>{{ groupingTitle }}</h4>
-
         <div class="mb-2" *ngIf="showTargetLevel">
           The target maturity level for this assessment is set to
           <strong [innerText]="maturitySvc.targetLevelName()"></strong>.

--- a/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.html
+++ b/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <div *transloco="let t" >
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-    <h3 class="mb-3">{{t('titles.other remarks')}}</h3>
     <label>Enter any general remarks or observations for the assessment</label>
     <textarea [(ngModel)]="remark" appAutoSize class="form-control" (blur)="saveRemark($event)"></textarea>
   </div>

--- a/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.html
@@ -24,7 +24,6 @@
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
     <div *ngIf="componentCount != 0; else elseBlock">
       <div id="chart" class="mb-3">
-        <h3>Ranked Components By Category</h3>
         <canvas id="canvasComponentRank">{{canvasComponentRank}}</canvas>
       </div>
       <div *ngIf="!initialized">
@@ -56,7 +55,6 @@
       </div>
     </div>
     <ng-template #elseBlock>
-      <h3>Ranked Components By Category</h3>
       <div class="alert-warning mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-11a">
         <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
         <span class="fs-base-3 p-2 d-flex flex-column justify-content-center flex-11a">

--- a/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.html
@@ -24,7 +24,6 @@
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
     <div *ngIf="dataSet != 0; else elseBlock">
       <div id="chart" class="mb-3">
-        <h3>Component Results By Category</h3>
         <p>This chart shows the individual scores for each of the categories in a network components based assessment.
         </p>
         <canvas id="canvasComponentCompliance">{{canvasComponentCompliance}}</canvas>
@@ -56,7 +55,6 @@
       </div>
     </div>
     <ng-template #elseBlock>
-      <h3>Component Results By Category</h3>
       <div class="alert-warning mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-11a">
         <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
         <span class="fs-base-3 p-2 d-flex flex-column justify-content-center flex-11a">

--- a/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.html
@@ -24,8 +24,6 @@
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
     <div *ngIf="componentCount != 0; else elseBlock">
       <div id="chart" class="mb-3">
-        <h3>Components Summary</h3>
-
         <div style="max-width:300px; margin:auto;">
           <canvas id="canvasComponentSummary">{{canvasComponentSummary}}</canvas>
         </div>
@@ -58,7 +56,6 @@
       </div>
     </div>
     <ng-template #elseBlock>
-      <h3>Components Summary</h3>
       <div class="alert-warning mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-11a">
         <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
         <span class="fs-base-3 p-2 d-flex flex-column justify-content-center flex-11a">

--- a/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.html
@@ -24,7 +24,6 @@
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
     <div *ngIf="dataSet != 0; else elseBlock">
       <div id="chart" class="mb-4">
-        <h3>Answers By Component Type</h3>
         <canvas id="canvasComponentTypes">{{chart}}</canvas>
       </div>
       <div *ngIf="!initialized">
@@ -60,7 +59,6 @@
       </div>
     </div>
     <ng-template #elseBlock>
-      <h3>Answers By Component Type</h3>
       <div class="alert-warning mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-11a">
         <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
         <span class="fs-base-3 p-2 d-flex flex-column justify-content-center flex-11a">

--- a/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.html
@@ -22,9 +22,6 @@
 -------------------------->
 <div class="assess-component d-flex flex-column justify-content-start flex-11a" *transloco="let t">
   <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-
-    <h3>{{t('titles.network warnings')}}</h3>
-
     <div *ngIf="initialized">
       <p>All identified network analysis problems.</p>
 

--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div class="assess-component d-flex flex-column justify-content-start flex-11a">
     <div class="white-panel d-flex flex-column justify-content-start flex-11a">
-        <h3 class="mb-4">{{domain?.title}}</h3>
-
         <app-crr-heatmap [domainAbbrev]="domainAbbrev"></app-crr-heatmap>
 
         <div *ngIf="!loaded">

--- a/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.html
@@ -22,7 +22,6 @@
 -------------------------->
 <div>
   <div class="white-panel" *transloco="let t">
-    <h3>{{t('reports.core.crr.summary results.title')}}</h3>
     <div>
       <div *ngIf="!summaryResultLoaded" class="my-5 spinner-container" style="margin: 2em auto">
         <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/assessment/results/feedback/feedback.component.html
+++ b/CSETWebNg/src/app/assessment/results/feedback/feedback.component.html
@@ -38,7 +38,6 @@
 </style>
 <div>
   <div class="white-panel d-flex flex-column justify-content-start flex-11a" *transloco="let t">
-    <h3 class="d-flex flex-column flex-00a">{{t('titles.feedback')}}</h3>
     <div class="flex-container">
       <p>
         {{t('feedback.text 1')}}


### PR DESCRIPTION
## Summary

Continue the cleanup of redundant h3/h4 page titles that duplicate information already shown in the sidebar navigation. This is a follow-up to PR #5327 which started this refactoring effort.

## Changes

- **Tutorial pages (8 files)**: Removed redundant titles from CMMC2, CRR, EDM, CIS, CPG, CPG2, IMR, and MVRA tutorial components
- **Prepare pages (2 files)**: Removed titles from CSI and Assessment Config IOD components  
- **Questions pages (3 files)**: Removed titles from Diagram Questions, Maturity Questions, and Other Remarks components
- **Results pages (2 files)**: Removed titles from Feedback and CRR Summary Results components
- **CRR Domain pages (1 file)**: Removed domain title from CRR Results Page component (affects all 10 CRR domain routes)
- **Analysis pages (5 files)**: Removed titles from Components Summary, Ranked, Results, Types, and Warnings components
- **Diagram pages (1 file)**: Removed Network Diagram title from Diagram Info component

## Breaking Changes

None

## Test Plan

- [ ] Navigate to each affected route and verify:
  - No redundant title appears at the top of the page content
  - Page content displays correctly below the white-panel container
  - Sub-section headers (h5/h6) remain intact
  - Sidebar still shows the correct page titles

### Affected Routes
- `/assessment/{id}/prepare/tutorial-cmmc2`
- `/assessment/{id}/prepare/tutorial-crr`
- `/assessment/{id}/prepare/tutorial-edm`
- `/assessment/{id}/prepare/tutorial-cis`
- `/assessment/{id}/prepare/tutorial-cpg`
- `/assessment/{id}/prepare/tutorial-cpg2`
- `/assessment/{id}/prepare/tutorial-imr`
- `/assessment/{id}/prepare/tutorial-mvra`
- `/assessment/{id}/prepare/csi`
- `/assessment/{id}/prepare/info-config-iod`
- `/assessment/{id}/prepare/diagram/info`
- `/assessment/{id}/diagram-questions`
- `/assessment/{id}/maturity-questions`
- `/assessment/{id}/other-remarks`
- `/assessment/{id}/results/feedback`
- `/assessment/{id}/results/crr-summary-results`
- `/assessment/{id}/results/crr-domain-am` (and all CRR domain pages)
- `/assessment/{id}/results/components-summary`
- `/assessment/{id}/results/components-ranked`
- `/assessment/{id}/results/components-results`
- `/assessment/{id}/results/components-types`
- `/assessment/{id}/results/components-warnings`

## Related Issues

Follows up on the work started in PR #5327

## Release Notes

Removed redundant page titles from additional component templates to improve UI consistency. Page titles are now only displayed in the sidebar navigation, eliminating duplication.

## Checklist

- [x] Conventional commit format followed
- [x] Changes are purely cosmetic/refactoring (no functional changes)
- [ ] Visual verification of affected pages