### PR TITLE
feat(cis): add embedded CIS results pages for section scoring and deficiency

### DIFF
--- a/CSETWebNg/src/app/app.module.ts
+++ b/CSETWebNg/src/app/app.module.ts
@@ -417,6 +417,8 @@ import { DisclaimerBlurbAComponent } from './reports/cis/shared/disclaimer-blurb
 import { ConfigCisComponent } from './assessment/prepare/maturity/config-cis/config-cis.component';
 import { CisRankedDeficiencyComponent } from './reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component';
 import { RankedDeficiencyChartComponent } from './assessment/results/cis/ranked-deficiency-chart/ranked-deficiency-chart.component';
+import { CisSectionScoringPageComponent } from './assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component';
+import { CisRankedDeficiencyPageComponent } from './assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component';
 import { CisSectionScoringComponent } from './reports/cis/cis-section-scoring/cis-section-scoring.component';
 import { CisScoringChartComponent } from './reports/cis/cis-section-scoring/cis-scoring-chart/cis-scoring-chart.component';
 import { CharterMismatchComponent } from './dialogs/charter-mistmatch/charter-mismatch.component';
@@ -878,6 +880,8 @@ ModuleRegistry.registerModules([AllCommunityModule]);
         ConfigCisComponent,
         CisRankedDeficiencyComponent,
         RankedDeficiencyChartComponent,
+        CisSectionScoringPageComponent,
+        CisRankedDeficiencyPageComponent,
         CisCommentsmarkedComponent,
         CisSectionScoringComponent,
         CisScoringChartComponent,

--- a/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 <div>
     <div class="white-panel d-flex justify-content-start flex-column flex-11a tutorial">
-        <h3 class="wrap-text mb-3">CIS Configuration</h3>
-
         <div class="mb-4">
             <h4>Naming the CIS Assessment</h4>
             <p>To realize the full benefits of the CIS, returning users have the ability to import previous answers as well

--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
@@ -1,0 +1,32 @@
+<!----------------------
+
+   Copyright 2025 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
+<div class="p-4" *transloco="let t">
+    <h3>{{t('reports.core.cis.deficiencies.title')}}</h3>
+
+    <p class="mb-4">
+        {{t('reports.core.cis.deficiencies.para 1')}}
+    </p>
+
+    <app-ranked-deficiency-chart></app-ranked-deficiency-chart>
+</div>

--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.scss
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.scss
@@ -1,0 +1,1 @@
+// Styles for CIS Ranked Deficiency embedded page

--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.ts
@@ -1,0 +1,38 @@
+////////////////////////////////
+//
+//   Copyright 2025 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
+import { Component } from '@angular/core';
+
+/**
+ * Embedded CIS Ranked Deficiency results page component.
+ * Displays deficiency comparison chart within the assessment flow.
+ */
+@Component({
+  selector: 'app-cis-ranked-deficiency-page',
+  templateUrl: './cis-ranked-deficiency-page.component.html',
+  styleUrls: ['./cis-ranked-deficiency-page.component.scss'],
+  standalone: false
+})
+export class CisRankedDeficiencyPageComponent {
+  constructor() { }
+}

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
@@ -1,0 +1,45 @@
+<!----------------------
+
+   Copyright 2025 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
+<div class="p-4" *transloco="let t">
+    <h3>CIS Section Scoring</h3>
+
+    <p class="mb-4">
+        This page displays scoring charts for each CIS section based on your assessment responses.
+        If a baseline assessment was selected, baseline scores will also be displayed for comparison.
+    </p>
+
+    <div *ngIf="loading" class="d-flex justify-content-center my-4">
+        <div class="spinner-border" role="status">
+            <span class="visually-hidden">Loading...</span>
+        </div>
+    </div>
+
+    <div *ngIf="!loading">
+        <div *ngFor="let s of myModel?.groupings">
+            <div class="mb-4">
+                <app-cis-scoring-chart [g]="s"></app-cis-scoring-chart>
+            </div>
+        </div>
+    </div>
+</div>

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.scss
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.scss
@@ -1,0 +1,1 @@
+// Styles for CIS Section Scoring embedded page

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.ts
@@ -1,0 +1,52 @@
+////////////////////////////////
+//
+//   Copyright 2025 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
+import { Component, OnInit } from '@angular/core';
+import { CisService } from '../../../../services/cis.service';
+
+/**
+ * Embedded CIS Section Scoring results page component.
+ * Displays section scoring charts within the assessment flow.
+ */
+@Component({
+  selector: 'app-cis-section-scoring-page',
+  templateUrl: './cis-section-scoring-page.component.html',
+  styleUrls: ['./cis-section-scoring-page.component.scss'],
+  standalone: false
+})
+export class CisSectionScoringPageComponent implements OnInit {
+
+  loading = true;
+  myModel: any;
+
+  constructor(public cisSvc: CisService) { }
+
+  ngOnInit(): void {
+    this.loading = true;
+
+    this.cisSvc.getCisSectionScoring().subscribe((resp: any) => {
+      this.myModel = resp.myModel;
+      this.loading = false;
+    });
+  }
+}

