### PR TITLE
CPG2 tutorial modifications

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
@@ -5,7 +5,6 @@
 // 
 //////////////////////////////// 
 
-using CSETWebCore.Business.Aggregation;
 using CSETWebCore.Business.Maturity;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Demographic;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
@@ -6,9 +6,7 @@
 //////////////////////////////// 
 
 using CSETWebCore.Business.Assessment;
-using CSETWebCore.Business.Maturity;
 using CSETWebCore.DataLayer.Model;
-using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Demographic;
 using System;
 using System.Collections.Generic;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ExportPoam.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ExportPoam.cs
@@ -97,7 +97,7 @@ namespace CSETWebCore.Business.Reports
                         foreach (var question in subgrouping.Questions)
                         {
                             // Skip questions that have been met.
-                            if (question.Answer == "Y" || isUnpardonable(question.DisplayNumber))
+                            if (question.Answer == "Y" || IsBarredFromInclusion(question.DisplayNumber))
                             {
                                 continue;
                             }
@@ -224,14 +224,34 @@ namespace CSETWebCore.Business.Reports
             return filename;
         }
 
+
         /// <summary>
-        /// Check if an item is unpardonable based on its control title.
+        /// Check if an item is not allowed in the POAM based on its control title.
+        /// 
+        /// These controls cannot be included in a Plan of Action and Milestones (POA&M).
+        /// They are explicitly barred from being included in a POA&M for Level 2 certification 
+        /// per § 170.21 of the 32 CFR CMMC Program final rule.
+        /// 
+        /// Key Points:
+        /// 
+        ///  - Must be fully implemented at assessment: This control must be fully implemented 
+        ///    from the start of the assessment and is non-negotiable
+        ///    
+        ///  - No deferrals allowed: Unlike some 1-point controls that can be deferred to a POA&M 
+        ///    for 180-day remediation, these controls must be "MET" at the time of the assessment
+        ///    
+        ///  - Certification blocker: If deficiencies are found in this control, it would result 
+        ///    in a "NOT MET" finding that cannot be remediated via a POA&M, and CMMC at Level 2 
+        ///    would not be achieved
+        ///    
+        ///  These controls receive no grace period. They must be working correctly before the 
+        ///  assessment begins.
         /// </summary>
         /// <param name="controlTitle"></param>
         /// <returns>bool</returns>
-        private static bool isUnpardonable(string controlTitle)
+        private static bool IsBarredFromInclusion(string controlTitle)
         {
-            var unpardonables = new List<string> {
+            var list = new List<string> {
                 "AC.L2-3.1.20",
                 "AC.L2-3.1.22",
                 "PE.L2-3.10.3",
@@ -246,7 +266,7 @@ namespace CSETWebCore.Business.Reports
                 "SI.L3-3.14.3E"
             };
 
-            return unpardonables.Contains(controlTitle);
+            return list.Contains(controlTitle);
         }
     }
 }

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -32,6 +32,8 @@ import { Observable } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { UploadDemographicsComponent } from "../../../../dialogs/import demographics/import-demographics.component";
 import { ConstantsService } from '../../../../services/constants.service';
+import { TranslocoService } from '@jsverse/transloco';
+import { OkayComponent } from '../../../../dialogs/okay/okay.component';
 
 
 
