### PR TITLE
i18n: add translations for CRR, IMR, and VADR assessment models

### DIFF
--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -1065,6 +1065,18 @@
     "cis": {
       "model short title": "CIS"
     },
+    "crr": {
+      "display-name": "Cyber Resilience Review (CRR)",
+      "model short title": "CRR"
+    },
+    "imr": {
+      "display-name": "Incident Management Review (IMR)",
+      "model short title": "IMR"
+    },
+    "vadr": {
+      "display-name": "CISA Validated Architecture Design Review (VADR)",
+      "model short title": "VADR"
+    },
     "cisa vadr": {
       "display-name": "CISA Validated Architecture Design Review (VADR)",
       "model short title": "CISA VADR",

--- a/CSETWebNg/src/assets/i18n/es.json
+++ b/CSETWebNg/src/assets/i18n/es.json
@@ -921,6 +921,18 @@
         },
         "cis": {
             "model short title": "CIS"
+        },
+        "crr": {
+            "display-name": "Revisión de Resiliencia Cibernética (CRR)",
+            "model short title": "CRR"
+        },
+        "imr": {
+            "display-name": "Revisión de Gestión de Incidentes (IMR)",
+            "model short title": "IMR"
+        },
+        "vadr": {
+            "display-name": "Revisión de Diseño de Arquitectura Validada de CISA (VADR)",
+            "model short title": "VADR"
         }
     },
     "aggregation": {

--- a/CSETWebNg/src/assets/i18n/jp.json
+++ b/CSETWebNg/src/assets/i18n/jp.json
@@ -530,6 +530,18 @@
     },
     "cis": {
       "model short title": "CIS"
+    },
+    "crr": {
+      "display-name": "サイバーレジリエンスレビュー (CRR)",
+      "model short title": "CRR"
+    },
+    "imr": {
+      "display-name": "インシデント管理レビュー (IMR)",
+      "model short title": "IMR"
+    },
+    "vadr": {
+      "display-name": "CISA検証済みアーキテクチャ設計レビュー (VADR)",
+      "model short title": "VADR"
     }
   }
 }

--- a/CSETWebNg/src/assets/i18n/uk.json
+++ b/CSETWebNg/src/assets/i18n/uk.json
@@ -847,6 +847,18 @@
     },
     "cis": {
       "model short title": "CIS"
+    },
+    "crr": {
+      "display-name": "Огляд кіберстійкості (CRR)",
+      "model short title": "CRR"
+    },
+    "imr": {
+      "display-name": "Огляд управління інцидентами (IMR)",
+      "model short title": "IMR"
+    },
+    "vadr": {
+      "display-name": "Огляд перевіреного архітектурного дизайну CISA (VADR)",
+      "model short title": "VADR"
     }
   },
   "aggregation": {


### PR DESCRIPTION
## Summary
Adds localized display names and short titles for CRR, IMR, and VADR assessment model types to support proper labeling across all supported languages.

## Changes
- Added CRR (Cyber Resilience Review) translations with display name and short title
- Added IMR (Incident Management Review) translations with display name and short title
- Added VADR (Validated Architecture Design Review) translations with display name and short title
- Updated all four language files: English, Spanish, Japanese, and Ukrainian

## Breaking Changes
None

## Test Plan
- [ ] Verify translations appear correctly in the UI when switching languages
- [ ] Check that CRR, IMR, and VADR assessment types display their localized names
- [ ] Test all four languages (en, es, jp, uk) to confirm proper character rendering

## Release Notes
Users will now see properly localized display names for CRR (Cyber Resilience Review), IMR (Incident Management Review), and VADR (Validated Architecture Design Review) assessment models in their selected language.

## Checklist
- [x] Translations added for all supported languages
- [x] Conventional commit format followed