### PR TITLE
fix(module-builder): reseed identity on NEW_QUESTION_SETS before insert

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -514,6 +514,7 @@ namespace CSETWebCore.Business.ModuleBuilder
 
             if (questionSetsToAdd.Count > 0)
             {
+                _context.Database.ExecuteSqlRaw("DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)");
                 _context.NEW_QUESTION_SETS.AddRange(questionSetsToAdd);
                 _context.SaveChanges();
             }
@@ -1031,6 +1032,7 @@ namespace CSETWebCore.Business.ModuleBuilder
                     Set_Name = request.SetName
                 };
 
+                _context.Database.ExecuteSqlRaw("DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)");
                 _context.NEW_QUESTION_SETS.Add(nqs);
                 _context.SaveChanges();
 
@@ -1095,6 +1097,7 @@ namespace CSETWebCore.Business.ModuleBuilder
                     Set_Name = request.SetName
                 };
 
+                _context.Database.ExecuteSqlRaw("DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)");
                 _context.NEW_QUESTION_SETS.Add(existingNqs);
                 _context.SaveChanges();
             }


### PR DESCRIPTION
## Summary
Adds `DBCC CHECKIDENT` reseed calls before inserting into `NEW_QUESTION_SETS` in the Module Builder to prevent identity column conflicts that cause insert failures.

## Changes
- Added `DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)` before `AddRange` in bulk question set addition
- Added `DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)` before single insert in custom question creation
- Added `DBCC CHECKIDENT('NEW_QUESTION_SETS', RESEED)` before insert of existing question in custom question flow

## Breaking Changes
None

## Test Plan
- [ ] Add questions to a set via Module Builder and verify no identity insert errors
- [ ] Add a custom question and verify successful creation
- [ ] Add an existing question to a set and verify successful insertion
- [ ] Verify Module Builder functionality works end-to-end after changes

## Release Notes
Fixed Module Builder insert failures caused by identity column desynchronization on the NEW_QUESTION_SETS table.

## Checklist
- [ ] Tests pass locally (`task test`)
- [ ] Linting passes (`task lint`)
- [ ] Documentation updated (if needed)
- [x] Breaking changes documented
- [x] Conventional commit format followed