### PR TITLE
More SSG cleanup for multi-sector

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicBusinessTests.cs
@@ -249,7 +249,7 @@ namespace CSETWebCore.Business.Tests.Demographic
             // Assert
             Assert.NotNull(result);
             Assert.Equal(assessmentId, result.AssessmentId);
-            Assert.Empty(result.SsgSectorIds);
+            Assert.Empty(result.SsgModelIds);
         }
 
         [Fact]
@@ -278,10 +278,10 @@ namespace CSETWebCore.Business.Tests.Demographic
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(3, result.SsgSectorIds.Count);
-            Assert.Contains(1, result.SsgSectorIds);
-            Assert.Contains(2, result.SsgSectorIds);
-            Assert.Contains(3, result.SsgSectorIds);
+            Assert.Equal(3, result.SsgModelIds.Count);
+            Assert.Contains(1, result.SsgModelIds);
+            Assert.Contains(2, result.SsgModelIds);
+            Assert.Contains(3, result.SsgModelIds);
         }
 
         [Fact]
@@ -321,7 +321,7 @@ namespace CSETWebCore.Business.Tests.Demographic
             var demographics = new Demographics
             {
                 AssessmentId = assessmentId,
-                SsgSectorIds = new List<int> { 1, 2, 3 }
+                SsgModelIds = new List<int> { 1, 2, 3 }
             };
 
             var existingSSG = new List<DETAILS_DEMOGRAPHICS>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
@@ -82,7 +82,7 @@ namespace CSETWebCore.Business.Demographic
             }
 
 
-            demographics.SsgSectorIds.AddRange(new CpgBusiness(_context, "en").DetermineSsgModels(assessmentId));
+            demographics.SsgModelIds.AddRange(new CpgBusiness(_context, "en").DetermineSsgModels(assessmentId));
 
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CpgBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CpgBusiness.cs
@@ -123,33 +123,33 @@ namespace CSETWebCore.Business.Maturity
         /// <summary>
         /// Figures out if an SSG model is applicable as a bonus.
         /// The SSG is based on the assessment's sector.
-        /// Returns null if no SSG is applicable.
+        /// Returns an empty list if no SSG is applicable.
         /// </summary>
         /// <returns></returns>
         public List<int> DetermineSsgModels(int assessmentId)
         {
-            List<int> list = [];
-
-            var ddSectors = _context.ASSESSMENT_SECTOR_SUBSECTOR.Where(x => x.Assessment_Id == assessmentId).ToList();
-
-            foreach (var s in ddSectors)
+            var sectorToModelMap = new Dictionary<int, int>
             {
-                // CHEMICAL
-                var chemicalSectors = new List<int>() { 1, 19 };
-                if (chemicalSectors.Contains((int)s.SectorId))
-                {
-                    list.Add(Constants.Constants.Model_SSG_CHEM);
-                }
+                { 1, Constants.Constants.Model_SSG_CHEM },
+                { 19, Constants.Constants.Model_SSG_CHEM },
+                { 13, Constants.Constants.Model_SSG_IT },
+                { 28, Constants.Constants.Model_SSG_IT },
+            };
 
-                // INFORMATION TECHNOLOGY (IT)
-                var itSectors = new List<int>() { 13, 28 };
-                if (itSectors.Contains((int)s.SectorId))
+            var ssgModels = new HashSet<int>();
+            var sectors = _context.ASSESSMENT_SECTOR_SUBSECTOR
+                .Where(x => x.Assessment_Id == assessmentId)
+                .ToList();
+
+            foreach (var sector in sectors)
+            {
+                if (sectorToModelMap.TryGetValue((int)sector.SectorId, out var modelId))
                 {
-                    list.Add(Constants.Constants.Model_SSG_IT);
+                    ssgModels.Add(modelId);
                 }
             }
 
-            return list;
+            return ssgModels.ToList();
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CpgStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CpgStructure.cs
@@ -110,7 +110,7 @@ namespace CSETWebCore.Helpers
             Top.ModelName = mm.Model_Name;
             Top.ModelId = (int)this.ModelId;
 
-            Top.TechDomain = _context.DETAILS_DEMOGRAPHICS.Where(x => x.DataItemName == "TECH-DOMAIN").FirstOrDefault()?.StringValue ?? null;
+            Top.TechDomain = _context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == this.AssessmentId && x.DataItemName == "TECH-DOMAIN").FirstOrDefault()?.StringValue ?? null;
 
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureForModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureForModel.cs
@@ -195,6 +195,7 @@ namespace CSETWebCore.Helpers
                         DisplayNumber = myQ.Question_Title,
                         ParentQuestionId = myQ.Parent_Question_Id,
                         QuestionType = myQ.Mat_Question_Type,
