### PR TITLE
Refresh completion bar when sectors are changed

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Export/ExportDemographicsManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Export/ExportDemographicsManager.cs
@@ -67,10 +67,10 @@ namespace CSETWebCore.Business.Demographic.Export
 
             }
 
-            foreach (var item in _context.INFORMATION.Where(x => x.Id == assessmentId))
-            {
-                model.jORG_DETAILS.Add(TinyMapper.Map<INFORMATION, jORG_DETAILS>(item));
-            }
+            //foreach (var item in _context.INFORMATION.Where(x => x.Id == assessmentId))
+            //{
+            //    model.jORG_DETAILS.Add(TinyMapper.Map<INFORMATION, jORG_DETAILS>(item));
+            //}
 
             foreach (var item in _context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == assessmentId))
             {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorChangeResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorChangeResponse.cs
@@ -1,0 +1,20 @@
+﻿//////////////////////////////// 
+// 
+//   Copyright 2025 Battelle Energy Alliance, LLC  
+// 
+// 
+//////////////////////////////// 
+using System.Collections.Generic;
+
+namespace CSETWebCore.Model.Demographic
+{
+    public class SectorChangeResponse
+    {
+        public List<ListItem2> Subsectors { get; set; } = [];
+
+        public int? CompletedCount { get; set; }
+        public int? TotalMaturityQuestionsCount { get; set; }
+        public int? TotalDiagramQuestionsCount { get; set; }
+        public int? TotalStandardQuestionsCount { get; set; }
+    }
+}

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -15,6 +15,7 @@ using CSETWebCore.Interfaces.Demographic;
 using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Demographic;
+using CSETWebCore.Model.Question;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -205,7 +206,7 @@ namespace CSETWebCore.Api.Controllers
         [Route("api/demographics/ext2/sector")]
         public IActionResult PostSector([FromBody] SectorSubsector request)
         {
-            var response = new List<ListItem2>();
+            var response = new SectorChangeResponse();
 
             try
             {
@@ -218,7 +219,17 @@ namespace CSETWebCore.Api.Controllers
                 if (request.SectorId != null)
                 {
                     var mgr = new DemographicExtBusiness(_context);
-                    response = mgr.GetSubsectors((int)request.SectorId);
+                    response.Subsectors = mgr.GetSubsectors((int)request.SectorId);
+                }
+
+
+                CompletionCounts stats = new CompletionCounter(_context).Count(assessmentId);
+                if (stats != null)
+                {
+                    response.CompletedCount = stats.CompletedCount;
+                    response.TotalMaturityQuestionsCount = stats.TotalMaturityQuestionsCount ?? 0;
+                    response.TotalDiagramQuestionsCount = stats.TotalDiagramQuestionsCount ?? 0;
+                    response.TotalStandardQuestionsCount = stats.TotalStandardQuestionsCount ?? 0;
                 }
             }
             catch (Exception exc)
@@ -239,6 +250,8 @@ namespace CSETWebCore.Api.Controllers
         [Route("api/demographics/ext2/sector")]
         public IActionResult DeleteSector([FromQuery] int seq)
         {
+            var response = new SectorChangeResponse();
+
             try
             {
                 int assessmentId = _token.AssessmentForUser();
@@ -246,13 +259,22 @@ namespace CSETWebCore.Api.Controllers
                 var smm = new SectorMultiManager(_context);
                 smm.Delete(assessmentId, seq);
 
+
+                CompletionCounts stats = new CompletionCounter(_context).Count(assessmentId);
+                if (stats != null)
+                {
+                    response.CompletedCount = stats.CompletedCount;
+                    response.TotalMaturityQuestionsCount = stats.TotalMaturityQuestionsCount ?? 0;
+                    response.TotalDiagramQuestionsCount = stats.TotalDiagramQuestionsCount ?? 0;
+                    response.TotalStandardQuestionsCount = stats.TotalStandardQuestionsCount ?? 0;
+                }
             }
             catch (Exception exc)
             {
                 NLog.LogManager.GetCurrentClassLogger().Error($"... {exc}");
             }
 
-            return Ok();
+            return Ok(response);
         }
     }
 }

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
@@ -27,6 +27,8 @@ import { AssessmentService } from '../../../../services/assessment.service';
 import { DemographicsIod } from '../../../../models/demographics-iod.model';
 import { SectorSub } from '../../../../models/demographics-extended.model';
 import { ConstantsService } from '../../../../services/constants.service';
