### PR TITLE
fix(i18n): add missing MVRA translation to all locale files

### DIFF
--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -1091,6 +1091,9 @@
         "desc-high": "This is what you would pick if you are shooting for a high level of maturity"
       },
       "addl observations 1": "Include any other observations that might be helpful in the assessment. They will be included in the report but are not related to any specific question."
+    },
+    "mvra": {
+      "model short title": "MVRA"
     }
   },
   "aggregation": {

--- a/CSETWebNg/src/assets/i18n/es.json
+++ b/CSETWebNg/src/assets/i18n/es.json
@@ -933,6 +933,9 @@
         "vadr": {
             "display-name": "Revisión de Diseño de Arquitectura Validada de CISA (VADR)",
             "model short title": "VADR"
+        },
+        "mvra": {
+            "model short title": "MVRA"
         }
     },
     "aggregation": {

--- a/CSETWebNg/src/assets/i18n/jp.json
+++ b/CSETWebNg/src/assets/i18n/jp.json
@@ -542,6 +542,9 @@
     "vadr": {
       "display-name": "CISA検証済みアーキテクチャ設計レビュー (VADR)",
       "model short title": "VADR"
+    },
+    "mvra": {
+      "model short title": "MVRA"
     }
   }
 }

--- a/CSETWebNg/src/assets/i18n/uk.json
+++ b/CSETWebNg/src/assets/i18n/uk.json
@@ -859,6 +859,9 @@
     "vadr": {
       "display-name": "Огляд перевіреного архітектурного дизайну CISA (VADR)",
       "model short title": "VADR"
+    },
+    "mvra": {
+      "model short title": "MVRA"
     }
   },
   "aggregation": {


### PR DESCRIPTION
## Summary
Adds the missing `mvra` translation entry to all four i18n locale files, eliminating the "Missing translation" console warning for `modules.mvra.model short title` on the My Assessments page.

## Changes
- Added `"mvra": { "model short title": "MVRA" }` to the `modules` section in `en.json`, `es.json`, `jp.json`, and `uk.json`
- Follows the same pattern used by other simple maturity models (e.g., `edm`, `c2m2`, `cis`)

## Breaking Changes
None

## Test Plan
- [ ] Run `npm run start` in `CSETWebNg/` and navigate to the My Assessments page
- [ ] Confirm no "Missing translation" console warning for `modules.mvra.model short title`
- [ ] If an MVRA assessment exists, confirm the short title displays as "MVRA"

## Release Notes
Fixed missing MVRA translation entry in all locale files, removing a console warning on the My Assessments page.

## Checklist
- [x] Conventional commit format followed
- [x] No breaking changes