+                        IsAnswerable = myQ.Is_Answerable,
                         AnswerText = answer?.Answer_Text,
                         AltAnswerText = answer?.Alternate_Justification,
                         Comment = answer?.Comment,
@@ -260,6 +261,9 @@ namespace CSETWebCore.Helpers
                     DisplayNumber = myQ.Question_Title,
                     ParentQuestionId = myQ.Parent_Question_Id,
                     QuestionType = myQ.Mat_Question_Type,
+                    IsAnswerable = myQ.Is_Answerable,
+                    AnswerText = answer?.Answer_Text,
+                    AltAnswerText = answer?.Alternate_Justification,
                     Comment = answer?.Comment ?? "",
                     Options = GetOptions(myQ.Mat_Question_Id)
                 };
@@ -323,6 +327,7 @@ namespace CSETWebCore.Helpers
                         ParentQuestionId = myQ.Parent_Question_Id,
                         ParentOptionId = myQ.Parent_Option_Id,
                         QuestionType = myQ.Mat_Question_Type,
+                        IsAnswerable = myQ.Is_Answerable,
                         Options = GetOptions(myQ.Mat_Question_Id)
                     };
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
@@ -30,7 +30,11 @@ namespace CSETWebCore.Model.Assessment
         public List<SectorSubsector> SectorSubsectors { get; set; } = [];
 
 
-        public List<int> SsgSectorIds { get; set; } = [];
+        /// <summary>
+        /// The list of all in-scope SSG models due to the assessment's
+        /// current state.
+        /// </summary>
+        public List<int> SsgModelIds { get; set; } = [];
 
 
         public int? Size { get; set; }

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -88,7 +88,7 @@ namespace CSETWebCore.Api.Controllers
                 });
             }
 