+import { CompletionService } from '../../../../services/completion.service';
+import { SectorChangeResponse } from '../../../../models/questions.model';
 
 
 @Component({
@@ -41,7 +43,7 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
   demographicData: DemographicsIod;
 
   /**
-   * Switch to turn on "multi sector" support.
+   * Switch to turn on "multi sector" support; multiple sector displays, add and delete links, etc.
    */
   @Input()
   multi: boolean = true;
@@ -52,6 +54,7 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
   constructor(
     public assessSvc: AssessmentService,
     public demoSvc: DemographicIodService,
+    public completionSvc: CompletionService,
     private c: ConstantsService
   ) { }
 
@@ -64,6 +67,8 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
    */
   ngOnChanges(changes: SimpleChanges): void {
     this.sectorList = this.demographicData.sectorSubsectors;
+
+    this.demoSvc.demographicUpdateCompleted$.next();
   }
 
   /**
@@ -77,15 +82,16 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
 
 
     // post the sector model to update the back end
-    this.demoSvc.saveSector(item).subscribe(subsectorList => {
-      item.subsectorList = subsectorList;
+    this.demoSvc.saveSector(item).subscribe((response: SectorChangeResponse) => {
+      item.subsectorList = response.subsectors;
 
       if (!item.subsectorList.some(x => x.optionValue == item.subsectorId)) {
         target.subsectorId = null;
       }
 
+      this.refreshCompletion(response);
+    
       this.assessSvc.assessment.sectorSubsectors = [...this.demographicData.sectorSubsectors];
-
 
       this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
     });
@@ -107,7 +113,6 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
     this.demographicData.sectorSubsectors.push(newSectorSubsector);
     this.assessSvc.assessment.sectorSubsectors = [...this.demographicData.sectorSubsectors];
 
-
     this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
   }
 
@@ -115,16 +120,35 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
    * 
    */
   onRemoveSector(evt, item) {
-    this.demoSvc.removeSector(item).subscribe(() => {
+    this.demoSvc.removeSector(item).subscribe((response: SectorChangeResponse) => {
+      
       const idd = this.demographicData.sectorSubsectors.findIndex(i => i.sequence == item.sequence);
       if (idd !== -1) {
         this.demographicData.sectorSubsectors.splice(idd, 1);
       }
 
-      this.assessSvc.assessment.sectorSubsectors = [...this.demographicData.sectorSubsectors];
+      this.refreshCompletion(response);
 
+      this.assessSvc.assessment.sectorSubsectors = [...this.demographicData.sectorSubsectors];
 
       this.assessSvc.assessmentStateChanged$.next(this.c.NAV_REFRESH_TREE_ONLY);
     });
+  }
+
+  /**
+   * refresh the questions counts to drive the progress bar
+   */
+  refreshCompletion(response: SectorChangeResponse) {
+      if (response?.completedCount !== undefined) {
+        const totalCount =
+          (response.totalMaturityQuestionsCount || 0) +
+          (response.totalDiagramQuestionsCount || 0) +
+          (response.totalStandardQuestionsCount || 0);
+          
+        this.assessSvc.completionRefreshRequested$.next({
+          completedCount: response.completedCount,
+          totalCount: totalCount
+        });
+      }
   }
 }

--- a/CSETWebNg/src/app/models/questions.model.ts
+++ b/CSETWebNg/src/app/models/questions.model.ts
@@ -318,6 +318,17 @@ export interface MaturityFilter {
 export interface AnswerQuestionResponse {
     answerId: number;
     detailsChanged: boolean;
+    
+    completedCount?: number;
+    totalMaturityQuestionsCount?: number;
+    totalDiagramQuestionsCount ?: number;
+    totalStandardQuestionsCount ?: number;
+}
+
+
+export interface SectorChangeResponse {
+    subsectors?: [];
+    
     completedCount?: number;
     totalMaturityQuestionsCount?: number;
     totalDiagramQuestionsCount ?: number;

--- a/CSETWebNg/src/app/services/completion.service.ts
+++ b/CSETWebNg/src/app/services/completion.service.ts
@@ -157,7 +157,5 @@ export class CompletionService {
   countAnswers() {
     this.answeredCount = this.questionflat.filter(x => x.answer !== 'U' && x.answer !== '' && x.answer !== null).length;
     this.totalCount = this.questionflat.length;
-
-
   }
 }


### PR DESCRIPTION
This pull request enhances the demographics sector/subsector management by returning additional completion statistics from the backend and updating the UI to reflect these statistics in real time. The changes improve the user experience by keeping progress indicators in sync with sector/subsector modifications and by refactoring the API and frontend to work with a richer response object.

Key changes include:

### Backend: API and Model Enhancements

* Introduced a new `SectorChangeResponse` model that includes subsectors and completion statistics, and updated the `PostSector` and `DeleteSector` endpoints in `DemographicsController` to return this enriched response. [[1]](diffhunk://#diff-8645a56f55b6e93f009d1b87e7a0cf2aebd39a2e069b245b49c63f3beb80321aR1-R20) [[2]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523L208-R209) [[3]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523L221-R232) [[4]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523R253-R277)
* Both endpoints now calculate and include completion counts (completed questions, total maturity, diagram, and standard questions) using the `CompletionCounter`. [[1]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523L221-R232) [[2]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523R253-R277)

### Frontend: Sector/Subsector Component Updates

* Updated `sector-subsector.component.ts` to consume the new `SectorChangeResponse`, updating subsector lists and triggering progress bar refreshes when sectors are added or removed. [[1]](diffhunk://#diff-fc185d09c2fbc48b93416dd92ad0c02c4a913f42ccc6d32260e995cbbbc2af74L80-R94) [[2]](diffhunk://#diff-fc185d09c2fbc48b93416dd92ad0c02c4a913f42ccc6d32260e995cbbbc2af74L110-R153)
* Added a `refreshCompletion` method to recalculate and broadcast completion progress based on the backend response.
* Ensured that the component notifies other parts of the app when demographic data changes, improving UI reactivity.

### Type and Interface Updates

* Defined the `SectorChangeResponse` interface in the frontend models to match the backend, and extended the `AnswerQuestionResponse` interface with completion statistics for consistency.

### Minor Codebase Improvements

* Cleaned up imports and improved comments for clarity and maintainability in the sector/subsector component. [[1]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523R18) [[2]](diffhunk://#diff-fc185d09c2fbc48b93416dd92ad0c02c4a913f42ccc6d32260e995cbbbc2af74L44-R46) [[3]](diffhunk://#diff-fc185d09c2fbc48b93416dd92ad0c02c4a913f42ccc6d32260e995cbbbc2af74R57)
* Removed unused/obsolete code in the backend export logic for demographics.
* Minor whitespace cleanup in the completion service.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