@@ -80,6 +82,7 @@ export class AssessmentDemographicsComponent implements OnInit {
         private c: ConstantsService,
         public configSvc: ConfigService,
         public dialog: MatDialog,
+        public tSvc: TranslocoService
     ) { }
 
     ngOnInit() {
@@ -159,6 +162,17 @@ export class AssessmentDemographicsComponent implements OnInit {
 
                 // Currently this screen shows PPD-21 (the current 16 critical infrastructure sector list)
                 this.demographicData.sectorDirective = 'PPD-21';
+
+                if (this.demographicData.acknowledgement == true) {
+                    const dlgOkay = this.dialog.open(OkayComponent, {
+                        data: {
+                            title: this.tSvc.translate('sector changes'),
+                            messageText: this.tSvc.translate('sector acknowledgement')
+                        }
+                    }).afterClosed().subscribe(result => {
+                        this.assessSvc.saveAcknowledgement().subscribe();
+                    });
+                }
             },
             error => console.error('Demographic load Error: ' + (<Error>error).message)
         );

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
@@ -31,6 +31,8 @@ import { NavigationService } from '../../../../services/navigation/navigation.se
 import { AwwaStandardComponent } from '../../standards/awwa-standard/awwa-standard.component';
 import { AwwaService } from '../../../../services/awwa.service';
 import { DemographicService } from '../../../../services/demographic.service';