-            return Ok(assessmentId);
+            return Ok(_demographic.GetDemographics(assessmentId));
         }
 
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -36,6 +36,7 @@ export class AssessmentConfigIodComponent implements OnInit {
   ngOnInit() {
     this.demoSvc.getDemographic().subscribe((data: any) => {
       this.demographics = data;
+      this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
     });
 
     this.iodDemoSvc.getDemographics().subscribe((data: any) => {

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -107,11 +107,15 @@ export class AssessmentDemographicsComponent implements OnInit {
         if (this.demoSvc.id) {
             this.getDemographics();
         }
+        
         this.refreshContacts();
         this.getOrganizationTypes();
     }
 
-    // Functionality to import demographic information, excluding contacts, organization point of contact, facilitator, critical service point of contact 
+    /**
+     * Functionality to import demographic information, excluding contacts, 
+     * organization point of contact, facilitator, critical service point of contact 
+     */
     importClick(event) {
         let dialogRef = null;
         this.unsupportedImportFile = false;
@@ -134,19 +138,12 @@ export class AssessmentDemographicsComponent implements OnInit {
     }
 
 
-    //Functionality to export demographic information, excluding contacts, organization point of contact, facilitator, critical service point of contact 
+    /**
+     * Functionality to export demographic information, excluding contacts, 
+     * organization point of contact, facilitator, critical service point of contact 
+     */
     exportClick() {
         this.demoSvc.exportDemographics()
-    }
-
-    /**
-     * 
-     */
-    onChangeSsg(list: number[]) {
-        this.demographicData.ssgSectorIds = list;
-        this.assessSvc.assessment.ssgSectorIds = list;
-        this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
-        this.updateDemographics();
     }
 
     /**
@@ -156,6 +153,8 @@ export class AssessmentDemographicsComponent implements OnInit {
         this.demoSvc.getDemographic().subscribe(
             (data: Demographic) => {
                 this.demographicData = data;
+                this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
+
                 if (this.demographicData.organizationType == "3") {
                     this.isSLTT = true;
                 }
@@ -224,7 +223,6 @@ export class AssessmentDemographicsComponent implements OnInit {
         return (this.configSvc.behaviors.showCriticalService ?? true)
             && (moduleBehavior?.showCriticalServiceDemog ?? true);
     }
-
 
     showEdmFields() {
         return this.assessSvc.assessment?.maturityModel?.modelName == 'EDM';

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
@@ -90,6 +90,7 @@ export class AssessmentDetailComponent implements OnInit {
 
     this.demoSvc.getDemographic().subscribe((data: any) => {
       this.demographics = data;
+      this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
 
 
       if (data.acknowledgement == true) {

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
@@ -94,16 +94,6 @@ export class DemographicsIodComponent implements OnInit {
   /**
    * 
    */
-  onChangeSsg(list: number[]) {
-    this.demographicData.ssgSectors = list;
-    this.assessSvc.assessment.ssgSectorIds = list;
-    this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
-    this.updateDemographics();
-  }
-
-  /**
-   * 
-   */
   changeRegType1(o: any, evt: any) {
     this.demographicData.regulationType1 = o.optionValue;
     this.updateDemographics();

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
@@ -32,6 +32,7 @@ import {
 import { CsiService } from '../../../../services/cis-csi.service';
 import { ConfigService } from './../../../../services/config.service';
 import { DemographicService } from '../../../../services/demographic.service';
+import { AssessmentService } from '../../../../services/assessment.service';
 
 @Component({
     selector: 'app-csi-service-demographics',
@@ -92,7 +93,12 @@ export class CsiServiceDemographicsComponent implements OnInit {
 
   demographics: any = {};
 
-  constructor(private csiSvc: CsiService, private demoSvc: DemographicService, private configSvc: ConfigService) { }
+  constructor(
+    private assessSvc: AssessmentService,
+    private csiSvc: CsiService, 
+    private demoSvc: DemographicService, 
+    private configSvc: ConfigService
+  ) { }
 
   ngOnInit(): void {
     this.csiSvc.getAllCsiBudgetBases().subscribe(
@@ -136,6 +142,7 @@ export class CsiServiceDemographicsComponent implements OnInit {
 
     this.demoSvc.getDemographic().subscribe((data: any) => {
       this.demographics = data;
+      this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
     });
   }
 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
@@ -23,6 +23,7 @@
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { SsgService } from '../../../../services/ssg.service';
+import { AssessmentService } from '../../../../services/assessment.service';
 
 @Component({
   selector: 'app-cpg-practices',
@@ -38,6 +39,7 @@ export class CpgPracticesComponent implements OnInit {
    * 
    */
   constructor(
+    public assessSvc: AssessmentService,
     public ssgSvc: SsgService
   ) { }
 
@@ -46,7 +48,7 @@ export class CpgPracticesComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
-    this.ssgBonusModels = this.ssgSvc.activeSsgModelIds;
+    this.ssgBonusModels = this.assessSvc.assessment.ssgModelIds;
   }
 
   /**

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
@@ -23,12 +23,12 @@
 <div>
     <div class="white-panel d-flex flex-column flex-11a" *transloco="let t">
         <h3 class="d-flex flex-column flex-00a">{{t('reports.core.cpg.report.performance summary')}}</h3>
-        <p>
+        <p class="mb-5">
             {{t('reports.core.cpg.report.p.a')}}
         </p>
 
 
-        <div *ngIf="assessorWorkflow">
+        <div *ngIf="assessorWorkflow" class="mb-5">
             <h4>
                 {{t('reports.core.cpg.report.compliance score')}}
             </h4>
@@ -50,7 +50,7 @@
 
         <!-- CPG 2.0 chart/table -->
         <ng-container *ngIf="modelId == 21">
-            <div class="mb-4" *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
+            <div class="mb-5" *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
                 <h4>{{t('reports.core.cpg.ot')}}</h4>
                 <app-cpg-domain-summary [distrib]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary>
 
@@ -58,7 +58,7 @@
                 <app-cpg-domain-summary-table [data]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary-table>
             </div>
 
-            <div class="mb-4" *ngIf="techDomain == 'IT' || techDomain == 'OT+IT' || techDomain == null">
+            <div class="mb-5" *ngIf="techDomain == 'IT' || techDomain == 'OT+IT' || techDomain == null">
                 <h4>{{t('reports.core.cpg.it')}}</h4>
                 <app-cpg-domain-summary [distrib]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary>
 
@@ -70,7 +70,7 @@
 
         <!-- SSG chart/table -->
         <ng-container *ngFor="let s of answerDistribsSsg">
-            <div class="mt-4 mb-4">
+            <div class="mt-4 mb-5">
                 <h4>{{ t('reports.core.cpg.report.ssg.2') }} - {{t(`reports.core.ssg.${s.modelId}`)}}</h4>
                 <app-cpg-domain-summary [distrib]="s.distribution"></app-cpg-domain-summary>
 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.ts
@@ -75,6 +75,7 @@ export class CpgSummaryComponent implements OnInit {
     this.assessorWorkflow = this.assessSvc.assessment.assessorMode ?? false;
 
     var demog: Demographic = await firstValueFrom(this.demoSvc.getDemographic());
+    this.assessSvc.assessment.ssgModelIds = demog.ssgModelIds;
     this.techDomain = demog.techDomain;
 
     // CPG 1.1
@@ -94,7 +95,7 @@ export class CpgSummaryComponent implements OnInit {
     }
 
     // SSG
-    const ssgPromises = this.ssgSvc.activeSsgModelIds.map(async id => {
+    const ssgPromises = this.assessSvc.assessment.ssgModelIds.map(async id => {
       const d = await this.getAnswerDistribution(id, '');
       return {
         modelId: id,

--- a/CSETWebNg/src/app/models/assessment-info.model.ts
+++ b/CSETWebNg/src/app/models/assessment-info.model.ts
@@ -48,7 +48,7 @@ export interface AssessmentDetail {
 
     // sectors
     sectorSubsectors?: SectorSub[];
-    ssgSectorIds?: number[];
+    ssgModelIds?: number[];
 
 
     useStandard?: boolean;
@@ -125,7 +125,7 @@ export interface Demographic {
     industryId?: number;
     sectorSubsectors?: SectorSub[];
 
-    ssgSectorIds?: number[];
+    ssgModelIds?: number[];
 
     size?: number;
     assetValue?: number;

--- a/CSETWebNg/src/app/models/demographics-iod.model.ts
+++ b/CSETWebNg/src/app/models/demographics-iod.model.ts
@@ -37,7 +37,7 @@ export interface DemographicsIod {
   sectorSubsectors?: SectorSub[];
 
 
-  ssgSectors?: number[];
+  // TODO-3261 ssgSectors?: number[];
 
   // Technology Domain (IT vs OT)
   techDomain?: string;

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
@@ -126,7 +126,7 @@ export class CpgDeficiencyComponent implements OnInit {
    */
   getSsgModels() {
     this.loadingSsg = true;
-    this.ssgBonusModels = this.ssgSvc.activeSsgModelIds;
+    this.ssgBonusModels = this.assessSvc.assessment.ssgModelIds;
 
     const obs: Observable<any>[] = [];
     this.ssgBonusModels.forEach(m => obs.push(this.maturitySvc.getMaturityDeficiency(m)));

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
@@ -83,7 +83,7 @@
         <app-cpg-practice-table [modelId]="modelId"></app-cpg-practice-table>
 
         <!-- heatmap - waiting for approval to enable this -->
-        <div *ngIf="false">
+        <div *ngIf="true">
             <h2 style="font-size: 1.4rem">{{ t('reports.core.heatmap.title') }}</h2>
             <div class="d-flex flex-row">
                 <p style="width: 70%" class="me-4">
@@ -108,7 +108,7 @@
         <app-cpg-practice-table [ssgModelId]="s"></app-cpg-practice-table>
 
         <!-- heatmap - waiting for approval to enable this -->
-        <div *ngIf="false">
+        <div *ngIf="true">
             <h2 style="font-size: 1.4rem">{{ t('reports.core.heatmap.title') }}</h2>
             <div class="d-flex flex-row">
                 <p style="width: 70%" class="me-4">

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -131,6 +131,7 @@ export class CpgReportComponent implements OnInit {
 
     var demog: Demographic = await firstValueFrom(this.demoSvc.getDemographic());
     this.techDomain = demog.techDomain;
+    this.assessSvc.assessment.ssgModelIds = demog.ssgModelIds;
 
     // CPG 1.1
     if (this.modelId == 11) {
@@ -173,7 +174,7 @@ export class CpgReportComponent implements OnInit {
    * 
    */
   async initSsg(): Promise<void> {
-    this.ssgBonusModelIds = this.ssgSvc.activeSsgModelIds;
+    this.ssgBonusModelIds = this.assessSvc.assessment.ssgModelIds;
 
     const ssgDistrib$ = this.ssgBonusModelIds.map(async id => {
       const d = await this.getAnswerDistribution(id, '');

--- a/CSETWebNg/src/app/reports/edm/edm.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.ts
@@ -29,6 +29,7 @@ import { MaturityQuestionResponse } from '../../models/questions.model';
 import { Demographic } from '../../models/assessment-info.model';
 import { ReportService } from '../../services/report.service';
 import { saveAs } from "file-saver";
+import { AssessmentService } from '../../services/assessment.service';
 
 @Component({
     selector: 'edm',
@@ -56,6 +57,7 @@ export class EdmComponent implements OnInit, AfterContentInit {
    */
   constructor(
     private titleService: Title,
+    private assessSvc: AssessmentService,
     public maturitySvc: MaturityService,
     public demoSvc: DemographicService,
     public reportSvc: ReportService
@@ -132,7 +134,9 @@ export class EdmComponent implements OnInit, AfterContentInit {
         this.demoSvc.getDemographic().subscribe(
           (data: Demographic) => {
             this.demographicData = data;
+            this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
             this.orgName = this.demographicData.organizationName;
+
             if (this.demographicData.organizationName?.length > 0) {
               this.displayName = this.orgName;
             }

--- a/CSETWebNg/src/app/services/demographic.service.ts
+++ b/CSETWebNg/src/app/services/demographic.service.ts
@@ -57,7 +57,7 @@ export class DemographicService {
   ) {
   }
 
-  
+
   /**
    *
    */
@@ -99,25 +99,19 @@ export class DemographicService {
    * @param demographic
    */
   updateDemographic(demographic: Demographic) {
-    // TODO-3261 - how should we do this?
-    //this.assessSvc.assessment.sectorId = demographic.sectorId;
-    
-    this.assessSvc.assessment.ssgSectorIds = demographic.ssgSectorIds;
     this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
 
     this.http.post(this.apiUrl, JSON.stringify(demographic), headers)
-      .subscribe(() => {
-        if (this.configSvc.userIsCisaAssessor) {
-        }
+      .subscribe((demographic: Demographic) => {
+        this.assessSvc.assessment.ssgModelIds = demographic.ssgModelIds;
+
         this.demographicUpdateCompleted$.next();
       });
   }
 
   importDemographics(demographic: Demographic) {
     return this.http.post(this.apiUrl + 'import', JSON.stringify(demographic), headers)
-      .subscribe(() => {
-
-      });
+      .subscribe(() => { });
   }
 
   exportDemographics() {

--- a/CSETWebNg/src/app/services/ssg.service.ts
+++ b/CSETWebNg/src/app/services/ssg.service.ts
@@ -84,29 +84,6 @@ export class SsgService {
    * Indicates if any of the SSGs are selected.
    */
   get isSsgActive(): boolean {
-    if (this.assessSvc.assessment?.ssgSectorIds) {
-      return this.assessSvc.assessment.ssgSectorIds.length > 0;
-    }
-
-    return false;
-  }
-
-  /**
-   * Returns the currently selected SSG models.
-   */
-  get activeSsgModelIds(): number[] {
-
-    // TODO:  crude mapping - make this slicker
-    const list = new Set<number>();
-    this.assessSvc.assessment?.ssgSectorIds?.forEach(sectorId => {
-      if (sectorId == 1 || sectorId == 19) {
-        list.add(18); // SSG CHEM
-      }
-      if (sectorId == 13 || sectorId == 28) {
-        list.add(20); // SSG IT
-      }
-    });
-
-    return Array.from(list);
+    return (this.assessSvc.assessment?.ssgModelIds?.length ?? 0) > 0;
   }
 }

--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -45,8 +45,8 @@
   "tech domain": {
     "label": "Technology Domain for Assessment",
     "select": "Select Technology Domain",
-    "ot": "Operational Technology (OT)",
-    "it": "Information Technology (IT)",
+    "ot": "Cross-Sector Goals - Operational Technology (OT)",
+    "it": "Cross-Sector Goals - Information Technology (IT)",
     "ot+it": "Both OT and IT"
   },
   "crit svc poc": "Critical Service Point of Contact",
@@ -1012,7 +1012,7 @@
     "cpg2": {
       "display-name": "Cyber Performance Goals (CPG) 2.0",
       "model short title": "CPG 2.0",
-      "question node title": "Goals"
+      "question node title": "Cross-Sector Goals"
     },
     "ssg": {
       "1": "Select any additional functions to include as Sector-Specific Goals",

--- a/CSETWebNg/src/assets/i18n/reports/en.json
+++ b/CSETWebNg/src/assets/i18n/reports/en.json
@@ -640,7 +640,7 @@
                          "1": "This table lists all applicable SSG security practices and how they have been answered.",
                          "2": "Sector Specific"
                     },
-                    "compliance score": "Compliance Score",
+                    "compliance score": "Cross-Sector Goals Compliance Score",
                     "current assessment": "Current Assessment",
                     "notes": "Notes",
                     "ttp or risk addressed": "TTP or Risk Addressed",
@@ -667,9 +667,9 @@
                          "5": "There are no deficiences in the sector-specific questions."
                     }
                },
-               "ot": "Operational Technology (OT)",
+               "ot": "Cross-Sector Goals - Operational Technology (OT)",
                "ot-abbrev": "OT",
-               "it": "Information Technology (IT)",
+               "it": "Cross-Sector Goals - Information Technology (IT)",
                "it-abbrev": "IT"
           },
           "ssg": {


### PR DESCRIPTION
This pull request updates the handling of SSG (Sector-Specific Guidance) models in both the backend and frontend, replacing the previous use of sector IDs with model IDs throughout the codebase. It also improves the retrieval and propagation of demographic data, ensures consistency in the data model, and includes minor UI and documentation tweaks.

**Backend: SSG Model Handling and Demographics**

* Replaced all usage of `SsgSectorIds` with `SsgModelIds` in the `Demographics` model, related business logic, and tests, ensuring that SSG models are referenced by model ID instead of sector ID. [[1]](diffhunk://#diff-406cbf86740cd5ff0da5a7a3dbadbab5fce5d67e4ef6c2d5e23c70d6b9b4d843L33-R37) [[2]](diffhunk://#diff-62c5e6f867829b13b276578546594568fbf3545b910d9b8ceae159b6700b7a58L85-R85) [[3]](diffhunk://#diff-ef0b4beddf77051da57caf6fb075fbe2e0255421b23f1c23f060b2f1d536c0c9L252-R252) [[4]](diffhunk://#diff-ef0b4beddf77051da57caf6fb075fbe2e0255421b23f1c23f060b2f1d536c0c9L281-R284) [[5]](diffhunk://#diff-ef0b4beddf77051da57caf6fb075fbe2e0255421b23f1c23f060b2f1d536c0c9L324-R324)
* Refactored `DetermineSsgModels` in `CpgBusiness` to use a mapping from sector to model ID and return a unique list of model IDs, improving clarity and correctness.
* The demographics POST endpoint now returns the full demographics object after saving, not just the assessment ID.
* Fixed a bug in `CpgStructure` so that `TechDomain` is retrieved for the correct assessment.

**Frontend: Demographics and SSG Model Propagation**

* Updated all relevant Angular components to use and propagate `ssgModelIds` instead of `ssgSectorIds`, ensuring the assessment state reflects the correct SSG models. This includes `AssessmentDemographicsComponent`, `AssessmentConfigIodComponent`, `AssessmentDetailComponent`, `CsiServiceDemographicsComponent`, and `CpgPracticesComponent`. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR156-R157) [[2]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6R39) [[3]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR93) [[4]](diffhunk://#diff-07200b9db0ff9ff95bf7dbc05536ceb4765789b37709a3e06df87fb8a7874532R145) [[5]](diffhunk://#diff-b5d187a5fb848ce18216e5ec75b208069c9f7eccb7cf77e3ff0f339753070731L49-R51)
* Removed obsolete or renamed SSG sector change handlers and updated documentation/comments for clarity in Angular components. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cL137-R146) [[2]](diffhunk://#diff-dd23b0a59ba36bc555d40cc0d1a10ad824f83c3fbda277feb40c1f117d280bc8L94-L103)

**Other Improvements**

* Added the `IsAnswerable` property and improved answer handling in maturity structure helpers for more accurate question rendering. [[1]](diffhunk://#diff-bde6188b719379837ffefb9507675ad5b98755a301a726191315171879c0d1f7R198) [[2]](diffhunk://#diff-bde6188b719379837ffefb9507675ad5b98755a301a726191315171879c0d1f7R264-R266) [[3]](diffhunk://#diff-bde6188b719379837ffefb9507675ad5b98755a301a726191315171879c0d1f7R330)
* Improved spacing and markup in the CPG summary report for better readability. [[1]](diffhunk://#diff-518a0b63182b08a46c5ec363b06ef6b54e8aaf382bb27ae3e5b43e8cd97676fdL26-R31) [[2]](diffhunk://#diff-518a0b63182b08a46c5ec363b06ef6b54e8aaf382bb27ae3e5b43e8cd97676fdL53-R61) [[3]](diffhunk://#diff-518a0b63182b08a46c5ec363b06ef6b54e8aaf382bb27ae3e5b43e8cd97676fdL73-R73)
* Minor code cleanup and improved documentation in several frontend components. [[1]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR110-R118) [[2]](diffhunk://#diff-07200b9db0ff9ff95bf7dbc05536ceb4765789b37709a3e06df87fb8a7874532R35) [[3]](diffhunk://#diff-b5d187a5fb848ce18216e5ec75b208069c9f7eccb7cf77e3ff0f339753070731R26) [[4]](diffhunk://#diff-b5d187a5fb848ce18216e5ec75b208069c9f7eccb7cf77e3ff0f339753070731R42) [[5]](diffhunk://#diff-518a0b63182b08a46c5ec363b06ef6b54e8aaf382bb27ae3e5b43e8cd97676fdL26-R31)

These changes collectively modernize the SSG model handling and provide a more robust, maintainable demographic data flow throughout the application.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
