### PR TITLE
fix(cis): remove duplicate h3 titles from CIS result pages

### DIFF
--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 
 <div class="p-4" *transloco="let t">
-    <h3>{{t('reports.core.cis.deficiencies.title')}}</h3>
-
     <p class="mb-4">
         {{t('reports.core.cis.deficiencies.para 1')}}
     </p>

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
@@ -22,8 +22,6 @@
 -------------------------->
 
 <div class="p-4" *transloco="let t">
-    <h3>CIS Section Scoring</h3>
-
     <p class="mb-4">
         This page displays scoring charts for each CIS section based on your assessment responses.
         If a baseline assessment was selected, baseline scores will also be displayed for comparison.


### PR DESCRIPTION
## Summary
Removes duplicate `<h3>` title headers from the CIS Ranked Deficiency and CIS Section Scoring pages that were rendering the page title twice.

## Changes
- Removed standalone `<h3>` title from `cis-ranked-deficiency-page.component.html`
- Removed standalone `<h3>` title from `cis-section-scoring-page.component.html`

## Breaking Changes
None

## Test Plan
- [ ] Navigate to a CIS assessment's Ranked Deficiency results page and verify only one title is shown
- [ ] Navigate to a CIS assessment's Section Scoring results page and verify only one title is shown
- [ ] Verify page content and layout are otherwise unaffected

## Release Notes
Fixed duplicate page titles appearing on CIS Ranked Deficiency and Section Scoring result pages.

## Checklist
- [x] Conventional commit format followed
- [ ] Tests pass locally
- [ ] No breaking changes