--- a/CSETWebNg/src/app/routing/assessments-routing/assessment-routing.module.ts
+++ b/CSETWebNg/src/app/routing/assessments-routing/assessment-routing.module.ts
@@ -89,6 +89,8 @@ import { OverviewComponent } from '../../assessment/results/overview/overview.co
 import { ReportsComponent } from '../../assessment/results/reports/reports.component';
 import { ResultsComponent } from '../../assessment/results/results.component';
 import { TsaAssessmentCompleteComponent } from '../../assessment/results/tsa-assessment-complete/tsa-assessment-complete.component';
+import { CisSectionScoringPageComponent } from '../../assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component';
+import { CisRankedDeficiencyPageComponent } from '../../assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component';
 import { AssessGuard } from '../../guards/assess.guard';
 import { CisaVadrLevelsComponent } from '../../assessment/prepare/maturity/cisa-vadr-levels/cisa-vadr-levels.component';
 import { CisaVadrInfoComponent } from '../../assessment/prepare/maturity/cisa-vadr-info/cisa-vadr-info.component';
@@ -193,6 +195,10 @@ const routes: Routes = [
             { path: 'crr-domain-edm', component: CrrResultsPage },
             { path: 'crr-domain-ta', component: CrrResultsPage },
             { path: 'crr-domain-sa', component: CrrResultsPage },
+
+            // CIS results pages
+            { path: 'section-scoring', component: CisSectionScoringPageComponent },
+            { path: 'ranked-deficiency', component: CisRankedDeficiencyPageComponent },
 
             { path: 'overview', component: OverviewComponent },
             { path: 'reports', component: ReportsComponent },


### PR DESCRIPTION
## Summary
Add two new embedded result page components for CIS assessments that display section scoring charts and ranked deficiency comparisons directly within the assessment flow, improving user experience by integrating key visualizations into the assessment journey.

## Commits
- `ee63f1d77` feat(cis): add CIS Section Scoring results page component
- `96ef0a098` feat(cis): add CIS Ranked Deficiency results page component
- `478358ff0` feat(cis): register CIS results pages and add routes
- `3d6406c58` refactor(ui): remove redundant header from CIS config page

## Changes
- Added `CisSectionScoringPageComponent` that fetches and displays scoring charts for each CIS section grouping with baseline comparison support
- Added `CisRankedDeficiencyPageComponent` that displays the ranked deficiency chart using the existing `app-ranked-deficiency-chart` component
- Added routes for `/section-scoring` and `/ranked-deficiency` paths in the assessment routing module
- Registered both new components in `app.module.ts`
- Removed redundant "CIS Configuration" header from config-cis component (consistent with recent header cleanup refactoring)

## Breaking Changes
None

## Test Plan
- [ ] Run `npm run build` to verify build succeeds
- [ ] Navigate to a CIS assessment and access the new results pages via their routes
- [ ] Verify section scoring charts render correctly with data
- [ ] Verify ranked deficiency chart renders correctly
- [ ] Test with and without baseline assessment selected to verify comparison functionality
- [ ] Verify CIS config page displays correctly without the redundant header

## Related Issues
None

## Release Notes
CIS assessments now include embedded section scoring and ranked deficiency pages within the results flow, providing users with immediate access to key visualizations without navigating to separate reports.

## Checklist
- [ ] Tests pass locally
- [ ] Linting passes
- [ ] Documentation updated (if needed)
- [x] Conventional commit format followed