+import { TranslocoService } from '@jsverse/transloco';
+import { OkayComponent } from '../../../../dialogs/okay/okay.component';
 
 
 @Component({
@@ -60,6 +62,7 @@ export class AssessmentDetailComponent implements OnInit {
     public navSvc: NavigationService,
     public awwaSvc: AwwaService,
     public configSvc: ConfigService,
+    public tSvc: TranslocoService,
     public datePipe: DatePipe,
     public dialog: MatDialog
   ) { }
@@ -87,6 +90,18 @@ export class AssessmentDetailComponent implements OnInit {
 
     this.demoSvc.getDemographic().subscribe((data: any) => {
       this.demographics = data;
+
+
+      if (data.acknowledgement == true) {
+        const dlgOkay = this.dialog.open(OkayComponent, {
+          data: {
+            title: this.tSvc.translate('sector changes'),
+            messageText: this.tSvc.translate('sector acknowledgement')
+          }
+        }).afterClosed().subscribe(result => {
+          this.assessSvc.saveAcknowledgement().subscribe();
+        });
+      }
     });
   }
 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
@@ -72,8 +72,6 @@
                 <li>{{ttcpg('3f')}}</li>
             </ul>
 
-            <p>{{ttcpg('3g')}}</p>
-
             <p>{{ttcpg('4')}}</p>
             <div class="img-frame">
                 <img src="assets/images/CPG2/tutorial/Picture1.png" style="width: 650px">
@@ -168,11 +166,45 @@
                 <li><b>{{t('answer-options.labels.not-cpg')}}</b> {{ttcpg('11d')}}</li>
             </ul>
 
+
+            <!---- Sector-Specific Goals (SSG)  ---------------------->
+            <h5 class="mt-5">{{ttcpg('13a')}}</h5>
+            <p>{{ttcpg('13b')}}</p>
+
+            <p>{{ttcpg('13c')}}
+
+            <ul>
+                <li [innerHTML]="ttcpg('13d')">
+                </li>
+                <li [innerHTML]="ttcpg('13e')">
+                </li>
+            </ul>
+
+            <p>
+                {{ttcpg('13f')}}
+                <a href="https://www.cisa.gov/cross-sector-cybersecurity-performance-goals"
+                    target="_blank">https://www.cisa.gov/cross-sector-cybersecurity-performance-goals</a>
+            </p>
+            <ul>
+                <li>
+                    {{ttcpg('13g')}}
+                </li>
+                <li>
+                    {{ttcpg('13h')}}
+                </li>
+                <li>
+                    {{ttcpg('13i')}}
+                </li>
+            </ul>
+
+
+            <!---- Additional Resources  ---------------------->
             <h5 class="mt-5">{{t('titles.additional resources')}}</h5>
             <p>{{t('tutorial.additional resources')}}</p>
             <p>{{t('tutorial.please visit')}} <a href="https://www.cisa.gov/cpgs"
                     target="_blank">https://www.cisa.gov/cpgs</a> {{t('tutorial.for more information')}}</p>
         </div>
     </div>
+
     <app-nav-back-next [page]="'tutorial-cpg2'"></app-nav-back-next>
 </div>

--- a/CSETWebNg/src/app/models/assessment-info.model.ts
+++ b/CSETWebNg/src/app/models/assessment-info.model.ts
@@ -118,6 +118,8 @@ export interface Demographic {
     // PPD-21 or NIPP
     sectorDirective?: string;
 
+    acknowledgement?: boolean;
+
     // TODO-3261
     sectorId?: number;
     industryId?: number;

--- a/CSETWebNg/src/assets/i18n/tutorial/en.json
+++ b/CSETWebNg/src/assets/i18n/tutorial/en.json
@@ -86,7 +86,6 @@
           "3d": "Detect",
           "3e": "Respond",
           "3f": "Recover",
-          "3g": "Users can also add Sector-Specific Goals via the Additional Goals on the Assessment Configuration page. SSGs address unique requirements in select critical infrastructure sectors and build upon the CPGs. Users are recommended to select any additional functions relevant to their organization, even if they are not the primary focus. For example, a financial institution that also maintains IT systems should include the Information Technology sector.",
           "4": "Each security practice includes the following components.",
           "5": "Each NIST CSF function has a set of associated security practices.",
           "6": "Each question has an assigned practice identifier.",
@@ -119,7 +118,16 @@
           "12d": "Operation Technology (OT)",
           "12e": "A broad range of programmable systems and devices that interact with the physical environment or manage devices that interact with the physical environment. These systems and devices detect or cause a direct change through the monitoring and/or control of devices, processes, and events. Examples include industrial control systems, building automation systems, transportation systems, physical access control systems, physical environment monitoring systems, and physical environment measurement systems. (Source: NIST SP 800-82 Rev. 3)",
           "12f": "Information Technology (IT)",
-          "12g": "Any services, equipment, or interconnected system(s) or subsystem(s) of equipment, that are used in the automatic acquisition, storage, analysis, evaluation, manipulation, management, movement, control, display, switching, interchange, transmission, or reception of data or information by the agency. For purposes of this definition, such services or equipment if used by the agency directly or is used by a contractor under a contract with the agency that requires its use; or to a significant extent, its use in the performance of a service or the furnishing of a product. Information technology includes computers, ancillary equipment (including imaging peripherals, input, output, and storage devices necessary for security and surveillance), peripheral equipment designed to be controlled by the central processing unit of a computer, software, firmware and similar procedures, services (including cloud computing and help-desk services or other professional services which support any point of the life cycle of the equipment or service), and related resources.  (Source: NIST SP 800-53 Rev. 5)"
+          "12g": "Any services, equipment, or interconnected system(s) or subsystem(s) of equipment, that are used in the automatic acquisition, storage, analysis, evaluation, manipulation, management, movement, control, display, switching, interchange, transmission, or reception of data or information by the agency. For purposes of this definition, such services or equipment if used by the agency directly or is used by a contractor under a contract with the agency that requires its use; or to a significant extent, its use in the performance of a service or the furnishing of a product. Information technology includes computers, ancillary equipment (including imaging peripherals, input, output, and storage devices necessary for security and surveillance), peripheral equipment designed to be controlled by the central processing unit of a computer, software, firmware and similar procedures, services (including cloud computing and help-desk services or other professional services which support any point of the life cycle of the equipment or service), and related resources.  (Source: NIST SP 800-53 Rev. 5)",
+          "13a": "Sector-Specific Goals (SSG)",
+          "13b": "Certain critical infrastructure sectors require Sector-Specific Goals, which build upon the CPGs and address unique sector requirements. Users are recommended to select any additional sectors relevant to their organization, even if they are not the primary focus. For example, a financial institution that also maintains IT systems should include the Information Technology sector.",
+          "13c": "CSET currently supports SSGs for the following sectors:",
+          "13d": " Chemical Sector (Not Oil and Gas) - <em>organizations involved in the use, production, storage, or distribution of chemicals within one or more components of the Chemical Sector—including agricultural chemicals, basic chemicals, specialty chemicals, and consumer products</em>",
+          "13e": "Information Technology Sector - <em>organizations that develop software for internal, commercial, or open source use</em>",
+          "13f": "The following sectors include additional guidance not covered in CSET. For more information about these sector-specific performance goals, please visit CISA's Cross-Sector Cybersecurity Performance Goals page:",
+          "13g": "Energy Sector",
+          "13h": "Healthcare and Public Health Sector",
+          "13i": "Water and Wastewater Systems Sector"
      },
      "cmmc2": {
           "title": "Cybersecurity Maturity Model Certification (CMMC) 2.0 Tutorial",

--- a/CSETWebNg/src/assets/settings/config.json
+++ b/CSETWebNg/src/assets/settings/config.json
@@ -40,7 +40,7 @@
     "canDeleteCustomModules": true,
     "showExportAllButton": false,
     "showAssessmentUpgrade": false,
-    "ignoreIodFieldValidation": true
+    "ignoreIodFieldValidation": false
   },
   "galleryLayout": "CSET",
   "installationMode": "CSET",


### PR DESCRIPTION
This pull request introduces several enhancements and fixes related to sector-specific goals, POA&M export logic, and user acknowledgement flows in the assessment module. The main focus is on improving the handling and visibility of sector-specific requirements, updating control exclusion logic for POA&M exports, and providing better user feedback through modal dialogs. There are also updates to internationalization and configuration settings.

**Sector-Specific Goals and Assessment Flow Improvements:**

* Added new logic to display a modal acknowledgement dialog in both `AssessmentDemographicsComponent` and `AssessmentDetailComponent` when the `acknowledgement` flag is true, leveraging the new `TranslocoService` for translations and the `OkayComponent` for user feedback. This ensures users are notified of important sector changes and their implications. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR165-R175) [[2]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR93-R104) [[3]](diffhunk://#diff-37f4f8bb2f18a727a6f3a86890f5e90d3b87ffa9b5613a4bdc4f86f9608ba092R121-R122)
* Updated the tutorial content and translation files to provide expanded information about Sector-Specific Goals (SSG), including which sectors are supported and additional guidance for users. This provides clearer instructions and context for organizations with unique sector requirements. [[1]](diffhunk://#diff-456fa97f8cfd26040ec2fc874bf5fdfc525ff5b73ec5a73308c3d6a2fc15314aR169-R208) [[2]](diffhunk://#diff-0958e4808d85f98cfef6cbf38b2c1978245bb9fceb92ea3407352c3a27c2417cL122-R130)

**POA&M Export Logic Updates:**

* Refactored the POA&M export logic by renaming and clarifying the method that determines which controls are barred from inclusion, updating its documentation to align with CMMC Level 2 requirements, and ensuring the correct controls are excluded from the export. [[1]](diffhunk://#diff-e5e85d855cfc7c5558f4b8850721db29b3e0cf72024ac713ba5ef1923fab97c5L100-R100) [[2]](diffhunk://#diff-e5e85d855cfc7c5558f4b8850721db29b3e0cf72024ac713ba5ef1923fab97c5R227-R254) [[3]](diffhunk://#diff-e5e85d855cfc7c5558f4b8850721db29b3e0cf72024ac713ba5ef1923fab97c5L249-R269)

**Internationalization and Configuration:**

* Integrated `TranslocoService` into demographic and assessment detail components to support dynamic translations for modal dialogs and user notifications. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR35-R36) [[2]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR34-R35)
* Changed the `ignoreIodFieldValidation` setting in `config.json` from `true` to `false`, enforcing stricter validation for IOD fields in assessments.

**Minor Cleanup:**

* Removed unused imports from demographic business logic files to streamline dependencies. [[1]](diffhunk://#diff-62c5e6f867829b13b276578546594568fbf3545b910d9b8ceae159b6700b7a58L8) [[2]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL9-L11)

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
