### PR TITLE
chore: update copyright year to 2026 across codebase

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/Fixtures/AssessmentTestsFixture.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/Fixtures/AssessmentTestsFixture.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Moq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/Helpers/DbSetMocking.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/Helpers/DbSetMocking.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/StandardsResponseTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Assessment/StandardsResponseTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Assessment;
 
 namespace CSETWebCore.Business.Tests.Assessment

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/AssessmentIO/Import/ImportUpgradeManagerTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/AssessmentIO/Import/ImportUpgradeManagerTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.AssessmentIO.Import;
 using SysVersion = System.Version;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/AssessmentIO/ZipWrapperTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/AssessmentIO/ZipWrapperTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System.Text;
 using ICSharpCode.SharpZipLib.Zip;
 using CSETWebCore.Business.AssessmentIO;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Common/HtmlFromXamlConverterTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Common/HtmlFromXamlConverterTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Common;
 
 namespace CSETWebCore.Business.Tests.Common

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Contact/ContactBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Contact/ContactBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Contact;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Conversion/ConversionBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Conversion/ConversionBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Contact;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Dashboard/DashboardChartBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Dashboard/DashboardChartBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Dashboard;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/DataLayer/CsetwebContextExtensionsTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/DataLayer/CsetwebContextExtensionsTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.DataLayer.Model;
 using Microsoft.EntityFrameworkCore;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/CisaAssessorWorkflowFieldValidatorTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/CisaAssessorWorkflowFieldValidatorTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Demographic;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Demographic;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Demographic;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicExtBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicExtBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Demographic;
 using CSETWebCore.DataLayer.Model;
 using Microsoft.EntityFrameworkCore;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramDifferenceManagerTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramDifferenceManagerTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Diagram;
 using CSETWebCore.DataLayer.Model;
 using Microsoft.EntityFrameworkCore;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramDifferencesTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramDifferencesTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Diagram;
 using CSETWebCore.Business.Diagram.Analysis;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramManagerTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Diagram/DiagramManagerTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Diagram;
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationDataTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationDataTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Observations;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Observations;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Model.Observations;
 
 namespace CSETWebCore.Business.Tests.Observations

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationsManagerTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Observations/ObservationsManagerTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Observations;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Observations;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/CompletionCounterTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/CompletionCounterTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using Microsoft.EntityFrameworkCore;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/ComponentQuestionBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/ComponentQuestionBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/QuestionBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/QuestionBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Common;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/RequirementBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Question/RequirementBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Reports/ReportsDataBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Reports/ReportsDataBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Reports;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/GeneralSalBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/GeneralSalBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistProcessingLogicTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistProcessingLogicTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistQuestionPocoTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistQuestionPocoTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 
 namespace CSETWebCore.Business.Tests.Sal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistSalBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistSalBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistSpecialFactorTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/NistSpecialFactorTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/SalBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Sal/SalBusinessTests.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Sal;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/UnitTest1.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/UnitTest1.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.Business.Tests;
 
 public class UnitTest1

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationCpgBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationCpgBusiness.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Business.Aggregation
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Business.Aggregation
 {
     public class AggregationCpgBusiness
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationMaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationMaturityBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/AnalyticsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/AnalyticsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentTypesBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentTypesBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsRankedCategoriesBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsRankedCategoriesBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsResultsByCategoryBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsResultsByCategoryBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsSummaryBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/ComponentsSummaryBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/MaturityAnswerTotalsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/MaturityAnswerTotalsBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/RankedCategoriesBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/RankedCategoriesBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardSummaryOverallBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardSummaryOverallBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsRankedCategoriesBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsRankedCategoriesBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsResultsByCategoryBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsResultsByCategoryBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsSummaryBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/StandardsSummaryBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter.html
@@ -1,4 +1,26 @@
-﻿
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
 <div class="email-footer" align="center">
     <p class="sub align-center">&copy; 2025 CSET. All rights reserved.</p>
     <p class="sub align-center">

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_ACET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_ACET.html
@@ -1,4 +1,26 @@
-﻿
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
 <div class="email-footer" align="center">
     <p class="sub align-center">&copy; 2025 ACET. All rights reserved.</p>
     <p class="sub align-center">

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_CF.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_CF.html
@@ -1,4 +1,26 @@
-﻿
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
 <div class="email-footer" align="center">
     <p class="sub align-center">&copy; 2025 CSET. All rights reserved.</p>
     <p class="sub align-center">

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_TSA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/EmailFooter_TSA.html
@@ -1,4 +1,26 @@
-﻿
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+
 <div class="email-footer" align="center">
     <p class="sub align-center">&copy; 2025 CSET-TSA. All rights reserved.</p>
     <p class="sub align-center">

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_ACET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_ACET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_CF.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_CF.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_CSET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_CSET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_RRA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_RRA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_TSA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/assessmentInviteTemplate_TSA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/inlineStylesheet.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/inlineStylesheet.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <style type="text/css" rel="stylesheet" media="all">
     /* Base ------------------------------ */
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_ACET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_ACET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_CF.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_CF.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_CSET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_CSET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_RRA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_RRA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_TSA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/invitedPasswordCreationTemplate_TSA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_ACET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_ACET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_CF.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_CF.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_CSET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_CSET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_TSA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordCreationTemplate_TSA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_ACET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_ACET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_CF.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_CF.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_CSET.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_CSET.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_TSA.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/EmailTemplates/passwordResetTemplate_TSA.html
@@ -2,7 +2,7 @@
     PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/ResponseFile/DocumentNotFound.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/ResponseFile/DocumentNotFound.html
@@ -1,4 +1,26 @@
-﻿<!DOCTYPE html>
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/ResponseFile/NoHostDefined.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/App_Data/ResponseFile/NoHostDefined.html
@@ -1,4 +1,26 @@
-﻿<!DOCTYPE html>
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+<!DOCTYPE html>
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentMode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentMode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentNaming.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentNaming.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/StandardsResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/StandardsResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/UserAcknowledge.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/UserAcknowledge.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
 using System.Linq;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/CSETWAssessmentExportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/CSETWAssessmentExportManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Export/JSONAssessmentExportManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/AwwaSheetConfig.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/AwwaSheetConfig.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/BulkSqlUpload.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/BulkSqlUpload.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_0_0_to_09_0_1_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_0_0_to_09_0_1_Upgrade.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_0_1_to_09_2_0_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_0_1_to_09_2_0_Upgrade.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_2_0_to_10_1_1_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_09_2_0_to_10_1_1_Upgrade.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_10_1_1_to_10_2_0_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_10_1_1_to_10_2_0_Upgrade.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_10_2_0_to_12_4_0_4_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_10_2_0_to_12_4_0_4_Upgrade.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_12_4_0_4_to_12_4_0_5_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_12_4_0_4_to_12_4_0_5_Upgrade.cs
@@ -1,7 +1,7 @@
 
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/GenericImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/GenericImporter.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ICSETJSONFileUpgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ICSETJSONFileUpgrade.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManagerACET.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManagerACET.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManagerAwwa.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManagerAwwa.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/Importer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/Importer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/customRules/IImportAssessmentRule.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/customRules/IImportAssessmentRule.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/customRules/SubCategoryLookupRule.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/customRules/SubCategoryLookupRule.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/AllGeneralJsonModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/IUpdateVersion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/IUpdateVersion.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/UploadAssessmentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/AutoGenerated/UploadAssessmentModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/ExportJSON.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/ExportJSON.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 
 namespace CSETWebCore.Business.AssessmentIO.Models
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/AllGeneralJsonModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/UploadAssessmentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_10.1/UploadAssessmentModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0.1/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0.1/AllGeneralJsonModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0.1/UploadAssessmentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0.1/UploadAssessmentModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0/AllGeneralJsonModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0/UploadAssessmentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.0/UploadAssessmentModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.2/AllGeneralJsonModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.2/AllGeneralJsonModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.2/UploadAssessmentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Models/Version_9.2/UploadAssessmentModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/ZipWrapper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/ZipWrapper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Authorization/ApiKeyAuthorize.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Authorization/ApiKeyAuthorize.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Authorization/CsetAuthorize.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Authorization/CsetAuthorize.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Common/HtmlFromXamlConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Common/HtmlFromXamlConverter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Contact/ContactBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Contact/ContactBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Conversion/CFEntry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Conversion/CFEntry.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Conversion/ConversionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Conversion/ConversionBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Dashboard/DashboardChartBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Dashboard/DashboardChartBusiness.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Business.Maturity;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Business.Maturity;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisDemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisDemographicBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisaAssessorWorkflowFieldValidator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisaAssessorWorkflowFieldValidator.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 using CSETWebCore.Model.Assessment;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/DemographicsExportFile.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/DemographicsExportFile.cs
@@ -1,4 +1,10 @@
-﻿
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+
 using System.IO;
 
 namespace CSETWebCore.Business.Demographic.DemographicIO

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Export/DemographicsExportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Export/DemographicsExportManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Import/DemographicsImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Import/DemographicsImportManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Models/DemographicsJsonModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Models/DemographicsJsonModel.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace CSETWebCore.Business.Demographic.DemographicIO.Models

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Models/UploadDemographicsModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Models/UploadDemographicsModel.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/FieldValidation.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/FieldValidation.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Helpers;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Helpers;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorMultiManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorMultiManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/Diagram.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/Diagram.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramDifferenceManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramDifferenceManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramDifferences.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramDifferences.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/DiagramManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/TranslateCsetdToDrawio.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/TranslateCsetdToDrawio.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysis.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysis.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisBaseMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisBaseMessage.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisLineMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisLineMessage.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisNodeMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/DiagramAnalysisNodeMessage.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/FullNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/FullNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/IDiagramAnalysis.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/IDiagramAnalysis.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/IDiagramAnalysisNodeMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/IDiagramAnalysisNodeMessage.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkAnalysisNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkAnalysisNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkComponent.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkComponent.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkGeometry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkGeometry.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkLayer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkLayer.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkLink.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkLink.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkNode.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkZone.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NetworkZone.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NodeNotFound.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NodeNotFound.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NodeViewModelBase.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/NodeViewModelBase.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/SimplifiedNetwork.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/SimplifiedNetwork.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/DrawIOParsingHelps.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/DrawIOParsingHelps.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/ExtractLeafSpanningTree.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/ExtractLeafSpanningTree.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/NetworkWalk.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/NetworkWalk.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/PermutationsGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/PermutationsGenerator.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/PostProcessConnectors.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/helpers/PostProcessConnectors.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/AbstractRule.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/AbstractRule.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/ComponentPairing.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/ComponentPairing.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/IRuleEvaluate.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/IRuleEvaluate.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/MalcolmRules/Rule8.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/MalcolmRules/Rule8.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2023 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/MalcolmRules/Rule9.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/MalcolmRules/Rule9.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2023 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule1.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule1.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule2.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule2.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule3.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule3.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule5.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule5.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule6.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule6.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule7.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/analysis/rules/Rule7.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/layers/LayerManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Diagram/layers/LayerManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Document/DocumentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Document/DocumentBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/FileRepository/FileRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/FileRepository/FileRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Framework/FrameworkBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Framework/FrameworkBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Framework/RankingManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Framework/RankingManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryBoardData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryBoardData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryEditor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryEditor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryItemStateParser.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryItemStateParser.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryLayout.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/GalleryLayout.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/IGalleryEditor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/IGalleryEditor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/IGalleryStateParser.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/GalleryParser/IGalleryStateParser.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Grouping/GroupingBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Grouping/GroupingBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcolmBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcolmBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcolmTree.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcolmTree.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Model.Malcolm;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Model.Malcolm;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcomHttpClient.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Malcolm/MalcomHttpClient.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/C2M2Business.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/C2M2Business.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CieQuestionsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CieQuestionsBusiness.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Nested;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisNavStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisNavStructure.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisQuestionsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisQuestionsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisScoring.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisScoring.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisScoringStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisScoringStructure.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CisStructure.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CmmcBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CmmcBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CpgBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/CpgBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/EdmNistCsfMapping.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/EdmNistCsfMapping.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/GroupScores.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/GroupScores.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
 using System.Collections.Generic;
 using System.Linq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/ModelProfile.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/ModelProfile.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Helpers;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Helpers;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/ModelScoring.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/ModelScoring.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionScopeAnalyzer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionScopeAnalyzer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionTreeXml.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionTreeXml.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleIO/ModuleImporter.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Notification/NotificationBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Notification/NotificationBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ActionItemText.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ActionItemText.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ActionItemsForReport.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ActionItemsForReport.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationsManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationsManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/CompletionCounter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/CompletionCounter.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentTypeSalData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentTypeSalData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/Hooks.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/Hooks.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/IQuestionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/IQuestionBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/InformationTabBuilder.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/InformationTabBuilder.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ParameterContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ParameterContainer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ParameterTextBuilder.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ParameterTextBuilder.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileFunction.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileFunction.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileImportQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileImportQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ProfileQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetails.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetails.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsContentViewModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsContentViewModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionInformationTabData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionInformationTabData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionPoco.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionPoco.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionRequirementManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionRequirementManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/RequirementBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/RequirementBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ReportEngine/DataHandling.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ReportEngine/DataHandling.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ModuleContentReport.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ModuleContentReport.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/MvraSummary.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/MvraSummary.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ObservationsToExcel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ObservationsToExcel.cs
@@ -1,4 +1,10 @@
-﻿using DocumentFormat.OpenXml.Packaging;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
 using DocumentFormat.OpenXml;
 using System.IO;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsUtils.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsUtils.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/RraSummary.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/RraSummary.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/VADRReports.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/VADRReports.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/CSETGlobalProperties.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/CSETGlobalProperties.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/CatalogRecommendationsTopicNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/CatalogRecommendationsTopicNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/FieldNames.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/FieldNames.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/FlowDocManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/FlowDocManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ICSETGlobalProperties.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ICSETGlobalProperties.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/IResourceLibraryRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/IResourceLibraryRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/NoneNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/NoneNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/PDFNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/PDFNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ProcurementLanguageTopicNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ProcurementLanguageTopicNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ReferenceDocumentManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ReferenceDocumentManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ResourceLibraryRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ResourceLibraryRepository.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ResourceNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/ResourceNode.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/SearchDocs.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/SearchDocs.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/TopicNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/TopicNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/XLSXNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/XLSXNode.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/XPSNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/RepositoryLibrary/XPSNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/CsetContextExtensions.GetCombinedOveralls.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/CsetContextExtensions.GetCombinedOveralls.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/RankedQuestionsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/RankedQuestionsBusiness.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/ResultsAnalysisBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Results/ResultsAnalysisBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/GeneralSalBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/GeneralSalBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistProcessingLogic.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistProcessingLogic.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistQuestionPoco.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistQuestionPoco.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistSalBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistSalBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistSpecialFactor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/NistSpecialFactor.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/SalBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Sal/SalBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardSpecficLevelRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardSpecficLevelRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Standards/StandardsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/User/UserBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/User/UserBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Version/VersionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Version/VersionBusiness.cs
@@ -1,4 +1,10 @@
-﻿using System.Linq;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Linq;
 using System.Reflection;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Version;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/Constants.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/Constants.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/StandardConstants.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Constants/StandardConstants.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/ByteBuffer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/ByteBuffer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/ColumnSetEncryption.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/ColumnSetEncryption.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/CryptoCommon.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/CryptoCommon.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/DecryptionBuffer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/DecryptionBuffer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/EncryptionBuffer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/EncryptionBuffer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/Id_StringPair.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.CryptoBuffer/Id_StringPair.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Attributes/LifecycleSingletonAttribute.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Attributes/LifecycleSingletonAttribute.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Attributes/LifecycleTransientAttribute.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Attributes/LifecycleTransientAttribute.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/ANSWER.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/ANSWER.cs
@@ -1,4 +1,10 @@
-﻿using System.Linq;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Linq;
 
 namespace CSETWebCore.DataLayer.Model
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsStandardMinMaxAvg.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsStandardMinMaxAvg.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.DataLayer.Manual
 {
     public class AnalyticsStandardMinMaxAvg

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsgetMedianOverall.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsgetMedianOverall.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.DataLayer.Manual
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.DataLayer.Manual
 {
     public class AnalyticsgetMedianOverall
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsgetMinMaxAverForSectorIndustryGroup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/AnalyticsgetMinMaxAverForSectorIndustryGroup.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.DataLayer.Manual
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.DataLayer.Manual
 {
     public class AnalyticsgetMinMaxAverForSectorIndustryGroup
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components_Base.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components_Base.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace CSETWebCore.DataLayer.Model

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components_Exploded_ForJSON.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Components_Exploded_ForJSON.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 
 namespace CSETWebCore.DataLayer.Model
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Questions.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Questions.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Questions_No_Components.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Questions_No_Components.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Requirements.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Requirements.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Standards_InScope.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/Answer_Standards_InScope.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace CSETWebCore.DataLayer.Model

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CSETContext.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CsetVersionResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CsetVersionResponse.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.DataLayer.Model
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.DataLayer.Model
 {
     /// <summary>
     /// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CsetWebContext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/CsetWebContext.cs
@@ -1,4 +1,10 @@
-﻿#nullable disable
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+#nullable disable
 using Microsoft.EntityFrameworkCore;
 
 namespace CSETWebCore.DataLayer.Model;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/DOCUMENT_FILE.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/DOCUMENT_FILE.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 using System.Linq;
 
 namespace CSETWebCore.DataLayer.Model

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/FeedbackDisplayContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/FeedbackDisplayContainer.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.DataLayer.Model
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.DataLayer.Model
 {
     public partial class FeedbackDisplayContainer
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/ID_result.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/ID_result.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/NEW_QUESTION_Ext.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/NEW_QUESTION_Ext.cs
@@ -1,4 +1,10 @@
-﻿using System.Linq;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 
 namespace CSETWebCore.DataLayer.Model

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/NEW_REQUIREMENT.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/NEW_REQUIREMENT.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using Microsoft.EntityFrameworkCore;
 using System.Linq;
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/RawCountsForEachAssessment_Standards.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/RawCountsForEachAssessment_Standards.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/RraStoredProcModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/RraStoredProcModels.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 
 namespace CSETWebCore.DataLayer.Manual
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/SetStandard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/SetStandard.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.DataLayer.Manual
 {
     public class SetStandard

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/standardAnalyticsgetMedianOverall.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/standardAnalyticsgetMedianOverall.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.DataLayer.Manual
 {
     public class standardAnalyticsgetMedianOverall

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_Assessments_For_UserResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_Assessments_For_UserResult.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.DataLayer.Model
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.DataLayer.Model
 {
     public partial class usp_Assessments_For_UserResult
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_GetRankedQuestions_Result.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_GetRankedQuestions_Result.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.DataLayer.Model
 {
     using System;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_GetTop5Areas_result.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_GetTop5Areas_result.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2019 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_getExplodedComponent.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/usp_getExplodedComponent.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 using System.ComponentModel.DataAnnotations;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vParameter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vParameter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vQUESTION_HEADINGS.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vQUESTION_HEADINGS.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vadrStoredProcModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Manual/vadrStoredProcModels.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.DataLayer.Manual

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContextExtensions.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/CsetwebContextExtensions.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 // Replacement implementations for low-complexity stored procedures
 using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/TSAModelNames.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/TSAModelNames.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 #nullable enable
 namespace CSETWebCore.DataLayer.Model
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileDescription.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileDescription.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileDescriptionShort.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileDescriptionShort.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/ModelDataAccess/FileResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DatabaseSetupException.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DatabaseSetupException.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DbManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/DbManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/InitialDbInfo.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DatabaseManager/InitialDbInfo.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/AnswerEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/AnswerEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ContactRole.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ContactRole.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/EnumHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/EnumHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/StringAttr.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/StringAttr.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/StringToEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/EnumHelper/StringToEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/MaturityModelEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/MaturityModelEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/QuestionPocoTypeEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/QuestionPocoTypeEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ResourceNodeType.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ResourceNodeType.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ResourceTypeEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ResourceTypeEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/SalValues.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/SalValues.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ScoreStatus.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/ScoreStatus.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/StandardModeEnum.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Enum/StandardModeEnum.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDataMappings.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDataMappings.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDiagramMappings.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDiagramMappings.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CSETtoExcelDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CreateExcelFile.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/CreateExcelFile.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/DataMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/DataMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/ExcelExporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.ExportCSV/ExcelExporter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AdditionalSupplemental.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AdditionalSupplemental.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Question;
 using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AnswerDistribution.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AnswerDistribution.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ApiKeyManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ApiKeyManager.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Interfaces.Helpers;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Interfaces.Helpers;
 using Microsoft.Extensions.Configuration;
 
 namespace CSETWebCore.Helpers

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AssessmentModeData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AssessmentModeData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AssessmentUtil.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/AssessmentUtil.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/BuildNumberHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/BuildNumberHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CSETDataPatches.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CSETDataPatches.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CmuScoringHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CmuScoringHelper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ConsoleLogger.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ConsoleLogger.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ConverterResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ConverterResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CpgStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CpgStructure.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CustomJsonWriter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/CustomJsonWriter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/DBIO.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/DBIO.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/DocumentImporter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/DocumentImporter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/EDMScoring.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/EDMScoring.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/FileStreamingHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/FileStreamingHelper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/IOHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/IOHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LastAnsweredHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LastAnsweredHelper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LevelManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LevelManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LocalInstallationHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/LocalInstallationHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureAsXml.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureAsXml.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureForModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MaturityStructureForModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MultipartRequestHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/MultipartRequestHelper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ObjectTypePair.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ObjectTypePair.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ParameterSubstitution.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ParameterSubstitution.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PasswordExpiration.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PasswordExpiration.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PasswordHash.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PasswordHash.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PercentageFixer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/PercentageFixer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/QuestionAnswerBuilder.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/QuestionAnswerBuilder.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Question;
 using System.Linq;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReferenceConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReferenceConverter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReferencesBuilder.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReferencesBuilder.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/BarChartInput.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/BarChartInput.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/BlockLegend.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/BlockLegend.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/CsfHeatmap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/CsfHeatmap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/GoalsHeatMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/GoalsHeatMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/Mil1PerformanceLegend.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/Mil1PerformanceLegend.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/MilHeatMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/MilHeatMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/NistDomainBlock.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/NistDomainBlock.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/PerformanceSummaryLegend.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/PerformanceSummaryLegend.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/QuestionsHeatMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/QuestionsHeatMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreBarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreBarChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreStackedBarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/ScoreStackedBarChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/SprsScoreGauge.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/SprsScoreGauge.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/WidgetResources.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ReportWidgets/WidgetResources.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/RequirementConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/RequirementConverter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ResourceHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ResourceHelper.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/SalCompare.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/SalCompare.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StandardConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StandardConverter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StatUtils.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StatUtils.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StringExt.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StringExt.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StringNumericComparer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/StringNumericComparer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/SupplementalGuidanceUtils.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/SupplementalGuidanceUtils.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TokenManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TokenManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TransactionSecurity.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TransactionSecurity.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TranslationOverlay.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TranslationOverlay.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Model.Question;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TrendDataProcessor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/TrendDataProcessor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UniqueIdGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UniqueIdGenerator.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAccountSecurityManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAccountSecurityManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthentication.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthenticationAzure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/UserAuthenticationAzure.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Authentication;
 using System.Linq;
 //using Microsoft.AspNetCore.Authentication.OpenIdConnect;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/Utilities.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/Utilities.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Aggregation/IAggregationBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Aggregation/IAggregationBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Analytics/IAnalyticsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Analytics/IAnalyticsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Assessment/IAssessmentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Assessment/IAssessmentBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 /////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Assessment/ICreateAssessmentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Assessment/ICreateAssessmentBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalRequirement.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalRequirement.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalResource.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalResource.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalStandard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IExternalStandard.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/AssessmentIO/IImportManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Cmu/ICmuScoringHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Cmu/ICmuScoringHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Common/IHtmlFromXamlConverter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Common/IHtmlFromXamlConverter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Contact/IContactBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Contact/IContactBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Dashboard/IDashboardBussiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Dashboard/IDashboardBussiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/DemographicIO/IDemographicImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/DemographicIO/IDemographicImportManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/GetName.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/GetName.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/ICisDemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/ICisDemographicBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/IDemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Demographic/IDemographicBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Diagram/IDiagramManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Diagram/IDiagramManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Document/IDocumentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Document/IDocumentBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/FileRepository/IFileRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/FileRepository/IFileRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Framework/IFrameworkBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Framework/IFrameworkBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IApiKeyManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IApiKeyManager.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IAssessmentModeData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IAssessmentModeData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IAssessmentUtil.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IAssessmentUtil.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ILocalInstallationHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ILocalInstallationHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IPasswordHash.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IPasswordHash.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IResourceHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IResourceHelper.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ITokenManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ITokenManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ITrendDataProcessor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/ITrendDataProcessor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IUserAuthentication.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IUserAuthentication.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IUtilities.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Helpers/IUtilities.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ILogger.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ILogger.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Malcolm/IMalcolmBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Malcolm/IMalcolmBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Maturity/ICisQuestionsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Maturity/ICisQuestionsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Maturity/IMaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Maturity/IMaturityBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ModuleBuilder/IModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ModuleBuilder/IModuleBuilderBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Notification/INotificationBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Notification/INotificationBusiness.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IParameterContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IParameterContainer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IQuestionPoco.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IQuestionPoco.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IQuestionRequirementManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IQuestionRequirementManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IRequirementBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Question/IRequirementBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ReportEngine/IDataHandling.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ReportEngine/IDataHandling.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Reports/IReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Reports/IReportsDataBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ResourceLibrary/IFlowDocManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/ResourceLibrary/IFlowDocManager.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Sal/ISalBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Sal/ISalBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Standards/IStandardSpecficLevelRepository.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Standards/IStandardSpecficLevelRepository.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Standards/IStandardsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Standards/IStandardsBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/User/IUserBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/User/IUserBusiness.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Version/IVersionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Interfaces/Version/IVersionBusiness.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 
 namespace CSETWebCore.Interfaces.Version
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AggregAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AggregAssessment.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/Aggregation.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/Aggregation.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AliasSaveRequest.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AliasSaveRequest.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AnswerCounts.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AnswerCounts.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentListResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentListResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentSelection.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentSelection.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentStandardGrid.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/AssessmentStandardGrid.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/BestToWorstCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/BestToWorstCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/ChartDataSet.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/ChartDataSet.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/GetComparisonBestToWorst.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/GetComparisonBestToWorst.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/HorizBarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/HorizBarChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/LineChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/LineChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeAnswer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeAnswer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeStructure.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MergeStructure.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MissedQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MissedQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MissedQuestionResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/MissedQuestionResponse.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Aggregation
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/PieChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/PieChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/SalComparison.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/SalComparison.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/SelectedStandards.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/SelectedStandards.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/StandardsCategoryResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/StandardsCategoryResult.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/analytics_getMinMaxAverageForSectorIndustryGroup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/analytics_getMinMaxAverageForSectorIndustryGroup.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/usp_getComponentsSummmary.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Aggregation/usp_getComponentsSummmary.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ChartData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ChartData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ComponentCategoryResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ComponentCategoryResult.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ComponentsRankedCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/ComponentsRankedCategory.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/DataRows.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/DataRows.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/DataRowsPie.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/DataRowsPie.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/FirstPage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/FirstPage.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/FirstPageMultiResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/FirstPageMultiResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/GetCombinedOveralls.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/GetCombinedOveralls.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/MultiResultBase.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/MultiResultBase.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/RankedCategories.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/RankedCategories.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/StandardsRankedCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/StandardsRankedCategory.cs
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/usp_getComponentTypes.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analysis/usp_getComponentTypes.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgAnswer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgAnswer.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.Model.Analytics;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgAssessment.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.Model.Analytics;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgDemographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgDemographics.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.Model.Analytics;
 
 public class AgDemographics

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgDocuments.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgDocuments.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.Model.Analytics;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgFinding.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/AgFinding.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.Model.Analytics;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/SectorsAndSamples.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Analytics/SectorsAndSamples.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AggregationAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AggregationAssessment.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Analytics;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AnalyticsAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AnalyticsAssessment.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AssessmentDetail.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/AssessmentDetail.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisOrganizationDemographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisOrganizationDemographics.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisServiceComposition.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisServiceComposition.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisServiceDemographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/CisServiceDemographics.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/GalleryConfig.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/GalleryConfig.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/StartAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/StartAssessment.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/AssessmentExportFile.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/AssessmentExportFile.cs
@@ -1,4 +1,10 @@
-﻿using System.IO;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.IO;
 
 namespace CSETWebCore.Model.AssessmentIO
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/AssessmentExportFileJSON.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/AssessmentExportFileJSON.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.Model.AssessmentIO
 {
     public class AssessmentExportFileJson

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalRequirement.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalRequirement.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalResource.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalResource.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalStandard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/ExternalStandard.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/PropertyHelpers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/PropertyHelpers.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/StandardSchemaProcessor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/AssessmentIO/StandardSchemaProcessor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Auth/PasswordResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Auth/PasswordResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Auth/TokenResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Auth/TokenResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Authentication/Login.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Authentication/Login.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Authentication/LoginResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Authentication/LoginResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Donuts.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Donuts.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Heatmap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Heatmap.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Tables.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/C2M2/Tables.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.C2M2.Tables
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Charting/ChartJs.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Charting/ChartJs.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cis/CisModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cis/CisModels.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/CisaAssessorWorkflow/CisaWorkflowFieldValidationResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/CisaAssessorWorkflow/CisaWorkflowFieldValidationResponse.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.CisaAssessorWorkflow
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cmu/CmuReportChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cmu/CmuReportChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cmu/CmuResultsModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cmu/CmuResultsModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/Bookmark.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/Bookmark.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Contact
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Contact
 {
     public class BookmarkRequest
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactAddParameters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactAddParameters.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactCreateParameters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactCreateParameters.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactDetail.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactDetail.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactInviteParameters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactInviteParameters.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactRemoveParameters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactRemoveParameters.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactSearchParameters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactSearchParameters.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactSearchResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactSearchResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactsListResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/ContactsListResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/UserLanguage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Contact/UserLanguage.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Contact
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Contact
 {
     public class UserLanguage
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/AssessmentData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/AssessmentData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/BarChart.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/BarChart.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/BarChartGrouping.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/BarChartGrouping.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Dashboard.BarCharts
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/CategoryStatistics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/CategoryStatistics.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/ChartDataTSA.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/ChartDataTSA.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardChartData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardChartData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardGraphData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardGraphData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardViewModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DashboardViewModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DataRows.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DataRows.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DataRowsAnalytics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/DataRowsAnalytics.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/MedianScatterPlot.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/MedianScatterPlot.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/SectorIndustryVM.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/SectorIndustryVM.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/TreeView.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Dashboard/TreeView.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/AssessmentSize.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/AssessmentSize.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DemographicAssetValue.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DemographicAssetValue.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DemographicExt.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DemographicExt.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DetailsDemographicsOptionsDTO.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/DetailsDemographicsOptionsDTO.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/ExtendedDemographic.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/ExtendedDemographic.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/Industry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/Industry.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/Sector.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/Sector.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorChangeResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorChangeResponse.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorSubsector.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/SectorSubsector.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 
 namespace CSETWebCore.Model.Demographic

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/StateAndProvince.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Demographic/StateAndProvince.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkObject.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkObject.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkProduct.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkProduct.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkVendor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/CommonSecurityAdvisoryFrameworkVendor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentName.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentName.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentNameMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentNameMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentSymbol.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentSymbol.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentSymbolGroup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/ComponentSymbolGroup.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramRequest.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramRequest.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramTemplate.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramTemplate.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramZones.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/DiagramZones.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/LayerVisibility.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/LayerVisibility.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRoot.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRoot.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCell.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCell.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCellMxGeometry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCellMxGeometry.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCellMxGeometryMxPoint.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootMxCellMxGeometryMxPoint.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObject.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObject.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObjectMxCell.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObjectMxCell.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObjectMxCellMxGeometry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Diagram/mxGraphModelRootObjectMxCellMxGeometry.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/Document.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/Document.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/DocumentWithAnswerId.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/DocumentWithAnswerId.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Document
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Document
 {
     public class DocumentWithAnswerId
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/DocumentsForMerge.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/DocumentsForMerge.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Document
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/FileUploadResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/FileUploadResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/FileUploadStreamResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/FileUploadStreamResult.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/MergeDocuments.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/MergeDocuments.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Document
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/QuestionDocumentsPair.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Document/QuestionDocumentsPair.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Document
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EDMscore.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EDMscore.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmAggregate.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmAggregate.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmAppendixResults.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmAppendixResults.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmScoreParent.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/EdmScoreParent.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/LeafNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/LeafNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/MidlevelScoreNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/MidlevelScoreNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/ScoringNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/ScoringNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/TopLevelScoreNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Edm/TopLevelScoreNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ExportJson/ExportJson.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 ////////////////////////////////

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkTier.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkTier.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkTierType.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/FrameworkTierType.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/TierSelection.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Framework/TierSelection.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Gallery/FavoriteRequest.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Gallery/FavoriteRequest.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using System;
 
 namespace CSETWebCore.Model.Gallery;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Gallery/GalleryItems.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Gallery/GalleryItems.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Buckets.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Buckets.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Filters.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Filters.cs
@@ -1,4 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Malcolm

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/MalcolmData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/MalcolmData.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Malcolm
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/TempNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/TempNode.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 using System.Text;
 
 namespace CSETWebCore.Model.Malcolm

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/ValuePairs.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/ValuePairs.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Malcolm
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/ValuePairs2.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/ValuePairs2.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Malcolm
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Malcolm
 {
     public class ValuePairs2
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Values.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Malcolm/Values.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Malcolm
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/AnswerColorDistrib.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/AnswerColorDistrib.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/AnswerDistribItem.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/AnswerDistribItem.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CPG/AnswerDistribDomain.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CPG/AnswerDistribDomain.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CPG/ContentModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CPG/ContentModel.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Model.Question;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Model.Question;
 using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Maturity.CPG

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CmmcScoreModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CmmcScoreModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CmmcScores.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/CmmcScores.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Maturity
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Maturity
 {
     public class CmmcScores
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/GlossaryEntry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/GlossaryEntry.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/GroupingTitle.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/GroupingTitle.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MatRelevantAnswers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MatRelevantAnswers.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityAssessment.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityComponent.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityComponent.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDetailsCalculations.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDetailsCalculations.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Maturity
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Maturity
 {
     public class MaturityDetailsCalculations
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDomain.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDomain.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDomainRemarks.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityDomainRemarks.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityGrouping.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityGrouping.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityLevel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityLevel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityMap.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityMap.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityModel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/MaturityResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/QuestionReferences.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/QuestionReferences.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/StructureOptions.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/StructureOptions.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Maturity
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Maturity
 {
     public class StructureOptions
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Module/EnabledModule.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Module/EnabledModule.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/CapabilityScore.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/CapabilityScore.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/DomainScore.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/DomainScore.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/FunctionScore.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/FunctionScore.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/LevelScore.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Mvra/LevelScore.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/ActionItems.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/ActionItems.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/Importance.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/Importance.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/MergeObservation.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/MergeObservation.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Observations

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/Observation.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/Observation.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/ObservationContact.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Observations/ObservationContact.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Password/Password.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Password/Password.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/AnalyticsQuestionAnswer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/AnalyticsQuestionAnswer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/Answer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/Answer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/AnswerQuestionResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/AnswerQuestionResponse.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/BaseQuestionInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/BaseQuestionInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CategoryContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CategoryContainer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ChildQuestionAnswers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ChildQuestionAnswers.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ColorsList.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ColorsList.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CommentData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CommentData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CompletionCounts.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CompletionCounts.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ComponentOverrideLinkInfo.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ComponentOverrideLinkInfo.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CsfMapping.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CsfMapping.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Question
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Question
 {
     public class CsfMapping
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CustomDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/CustomDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/Domain.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/Domain.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/DomainAssessmentFactor.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/DomainAssessmentFactor.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FeedbackQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FeedbackQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FrameworkInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FrameworkInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FrameworkQuestionItem.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FrameworkQuestionItem.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FullAnswer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/FullAnswer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/MaturityQuestionInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/MaturityQuestionInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterAssessment.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterAssessment.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterToken.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterToken.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterValues.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/ParameterValues.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionAnswer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionAnswer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionGroup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionGroup.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionPlusHeaders.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionPlusHeaders.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionProp.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionProp.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionRequirementCounts.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionRequirementCounts.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionSubCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/QuestionSubCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RelatedQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RelatedQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RelatedQuestionInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RelatedQuestionInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementInfoData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementInfoData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementLevel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementLevel.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementPlus.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementPlus.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementTabData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementTabData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementsPass.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/RequirementsPass.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/SubCategoryAnswers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/SubCategoryAnswers.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/SubCategoryAnswersPlus.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/SubCategoryAnswersPlus.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/TTPReference.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/TTPReference.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Question
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Question
 {
     public class TTPReference
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/TranslationOverlayModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Question/TranslationOverlayModels.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.Model.Question
 {
     /// <summary>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/AggInformation.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/AggInformation.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/AggregationReportData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/AggregationReportData.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/BasicReportData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/BasicReportData.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ControlRow.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ControlRow.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/DocumentsReport.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/DocumentsReport.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Model.Document;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Model.Document;
 using System.Collections.Generic;
 
 namespace CSETWebCore.Model.Reports

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityBasicReportData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityBasicReportData.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityReportData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityReportData.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityReportDetailData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/MaturityReportDetailData.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ObservationIngredients.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ObservationIngredients.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 
 namespace CSETWebCore.Model.Reports
 {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/PdfString.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/PdfString.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/QuestionsReviewed.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/QuestionsReviewed.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Model.Reports
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Model.Reports
 {
     class QuestionsReviewed
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ReportVM.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/ReportVM.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/StandardQuestions.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Reports/StandardQuestions.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/ReferenceFileResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/ReferenceFileResponse.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/SearchRequest.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/SearchRequest.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/SimpleNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/ResourceLibrary/SimpleNode.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GenSalPairs.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GenSalPairs.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GenSalWeights.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GenSalWeights.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GeneralSalDescriptionsWeights.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/GeneralSalDescriptionsWeights.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/SalAnswers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/SalAnswers.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/Sals.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/Sals.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/SaveWeight.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Sal/SaveWeight.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/AddQuestionsRequest.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/AddQuestionsRequest.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/BasicResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/BasicResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/CategoriesSubcategoriesGroupHeadings.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/CategoriesSubcategoriesGroupHeadings.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/CategoryEntry.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/CategoryEntry.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/HeadingUpdateParms.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/HeadingUpdateParms.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ModuleResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ModuleResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionAdd.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionAdd.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionDetail.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionDetail.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListSubcategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionListSubcategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionSearch.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionSearch.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionTextUpdateParms.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/QuestionTextUpdateParms.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ReferenceDoc.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ReferenceDoc.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ReferenceDocLists.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/ReferenceDocLists.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/Requirement.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/Requirement.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/RequirementListCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/RequirementListCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/RequirementListSubcategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/RequirementListSubcategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SalParms.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SalParms.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetDetail.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetDetail.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetFileSelection.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetFileSelection.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetListResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetListResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetQuestion.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/SetQuestion.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/Supplemental.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Set/Supplemental.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/QuestionGroupHeadingSimple.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/QuestionGroupHeadingSimple.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/Standard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/Standard.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/StandardCategory.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/StandardCategory.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/StandardsResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Standards/StandardsResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/CreateUser.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/CreateUser.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserCreateResponse.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserCreateResponse.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserDetail.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserDetail.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserRole.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/User/UserRole.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 namespace CSETWebCore.Api.Models
 {
     public class UserRole

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.UpgradeLibrary/VersionHandler.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.UpgradeLibrary/VersionHandler.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationAnalysisController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationAnalysisController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationMaturityController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AggregationMaturityController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalysisController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalysisController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalyticsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalyticsController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalyticsDashboardController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AnalyticsDashboardController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AngularConfigController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AngularConfigController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentExportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentExportController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentImportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AssessmentImportController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AuthController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/AuthController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CRRMController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CRRMController.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using Microsoft.AspNetCore.Mvc;
 using CSETWebCore.Business.Authorization;
 using CSETWebCore.Business.AssessmentIO.Export;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CisCriticalServiceInformationController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CisCriticalServiceInformationController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CmmcController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CmmcController.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using CSETWebCore.Business.Authorization;
 using CSETWebCore.Business.Maturity;
 using CSETWebCore.DataLayer.Model;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CmuController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CmuController.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Assessment;
 using CSETWebCore.Interfaces.Demographic;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ContactsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ContactsController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ConversionController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ConversionController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CreController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/CreController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DHSEmailController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DHSEmailController.cs
@@ -1,3 +1,9 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DashboardController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DashboardController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsExportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsExportController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsImportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsImportController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DiagnosticController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DiagnosticController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DiagramController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DiagramController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/EdmController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/EdmController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ExcelExportController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ExcelExportController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FileDownloadController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FileDownloadController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FileUploadController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FileUploadController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FrameworkController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/FrameworkController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GalleryEditorController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GalleryEditorController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GalleryStateController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GalleryStateController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GeneralSalController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GeneralSalController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GroupingController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GroupingController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GuidController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/GuidController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/HeatmapController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/HeatmapController.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Business.Maturity;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Business.Maturity;
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MalcolmController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MalcolmController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityC2M2Controller.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityC2M2Controller.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityCpgController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/MaturityCpgController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ModuleBuilderController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ModuleBuilderController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ObservationsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ObservationsController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ProtectedFeatureController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ProtectedFeatureController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmmcController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmmcController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmuController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmuController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ResetPasswordController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ResetPasswordController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ResourceLibraryController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ResourceLibraryController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/RootDiagramContainer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/RootDiagramContainer.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SalController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SalController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SchemaController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SchemaController.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SetsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/SetsController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/StandardsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/StandardsController.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/UserController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/UserController.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using CSETWebCore.Api.Models;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/VersionController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/VersionController.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using System;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Version;
 using Microsoft.AspNetCore.Mvc;

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/clear.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/clear.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/dropbox.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/dropbox.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/export3.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/export3.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/github.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/github.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/gitlab.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/gitlab.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/index.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/index.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=5" ><![endif]-->
 <!DOCTYPE html>
 <html>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/onedrive3.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/onedrive3.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 	<head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/open.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/open.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/teams.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/teams.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=5" ><![endif]-->
 <!DOCTYPE html>
 <html>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/vsdxImporter.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/src/main/webapp/vsdxImporter.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <!DOCTYPE html>
 <html>
 <head>

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/teams.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Diagram/teams.html
@@ -1,1 +1,23 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 dummy

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Documents/ApplicationDocuments/FIPS199Language.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Documents/ApplicationDocuments/FIPS199Language.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/ErrorDetails.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/ErrorDetails.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/ExceptionMiddlewareExtensions.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/ExceptionMiddlewareExtensions.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/MalcolmUploadError.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Error/MalcolmUploadError.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/FileUploadStream.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/FileUploadStream.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/PropertyHelpers.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/PropertyHelpers.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/ValidateMimeMultipartContentFilter.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Helpers/ValidateMimeMultipartContentFilter.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalRequirement.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalRequirement.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalResource.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalResource.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalStandard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/IExternalStandard.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/ILogger.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Interfaces/ILogger.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/CmuVM.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/CmuVM.cs
@@ -1,6 +1,6 @@
 ﻿//////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ConsoleLogger.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ConsoleLogger.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/CrrVM.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/CrrVM.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalDocument.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalDocument.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalRequirement.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalRequirement.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalResource.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalResource.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalStandard.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ExternalStandard.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ResponseMessage.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/ResponseMessage.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Api.Models
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Api.Models
 {
     public class ResponseMessage
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/UserAdmin.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Models/UserAdmin.cs
@@ -1,4 +1,10 @@
-﻿namespace CSETWebCore.Api.Models
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+namespace CSETWebCore.Api.Models
 {
     public class UserAdmin
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Program.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Startup.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Startup.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/WebApp/Holder.html
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/WebApp/Holder.html
@@ -1,4 +1,26 @@
-﻿<!DOCTYPE html>
+﻿<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />

--- a/CSETWebApi/CSETWeb_Api/DuplicateAssessments/AssessmentsDuplicator.cs
+++ b/CSETWebApi/CSETWeb_Api/DuplicateAssessments/AssessmentsDuplicator.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Business.AssessmentIO.Export;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Business.AssessmentIO.Export;
 using CSETWebCore.Business.AssessmentIO.Import;
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;

--- a/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockLocalInstallationHelper.cs
+++ b/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockLocalInstallationHelper.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.DataLayer.Model;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;
 
 namespace DuplicateAssessments

--- a/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockTokenManager.cs
+++ b/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockTokenManager.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Constants;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Constants;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Helpers;
 using CSETWebCore.Interfaces.Helpers;

--- a/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockUtilities.cs
+++ b/CSETWebApi/CSETWeb_Api/DuplicateAssessments/MockUtilities.cs
@@ -1,4 +1,10 @@
-﻿using CSETWebCore.Interfaces.Helpers;
+﻿////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Interfaces.Helpers;
 
 namespace DuplicateAssessments
 {

--- a/CSETWebApi/CSETWeb_Api/ProcViewSerializer/DBIO.cs
+++ b/CSETWebApi/CSETWeb_Api/ProcViewSerializer/DBIO.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Program.cs
+++ b/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Program.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Properties/AssemblyInfo.cs
+++ b/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Serializer.cs
+++ b/CSETWebApi/CSETWeb_Api/ProcViewSerializer/Serializer.cs
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 // 
 //////////////////////////////// 

--- a/CSETWebNg/src/app/aggregation/aggregation-detail/aggregation-detail.component.html
+++ b/CSETWebNg/src/app/aggregation/aggregation-detail/aggregation-detail.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/aggregation-detail/aggregation-detail.component.ts
+++ b/CSETWebNg/src/app/aggregation/aggregation-detail/aggregation-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/aggregation-home/aggregation-home.component.html
+++ b/CSETWebNg/src/app/aggregation/aggregation-home/aggregation-home.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/aggregation-home/aggregation-home.component.ts
+++ b/CSETWebNg/src/app/aggregation/aggregation-home/aggregation-home.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.html
+++ b/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.ts
+++ b/CSETWebNg/src/app/aggregation/alias-assessments/alias-assessments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-bestworst/compare-bestworst.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-bestworst/compare-bestworst.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-bestworst/compare-bestworst.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-bestworst/compare-bestworst.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-individual/compare-individual.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-individual/compare-individual.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-individual/compare-individual.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-individual/compare-individual.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-missed/compare-missed.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-missed/compare-missed.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-missed/compare-missed.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/maturity-based/compare-missed/compare-missed.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-bestworst/compare-bestworst.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-bestworst/compare-bestworst.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-bestworst/compare-bestworst.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-bestworst/compare-bestworst.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-individual/compare-individual.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-individual/compare-individual.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-individual/compare-individual.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-individual/compare-individual.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-missed/compare-missed.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-missed/compare-missed.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-missed/compare-missed.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-missed/compare-missed.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-summary/compare-summary.component.html
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-summary/compare-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-summary/compare-summary.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/standards-based/compare-summary/compare-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/merge/merge.component.html
+++ b/CSETWebNg/src/app/aggregation/merge/merge.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/merge/merge.component.ts
+++ b/CSETWebNg/src/app/aggregation/merge/merge.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.html
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 250px"
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-compare-compatibility/trend-compare-compatibility.component.html
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-compare-compatibility/trend-compare-compatibility.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-compare-compatibility/trend-compare-compatibility.component.ts
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-compare-compatibility/trend-compare-compatibility.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/app.component.html
+++ b/CSETWebNg/src/app/app.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/app.component.ts
+++ b/CSETWebNg/src/app/app.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/app.module.ts
+++ b/CSETWebNg/src/app/app.module.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/assessment.component.ts
+++ b/CSETWebNg/src/app/assessment/assessment.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-info/diagram-info.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/components/diagram-components.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/diagram-inventory.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/links/links.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/network-warnings/network-warnings.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/shapes/shapes.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/text/text.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities-dialog/diagram-vulnerabilities-dialog.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities-dialog/diagram-vulnerabilities-dialog.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities-dialog/diagram-vulnerabilities-dialog.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities-dialog/diagram-vulnerabilities-dialog.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/vulnerabilities/diagram-vulnerabilities.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/zones/zones.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/zones/zones.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram-inventory/zones/zones.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram-inventory/zones/zones.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/diagram/diagram.component.html
+++ b/CSETWebNg/src/app/assessment/diagram/diagram.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/diagram/diagram.component.ts
+++ b/CSETWebNg/src/app/assessment/diagram/diagram.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.html
+++ b/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.ts
+++ b/CSETWebNg/src/app/assessment/documents/status-create/status-create.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/navigation/nav-back-next/nav-back-next.component.html
+++ b/CSETWebNg/src/app/assessment/navigation/nav-back-next/nav-back-next.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/navigation/nav-back-next/nav-back-next.component.ts
+++ b/CSETWebNg/src/app/assessment/navigation/nav-back-next/nav-back-next.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { AssessmentContactsResponse, AssessmentDetail } from '../../../../models/assessment-info.model';
 import { DemographicsIod } from '../../../../models/demographics-iod.model';

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config/assessment-config.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config/assessment-config.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config/assessment-config.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config/assessment-config.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-item/contact-item.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-tooltip/contact-tooltip.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-tooltip/contact-tooltip.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="contact-tooltip" *transloco="let t">
   <h5>{{t('contact.details')}}</h5>
   <div *ngIf="POC"> <strong>{{t('contact.primary point of contact')}}</strong></div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-tooltip/contact-tooltip.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/contact-tooltip/contact-tooltip.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { DemographicService } from '../../../../services/demographic.service';

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-info.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2021 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-composition/csi-service-composition.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi-service-demographics/csi-service-demographics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/csi/csi.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/csi.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/framework/framework.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/framework/framework.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/framework/framework.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/framework/framework.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-info/cisa-vadr-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-info/cisa-vadr-info.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-info/cisa-vadr-info.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-info/cisa-vadr-info.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-levels/cisa-vadr-levels.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-levels/cisa-vadr-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-levels/cisa-vadr-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cisa-vadr-levels/cisa-vadr-levels.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component } from '@angular/core';
 import { AssessmentService } from '../../../../services/assessment.service';
 import { MaturityService } from '../../../../services/maturity.service';

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-a/cmmc-a.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-a/cmmc-a.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-a/cmmc-a.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-a/cmmc-a.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-levels/cmmc-levels.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-levels/cmmc-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-levels/cmmc-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc-levels/cmmc-levels.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/cmmc2-levels/cmmc2-levels.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component } from '@angular/core';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
 import { MaturityService } from '../../../../services/maturity.service';

--- a/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/config-cis/config-cis.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/model-select/model-select.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/model-select/model-select.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/model-select/model-select.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/model-select/model-select.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cis/tutorial-cis.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cmmc2/tutorial-cmmc2.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg/tutorial-cpg.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-cpg2/tutorial-cpg2.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-crr/tutorial-crr.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-edm/tutorial-edm.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-imr/tutorial-imr.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-mvra/tutorial-mvra.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/maturity/tutorial-rra/tutorial-rra.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/prepare.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/prepare.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/prepare.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/prepare.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/required/required.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/required/required.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/required/required.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/required/required.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-gen/sal-gen.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/nist-sal.models.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/nist-sal.models.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-nist/sal-nist.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sal-simple/sal-simple.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sals.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sals.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/sals/sals.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/sals/sals.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/prepare/standards/awwa-standard/awwa-standard.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/standards/awwa-standard/awwa-standard.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/prepare/standards/awwa-standard/awwa-standard.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/standards/awwa-standard/awwa-standard.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/ask-questions/ask-questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/category-block/category-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.ts
@@ -1,7 +1,7 @@
 import { CompletionService } from './../../../services/completion.service';
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/grouping-block/grouping-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/grouping-description/grouping-description.component.html
+++ b/CSETWebNg/src/app/assessment/questions/grouping-description/grouping-description.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/grouping-description/grouping-description.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/grouping-description/grouping-description.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/issues/issues.component.html
+++ b/CSETWebNg/src/app/assessment/questions/issues/issues.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/issues/issues.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/issues/issues.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-default/malcolm-answer-default.component.html
+++ b/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-default/malcolm-answer-default.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-default/malcolm-answer-default.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-default/malcolm-answer-default.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 import { QuestionsService } from '../../../../services/questions.service';
 import { MalcolmService } from '../../../../services/malcolm.service';

--- a/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-nested/malcolm-answer-nested.component.html
+++ b/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-nested/malcolm-answer-nested.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-nested/malcolm-answer-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/malcolm-answer/malcolm-answer-nested/malcolm-answer-nested.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { QuestionsService } from '../../../../services/questions.service';
 import { MalcolmService } from '../../../../services/malcolm.service';

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/cre-question-selector/cre-question-selector.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/grouping-block-nested/grouping-block-nested.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/grouping-block-nested/grouping-block-nested.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/grouping-block-nested/grouping-block-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/grouping-block-nested/grouping-block-nested.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/maturity-questions-nested/maturity-questions-nested.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/option-block-nested/option-block-nested.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/option-block-nested/option-block-nested.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/option-block-nested/option-block-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/option-block-nested/option-block-nested.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/question-block-nested/question-block-nested.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/question-block-nested/question-block-nested.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/question-block-nested/question-block-nested.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/nested/question-block-nested/question-block-nested.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/option-block/option-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/option-block/option-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/option-block/option-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/option-block/option-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/observations/additional-observations/additional-observations.component.html
+++ b/CSETWebNg/src/app/assessment/questions/observations/additional-observations/additional-observations.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/observations/additional-observations/additional-observations.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/additional-observations/additional-observations.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.html
+++ b/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/observations/observations-general/observations-general.component.html
+++ b/CSETWebNg/src/app/assessment/questions/observations/observations-general/observations-general.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/observations/observations-general/observations-general.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/observations-general/observations-general.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ObservationDetailComponent } from '../observation-detail.component';

--- a/CSETWebNg/src/app/assessment/questions/observations/observations.model.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/observations.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.html
+++ b/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/other-remarks/other-remarks.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { AssessmentService } from '../../../services/assessment.service';
 

--- a/CSETWebNg/src/app/assessment/questions/placeholder-questions/placeholder-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/placeholder-questions/placeholder-questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/placeholder-questions/placeholder-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/placeholder-questions/placeholder-questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/principle-summary/principle-summary.component.html
+++ b/CSETWebNg/src/app/assessment/questions/principle-summary/principle-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/principle-summary/principle-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/principle-summary/principle-summary.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AssessmentService } from '../../../services/assessment.service';

--- a/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-block-vadr/question-block-vadr.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block-vadr/question-block-vadr.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-block-vadr/question-block-vadr.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block-vadr/question-block-vadr.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-extras-dialog/question-extras-dialog.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-extras-dialog/question-extras-dialog.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/question-extras-dialog/question-extras-dialog.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras-dialog/question-extras-dialog.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-text/glossary-term/glossary-term.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-text/glossary-term/glossary-term.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/question-text/glossary-term/glossary-term.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-text/glossary-term/glossary-term.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-text/question-text-cpg/question-text-cpg.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-text/question-text-cpg/question-text-cpg.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/question-text/question-text-cpg/question-text-cpg.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-text/question-text-cpg/question-text-cpg.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/question-text/question-text.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-text/question-text.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/questions/question-text/question-text.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-text/question-text.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/questions.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/references-display/references-display.component.html
+++ b/CSETWebNg/src/app/assessment/questions/references-display/references-display.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/references-display/references-display.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/references-display/references-display.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/references-section/references-section.component.html
+++ b/CSETWebNg/src/app/assessment/questions/references-section/references-section.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div *ngFor="let doc of documents; let lastDoc = last" class="mb-1" [class.mb-4]="lastDoc">
     {{doc.title}}<ng-container *ngIf="doc.fileName || doc.url || true">: </ng-container>
 

--- a/CSETWebNg/src/app/assessment/questions/references-section/references-section.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/references-section/references-section.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { ReferenceDocLink } from '../../../models/question-extras.model';
 import { ConfigService } from '../../../services/config.service';

--- a/CSETWebNg/src/app/assessment/questions/references-table/references-table.component.html
+++ b/CSETWebNg/src/app/assessment/questions/references-table/references-table.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/questions/references-table/references-table.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/references-table/references-table.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/analysis.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/analysis.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/analysis.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/analysis.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="d-flex flex-column justify-content-center flex-11a" (keydown.enter)="submit()">
   <div class="mat-dialog-header p-3 d-flex justify-content-start align-items-center flex-00a">
     <span class="cset-icons-key-shield fs-base-6 me-3"></span>

--- a/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.spec.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AnalyticsLoginComponent } from './analytics-login.component';

--- a/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/analytics-login/analytics-login.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit, Inject, Input, Output, EventEmitter } from '@angular/core';
 import { FormControl, NgForm, FormGroupDirective, Validators, FormGroup } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http'

--- a/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-ranked/components-ranked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-results/components-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-summary/components-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-types/components-types.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/components-warnings/components-warnings.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/dashboard/dashboard.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/ranked-questions/ranked-questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-ranked/standards-ranked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-results/standards-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analysis/standards-summary/standards-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analytics-compare/analytics-compare.component.html
+++ b/CSETWebNg/src/app/assessment/results/analytics-compare/analytics-compare.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analytics-compare/analytics-compare.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analytics-compare/analytics-compare.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div>
   <div class="white-panel oy-auto ox-auto d-flex flex-column flex-11a" *transloco="let t">
     <p>{{t('analytics.description 1')}}</p>

--- a/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analytics-results/analytics-results.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { AnalyticsService } from '../../../services/analytics.service';
 import { NavigationService } from '../../../services/navigation/navigation.service';

--- a/CSETWebNg/src/app/assessment/results/analytics/analytics.component.html
+++ b/CSETWebNg/src/app/assessment/results/analytics/analytics.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div>
 <div class="white-panel oy-auto ox-auto d-flex flex-column flex-11a">
 

--- a/CSETWebNg/src/app/assessment/results/analytics/analytics.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/analytics/analytics.component.spec.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AnalyticsComponent } from './analytics.component';

--- a/CSETWebNg/src/app/assessment/results/analytics/analytics.component.ts
+++ b/CSETWebNg/src/app/assessment/results/analytics/analytics.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';

--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-ranked-deficiency-page/cis-ranked-deficiency-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cis/cis-section-scoring-page/cis-section-scoring-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cis/ranked-deficiency-chart/ranked-deficiency-chart.component.html
+++ b/CSETWebNg/src/app/assessment/results/cis/ranked-deficiency-chart/ranked-deficiency-chart.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cis/ranked-deficiency-chart/ranked-deficiency-chart.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cis/ranked-deficiency-chart/ranked-deficiency-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-answer-block/cpg-answer-block.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-answer-block/cpg-answer-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-answer-block/cpg-answer-block.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-answer-block/cpg-answer-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-cost-impact-complexity/cpg-cost-impact-complexity.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary/cpg-domain-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary/cpg-domain-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary/cpg-domain-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary/cpg-domain-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 import { CpgService } from '../../../../services/cpg.service';
 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/crr/crr-heatmap/crr-heatmap.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-heatmap/crr-heatmap.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/crr/crr-heatmap/crr-heatmap.component.ts
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-heatmap/crr-heatmap.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-detail/crr-results-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-results-page/crr-results-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/crr/crr-summary-results/crr-summary-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-blocks-compact/edm-blocks-compact.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-heatmap/edm-heatmap.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/edm-q-blocks-horizontal/edm-q-blocks-horizontal.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/maturity-indicator-levels/maturity-indicator-levels.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-formation/relationship-formation.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/relationship-management/relationship-management.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/service-protection/service-protection.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/edm/summary-results/summary-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/feedback/feedback.component.html
+++ b/CSETWebNg/src/app/assessment/results/feedback/feedback.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/feedback/feedback.component.ts
+++ b/CSETWebNg/src/app/assessment/results/feedback/feedback.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.html
+++ b/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.ts
+++ b/CSETWebNg/src/app/assessment/results/key-display-1/key-display-1.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/chart-components/compliance-score/compliance-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/chart-components/compliance-score/compliance-score.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/chart-components/compliance-score/compliance-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/chart-components/compliance-score/compliance-score.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-compliance/cmmc-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-gaps/cmmc-gaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-drilldown/cmmc-level-drilldown.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc/cmmc-level-results/cmmc-level-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-domain-results/cmmc2-domain-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-gaps/cmmc2-gaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level-results/cmmc2-level-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level1-score/cmmc2-level1-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level1-score/cmmc2-level1-score.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level1-score/cmmc2-level1-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level1-score/cmmc2-level1-score.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level2-score/cmmc2-level2-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level2-score/cmmc2-level2-score.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level2-score/cmmc2-level2-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-level2-score/cmmc2-level2-score.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-results/cmmc2-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-results/cmmc2-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-results/cmmc2-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-results/cmmc2-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/cmmc2-scores/cmmc2-scores.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-level3-score/cmmc2-level3-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-level3-score/cmmc2-level3-score.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-level3-score/cmmc2-level3-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-level3-score/cmmc2-level3-score.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/cmmc2-scorecard/cmmc2-scorecard-page.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { AssessmentService } from '../../../../../services/assessment.service';
 import { MaturityService } from '../../../../../services/maturity.service';

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/level-scorecard/level-scorecard.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/level-scorecard/level-scorecard.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/level-scorecard/level-scorecard.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/level-scorecard/level-scorecard.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { LayoutService } from '../../../../../services/layout.service';
 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-cmmc2/scorecard/sprs-score/sprs-score.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-domains/mvra-answer-domains.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-domains/mvra-answer-domains.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-domains/mvra-answer-domains.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-domains/mvra-answer-domains.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-functions/mvra-answer-functions.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-functions/mvra-answer-functions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-functions/mvra-answer-functions.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-answer-functions/mvra-answer-functions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps-page/mvra-gaps-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps-page/mvra-gaps-page.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps-page/mvra-gaps-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps-page/mvra-gaps-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-gaps/mvra-gaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary-page/mvra-summary-page.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary-page/mvra-summary-page.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary-page/mvra-summary-page.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary-page/mvra-summary-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-mvra/mvra-summary/mvra-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-compliance/rra-answer-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-counts/rra-answer-counts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-answer-distribution/rra-answer-distribution.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-gaps/rra-gaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-level-results/rra-level-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-levels/rra-levels.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-questions-scoring/rra-questions-scoring.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary-all/rra-summary-all.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.spec.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-rra/rra-summary/rra-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-compliance/vadr-answer-compliance.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-compliance/vadr-answer-compliance.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-compliance/vadr-answer-compliance.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-compliance/vadr-answer-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-counts/vadr-answer-counts.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-counts/vadr-answer-counts.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-counts/vadr-answer-counts.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-counts/vadr-answer-counts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-distribution/vadr-answer-distribution.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-distribution/vadr-answer-distribution.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-distribution/vadr-answer-distribution.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-answer-distribution/vadr-answer-distribution.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-gaps/vadr-gaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-level-results/vadr-level-results.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-level-results/vadr-level-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-level-results/vadr-level-results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-level-results/vadr-level-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-levels/vadr-levels.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-levels/vadr-levels.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-levels/vadr-levels.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-levels/vadr-levels.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-questions-scoring/vadr-questions-scoring.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-questions-scoring/vadr-questions-scoring.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-questions-scoring/vadr-questions-scoring.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-questions-scoring/vadr-questions-scoring.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary-all/vadr-summary-all.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary-all/vadr-summary-all.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary-all/vadr-summary-all.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary-all/vadr-summary-all.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary/vadr-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary/vadr-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary/vadr-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/mat-vadr/vadr-summary/vadr-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/overview/overview.component.html
+++ b/CSETWebNg/src/app/assessment/results/overview/overview.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/overview/overview.component.ts
+++ b/CSETWebNg/src/app/assessment/results/overview/overview.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/reports/cisa-workflow-warnings/cisa-workflow-warnings.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/cisa-workflow-warnings/cisa-workflow-warnings.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <ng-container *transloco="let t">
     <div *ngIf="invalidFields?.length > 0">
         <div class="alert alert-warning">

--- a/CSETWebNg/src/app/assessment/results/reports/cisa-workflow-warnings/cisa-workflow-warnings.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/cisa-workflow-warnings/cisa-workflow-warnings.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { TranslocoService } from '@jsverse/transloco';
 

--- a/CSETWebNg/src/app/assessment/results/reports/key-report/key-report.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/key-report/key-report.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="container mt-5 pt-5" id="pdfTable" #pdfTable style="margin-top: 3rem; padding-top: 3rem;">
     <!-- <div class="row">
         <div class="col-12 text-center">

--- a/CSETWebNg/src/app/assessment/results/reports/key-report/key-report.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/key-report/key-report.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, ViewChild, ElementRef } from '@angular/core';
 import { AssessmentService } from '../../../../services/assessment.service';
 import { AuthenticationService } from '../../../../services/authentication.service';

--- a/CSETWebNg/src/app/assessment/results/reports/report-list/report-list-common.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/report-list/report-list-common.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/reports/report-list/report-list-common.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/report-list/report-list-common.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { AssessmentService } from '../../../../services/assessment.service';
 import { ObservationsService } from '../../../../services/observations.service';

--- a/CSETWebNg/src/app/assessment/results/reports/report-list/report-list.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/report-list/report-list.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="d-flex flex-column justify-content-start align-items-start mb-4" *transloco="let t">
      <h4>{{sectionTitle}}</h4>
 

--- a/CSETWebNg/src/app/assessment/results/reports/report-list/report-list.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/report-list/report-list.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 import { ReportService } from '../../../../services/report.service';
 import { TranslocoService } from '@jsverse/transloco';

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/results.component.html
+++ b/CSETWebNg/src/app/assessment/results/results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/results.component.ts
+++ b/CSETWebNg/src/app/assessment/results/results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/score-range/score-range.component.html
+++ b/CSETWebNg/src/app/assessment/results/score-range/score-range.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/score-range/score-range.component.ts
+++ b/CSETWebNg/src/app/assessment/results/score-range/score-range.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/score-ranges/score-ranges.component.html
+++ b/CSETWebNg/src/app/assessment/results/score-ranges/score-ranges.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/score-ranges/score-ranges.component.ts
+++ b/CSETWebNg/src/app/assessment/results/score-ranges/score-ranges.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/sd/sd-answer-summary/sd-answer-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/sd/sd-answer-summary/sd-answer-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/assessment/results/sd/sd-answer-summary/sd-answer-summary.component.ts
+++ b/CSETWebNg/src/app/assessment/results/sd/sd-answer-summary/sd-answer-summary.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { QuestionsNestedService } from '../../../../services/questions-nested.service';
 import { MaturityService } from '../../../../services/maturity.service';

--- a/CSETWebNg/src/app/assessment/results/tsa-assessment-complete/tsa-assessment-complete.component.html
+++ b/CSETWebNg/src/app/assessment/results/tsa-assessment-complete/tsa-assessment-complete.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/results/tsa-assessment-complete/tsa-assessment-complete.component.ts
+++ b/CSETWebNg/src/app/assessment/results/tsa-assessment-complete/tsa-assessment-complete.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/upgrade/upgrade.component.html
+++ b/CSETWebNg/src/app/assessment/upgrade/upgrade.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/assessment/upgrade/upgrade.component.ts
+++ b/CSETWebNg/src/app/assessment/upgrade/upgrade.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/add-question/add-question.component.html
+++ b/CSETWebNg/src/app/builder/add-question/add-question.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/add-question/add-question.component.ts
+++ b/CSETWebNg/src/app/builder/add-question/add-question.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/builder-breadcrumbs/builder-breadcrumbs.component.html
+++ b/CSETWebNg/src/app/builder/builder-breadcrumbs/builder-breadcrumbs.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/builder-breadcrumbs/builder-breadcrumbs.component.ts
+++ b/CSETWebNg/src/app/builder/builder-breadcrumbs/builder-breadcrumbs.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.html
+++ b/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
+++ b/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.html
+++ b/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.ts
+++ b/CSETWebNg/src/app/builder/module-add-clone/module-add-clone.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/question-list/question-list.component.html
+++ b/CSETWebNg/src/app/builder/question-list/question-list.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/question-list/question-list.component.ts
+++ b/CSETWebNg/src/app/builder/question-list/question-list.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/ref-document/ref-document.component.html
+++ b/CSETWebNg/src/app/builder/ref-document/ref-document.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/ref-document/ref-document.component.ts
+++ b/CSETWebNg/src/app/builder/ref-document/ref-document.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.html
+++ b/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
+++ b/CSETWebNg/src/app/builder/requirement-detail/requirement-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.html
+++ b/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.ts
+++ b/CSETWebNg/src/app/builder/requirement-list/requirement-list.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/set-detail/set-detail.component.html
+++ b/CSETWebNg/src/app/builder/set-detail/set-detail.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/set-detail/set-detail.component.ts
+++ b/CSETWebNg/src/app/builder/set-detail/set-detail.component.ts
@@ -1,7 +1,7 @@
 import { AlertComponent } from './../../dialogs/alert/alert.component';
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/builder/standard-documents/standard-documents.component.html
+++ b/CSETWebNg/src/app/builder/standard-documents/standard-documents.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/builder/standard-documents/standard-documents.component.ts
+++ b/CSETWebNg/src/app/builder/standard-documents/standard-documents.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/components/theme-toggle/theme-toggle.component.html
+++ b/CSETWebNg/src/app/components/theme-toggle/theme-toggle.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <button class="tw:dark:hover:bg-bg-tertiary" mat-menu-item (click)="toggleTheme()"
   [attr.aria-label]="isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'"
   [title]="(isDarkMode ? 'menu.user.switch to light mode' : 'menu.user.switch to dark mode') | transloco" type="button">

--- a/CSETWebNg/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/CSETWebNg/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { ThemeService, Theme } from '../../services/theme.service';
 import { Subscription } from 'rxjs';

--- a/CSETWebNg/src/app/dialogs/about-cset/about-cset.component.html
+++ b/CSETWebNg/src/app/dialogs/about-cset/about-cset.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/about-cset/about-cset.component.ts
+++ b/CSETWebNg/src/app/dialogs/about-cset/about-cset.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/about/about.component.html
+++ b/CSETWebNg/src/app/dialogs/about/about.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/about/about.component.ts
+++ b/CSETWebNg/src/app/dialogs/about/about.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/accessibility-statement/accessibility-statement.component.html
+++ b/CSETWebNg/src/app/dialogs/accessibility-statement/accessibility-statement.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/accessibility-statement/accessibility-statement.component.ts
+++ b/CSETWebNg/src/app/dialogs/accessibility-statement/accessibility-statement.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.html
+++ b/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.ts
+++ b/CSETWebNg/src/app/dialogs/add-requirement/add-requirement/add-requirement.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/advisory/advisory.component.html
+++ b/CSETWebNg/src/app/dialogs/advisory/advisory.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/advisory/advisory.component.ts
+++ b/CSETWebNg/src/app/dialogs/advisory/advisory.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/alert/alert.component.html
+++ b/CSETWebNg/src/app/dialogs/alert/alert.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/alert/alert.component.ts
+++ b/CSETWebNg/src/app/dialogs/alert/alert.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/assessment-documents/assessment-documents.component.html
+++ b/CSETWebNg/src/app/dialogs/assessment-documents/assessment-documents.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/assessment-documents/assessment-documents.component.ts
+++ b/CSETWebNg/src/app/dialogs/assessment-documents/assessment-documents.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/assessment-encryption/export-assessment/export-assessment.component.html
+++ b/CSETWebNg/src/app/dialogs/assessment-encryption/export-assessment/export-assessment.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/assessment-encryption/export-assessment/export-assessment.component.ts
+++ b/CSETWebNg/src/app/dialogs/assessment-encryption/export-assessment/export-assessment.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/assessment-encryption/import-password/import-password.component.html
+++ b/CSETWebNg/src/app/dialogs/assessment-encryption/import-password/import-password.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/assessment-encryption/import-password/import-password.component.ts
+++ b/CSETWebNg/src/app/dialogs/assessment-encryption/import-password/import-password.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/change-password/change-password.component.html
+++ b/CSETWebNg/src/app/dialogs/change-password/change-password.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/change-password/change-password.component.ts
+++ b/CSETWebNg/src/app/dialogs/change-password/change-password.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/change-password/password-validation.ts
+++ b/CSETWebNg/src/app/dialogs/change-password/password-validation.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/charter-mistmatch/charter-mismatch.component.html
+++ b/CSETWebNg/src/app/dialogs/charter-mistmatch/charter-mismatch.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/charter-mistmatch/charter-mismatch.component.ts
+++ b/CSETWebNg/src/app/dialogs/charter-mistmatch/charter-mismatch.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/confirm/confirm.component.html
+++ b/CSETWebNg/src/app/dialogs/confirm/confirm.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/confirm/confirm.component.ts
+++ b/CSETWebNg/src/app/dialogs/confirm/confirm.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.html
+++ b/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.ts
+++ b/CSETWebNg/src/app/dialogs/edit-user/edit-user.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/ejection/ejection.component.html
+++ b/CSETWebNg/src/app/dialogs/ejection/ejection.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/ejection/ejection.component.ts
+++ b/CSETWebNg/src/app/dialogs/ejection/ejection.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/email/email.component.html
+++ b/CSETWebNg/src/app/dialogs/email/email.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/email/email.component.ts
+++ b/CSETWebNg/src/app/dialogs/email/email.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/enable-protected/enable-protected.component.html
+++ b/CSETWebNg/src/app/dialogs/enable-protected/enable-protected.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/enable-protected/enable-protected.component.ts
+++ b/CSETWebNg/src/app/dialogs/enable-protected/enable-protected.component.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from './../../services/config.service';
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/excel-export/excel-export.component.html
+++ b/CSETWebNg/src/app/dialogs/excel-export/excel-export.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/excel-export/excel-export.component.ts
+++ b/CSETWebNg/src/app/dialogs/excel-export/excel-export.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.html
+++ b/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.ts
+++ b/CSETWebNg/src/app/dialogs/global-parameters/global-parameters.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.html
+++ b/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.ts
+++ b/CSETWebNg/src/app/dialogs/import demographics/import-demographics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/import-assessment/import-assessment.component.html
+++ b/CSETWebNg/src/app/dialogs/import-assessment/import-assessment.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/import-assessment/import-assessment.component.ts
+++ b/CSETWebNg/src/app/dialogs/import-assessment/import-assessment.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/inline-parameter/inline-parameter.component.html
+++ b/CSETWebNg/src/app/dialogs/inline-parameter/inline-parameter.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/inline-parameter/inline-parameter.component.ts
+++ b/CSETWebNg/src/app/dialogs/inline-parameter/inline-parameter.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/keyboard-shortcuts/keyboard-shortcuts.component.html
+++ b/CSETWebNg/src/app/dialogs/keyboard-shortcuts/keyboard-shortcuts.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/keyboard-shortcuts/keyboard-shortcuts.component.ts
+++ b/CSETWebNg/src/app/dialogs/keyboard-shortcuts/keyboard-shortcuts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/license/license.component.html
+++ b/CSETWebNg/src/app/dialogs/license/license.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 
@@ -27,7 +27,7 @@
   <mat-dialog-content class="p-3 pe-0 oy-auto d-flex flex-column flex-11a">
     <div class="pe-3">
       <p>
-        Copyright 2025 Battelle Energy Alliance, LLC
+        Copyright 2026 Battelle Energy Alliance, LLC
       </p>
       <p>
         Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/CSETWebNg/src/app/dialogs/license/license.component.ts
+++ b/CSETWebNg/src/app/dialogs/license/license.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/malcolm/malcolm-instructions/malcolm-instructions.component.html
+++ b/CSETWebNg/src/app/dialogs/malcolm/malcolm-instructions/malcolm-instructions.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/malcolm/malcolm-instructions/malcolm-instructions.component.ts
+++ b/CSETWebNg/src/app/dialogs/malcolm/malcolm-instructions/malcolm-instructions.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MalcolmUploadErrorComponent } from '../malcolm-upload-error.component';

--- a/CSETWebNg/src/app/dialogs/malcolm/malcolm-upload-error.component.html
+++ b/CSETWebNg/src/app/dialogs/malcolm/malcolm-upload-error.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/malcolm/malcolm-upload-error.component.ts
+++ b/CSETWebNg/src/app/dialogs/malcolm/malcolm-upload-error.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/merge-question-detail/merge-question-detail.component.html
+++ b/CSETWebNg/src/app/dialogs/merge-question-detail/merge-question-detail.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/merge-question-detail/merge-question-detail.component.ts
+++ b/CSETWebNg/src/app/dialogs/merge-question-detail/merge-question-detail.component.ts
@@ -1,7 +1,7 @@
 
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.html
+++ b/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.spec.ts
+++ b/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.ts
+++ b/CSETWebNg/src/app/dialogs/new-assessment-dialog/new-assessment-dialog.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/okay/okay.component.html
+++ b/CSETWebNg/src/app/dialogs/okay/okay.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/okay/okay.component.ts
+++ b/CSETWebNg/src/app/dialogs/okay/okay.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/online-disclaimer/online-disclaimer.component.html
+++ b/CSETWebNg/src/app/dialogs/online-disclaimer/online-disclaimer.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/online-disclaimer/online-disclaimer.component.ts
+++ b/CSETWebNg/src/app/dialogs/online-disclaimer/online-disclaimer.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/question-filters-reports/question-filters-reports.component.html
+++ b/CSETWebNg/src/app/dialogs/question-filters-reports/question-filters-reports.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/question-filters-reports/question-filters-reports.component.ts
+++ b/CSETWebNg/src/app/dialogs/question-filters-reports/question-filters-reports.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/question-filters/question-filters.component.html
+++ b/CSETWebNg/src/app/dialogs/question-filters/question-filters.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/question-filters/question-filters.component.ts
+++ b/CSETWebNg/src/app/dialogs/question-filters/question-filters.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/roles-changed/roles-changed.component.html
+++ b/CSETWebNg/src/app/dialogs/roles-changed/roles-changed.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/roles-changed/roles-changed.component.ts
+++ b/CSETWebNg/src/app/dialogs/roles-changed/roles-changed.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/rra-mini-user-guide/rra-mini-user-guide.component.html
+++ b/CSETWebNg/src/app/dialogs/rra-mini-user-guide/rra-mini-user-guide.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/rra-mini-user-guide/rra-mini-user-guide.component.ts
+++ b/CSETWebNg/src/app/dialogs/rra-mini-user-guide/rra-mini-user-guide.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/sector-help/sector-help.component.html
+++ b/CSETWebNg/src/app/dialogs/sector-help/sector-help.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/sector-help/sector-help.component.ts
+++ b/CSETWebNg/src/app/dialogs/sector-help/sector-help.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.html
+++ b/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.ts
+++ b/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/terms-of-use/terms-of-use.component.html
+++ b/CSETWebNg/src/app/dialogs/terms-of-use/terms-of-use.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/dialogs/terms-of-use/terms-of-use.component.ts
+++ b/CSETWebNg/src/app/dialogs/terms-of-use/terms-of-use.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
+++ b/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.ts
+++ b/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Inject, OnInit } from '@angular/core';
 import { AuthenticationService } from '../../services/authentication.service';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';

--- a/CSETWebNg/src/app/guards/aggregation.guard.ts
+++ b/CSETWebNg/src/app/guards/aggregation.guard.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/guards/assess.guard.ts
+++ b/CSETWebNg/src/app/guards/assess.guard.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/guards/auth.guard.ts
+++ b/CSETWebNg/src/app/guards/auth.guard.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/guards/role.guard.ts
+++ b/CSETWebNg/src/app/guards/role.guard.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router, CanActivate } from '@angular/router';
 import { AuthenticationService } from '../services/authentication.service';

--- a/CSETWebNg/src/app/helpers/auto-size.directive.ts
+++ b/CSETWebNg/src/app/helpers/auto-size.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/comparer.ts
+++ b/CSETWebNg/src/app/helpers/comparer.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/completion-count.pipe.ts
+++ b/CSETWebNg/src/app/helpers/completion-count.pipe.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Pipe, PipeTransform } from '@angular/core';
 import { TranslocoService } from '@jsverse/transloco';
 

--- a/CSETWebNg/src/app/helpers/confirm-equal-validator.directive.ts
+++ b/CSETWebNg/src/app/helpers/confirm-equal-validator.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/date-localize.pipe.ts
+++ b/CSETWebNg/src/app/helpers/date-localize.pipe.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/digits-only-not-zero.directive.ts
+++ b/CSETWebNg/src/app/helpers/digits-only-not-zero.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/digits-only.directive.ts
+++ b/CSETWebNg/src/app/helpers/digits-only.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/email-validator.directive.ts
+++ b/CSETWebNg/src/app/helpers/email-validator.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/focus.directive.ts
+++ b/CSETWebNg/src/app/helpers/focus.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/in-view/in-view.component.ts
+++ b/CSETWebNg/src/app/helpers/in-view/in-view.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/jwt-parser.ts
+++ b/CSETWebNg/src/app/helpers/jwt-parser.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/jwt.interceptor.ts
+++ b/CSETWebNg/src/app/helpers/jwt.interceptor.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/linebreak.pipe.ts
+++ b/CSETWebNg/src/app/helpers/linebreak.pipe.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/linebreakplain.pipe.ts
+++ b/CSETWebNg/src/app/helpers/linebreakplain.pipe.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/nullish-coalesce.pipe.ts
+++ b/CSETWebNg/src/app/helpers/nullish-coalesce.pipe.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/progress/progress.component.html
+++ b/CSETWebNg/src/app/helpers/progress/progress.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/helpers/progress/progress.component.ts
+++ b/CSETWebNg/src/app/helpers/progress/progress.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/run-scripts.directive.ts
+++ b/CSETWebNg/src/app/helpers/run-scripts.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/safe.pipe.ts
+++ b/CSETWebNg/src/app/helpers/safe.pipe.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/url-routing.helper.ts
+++ b/CSETWebNg/src/app/helpers/url-routing.helper.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/helpers/zip-code.directive.ts
+++ b/CSETWebNg/src/app/helpers/zip-code.directive.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/commands/formatAsXml.ts
+++ b/CSETWebNg/src/app/import/formatting/commands/formatAsXml.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/commands/index.ts
+++ b/CSETWebNg/src/app/import/formatting/commands/index.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/commands/minifyXml.ts
+++ b/CSETWebNg/src/app/import/formatting/commands/minifyXml.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/formatters/index.ts
+++ b/CSETWebNg/src/app/import/formatting/formatters/index.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/formatters/v2-xml-formatter.ts
+++ b/CSETWebNg/src/app/import/formatting/formatters/v2-xml-formatter.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/index.ts
+++ b/CSETWebNg/src/app/import/formatting/index.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/xml-formatter.ts
+++ b/CSETWebNg/src/app/import/formatting/xml-formatter.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/xml-formatting-edit-provider.ts
+++ b/CSETWebNg/src/app/import/formatting/xml-formatting-edit-provider.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/formatting/xml-formatting-options.ts
+++ b/CSETWebNg/src/app/import/formatting/xml-formatting-options.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/import.component.html
+++ b/CSETWebNg/src/app/import/import.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/import/import.component.ts
+++ b/CSETWebNg/src/app/import/import.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/admin-settings/admin-settings.component.html
+++ b/CSETWebNg/src/app/initial/admin-settings/admin-settings.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/initial/admin-settings/admin-settings.component.ts
+++ b/CSETWebNg/src/app/initial/admin-settings/admin-settings.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.html
+++ b/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.ts
+++ b/CSETWebNg/src/app/initial/assessmenet-comparison-analytics/assessment-comparison-analytics.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/cset-origin/cset-origin.component.html
+++ b/CSETWebNg/src/app/initial/cset-origin/cset-origin.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/initial/cset-origin/cset-origin.component.ts
+++ b/CSETWebNg/src/app/initial/cset-origin/cset-origin.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/initial.component.html
+++ b/CSETWebNg/src/app/initial/initial.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/initial/initial.component.ts
+++ b/CSETWebNg/src/app/initial/initial.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.spec.ts
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.html
+++ b/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.ts
+++ b/CSETWebNg/src/app/initial/login-access-key/login-access-key.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.html
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
+++ b/CSETWebNg/src/app/initial/login-cset/login-cset.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login/login.component.html
+++ b/CSETWebNg/src/app/initial/login/login.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/login/login.component.ts
+++ b/CSETWebNg/src/app/initial/login/login.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/logout/logout.component.html
+++ b/CSETWebNg/src/app/initial/logout/logout.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/initial/logout/logout.component.ts
+++ b/CSETWebNg/src/app/initial/logout/logout.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
+++ b/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.ts
+++ b/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/no-server-connection/no-server-connection.component.html
+++ b/CSETWebNg/src/app/initial/no-server-connection/no-server-connection.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="no-connection w-100 py-2 text-center" style="background-color: #d10606; color: white">
      <i class="fa fa-ethernet me-2"></i> {{ tSvc.translate('connection.no server connection') }}
      <button class="btn btn-light ms-2 c-gray-600" (click)="showDialog()">{{ tSvc.translate('connection.details') }}</button>

--- a/CSETWebNg/src/app/initial/no-server-connection/no-server-connection.component.ts
+++ b/CSETWebNg/src/app/initial/no-server-connection/no-server-connection.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { AlertComponent } from '../../dialogs/alert/alert.component';

--- a/CSETWebNg/src/app/initial/privacy-warning-reject/privacy-warning-reject.component.html
+++ b/CSETWebNg/src/app/initial/privacy-warning-reject/privacy-warning-reject.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/privacy-warning-reject/privacy-warning-reject.component.ts
+++ b/CSETWebNg/src/app/initial/privacy-warning-reject/privacy-warning-reject.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/privacy-warning/privacy-warning.component.html
+++ b/CSETWebNg/src/app/initial/privacy-warning/privacy-warning.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/privacy-warning/privacy-warning.component.ts
+++ b/CSETWebNg/src/app/initial/privacy-warning/privacy-warning.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/register/register.component.html
+++ b/CSETWebNg/src/app/initial/register/register.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/initial/register/register.component.ts
+++ b/CSETWebNg/src/app/initial/register/register.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.html
+++ b/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.ts
+++ b/CSETWebNg/src/app/initial/reset-pass/reset-pass.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/search-page/search-page.component.html
+++ b/CSETWebNg/src/app/initial/search-page/search-page.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/initial/search-page/search-page.component.ts
+++ b/CSETWebNg/src/app/initial/search-page/search-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.html
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.ts
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-blank/layout-blank.component.html
+++ b/CSETWebNg/src/app/layout/layout-blank/layout-blank.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-blank/layout-blank.component.ts
+++ b/CSETWebNg/src/app/layout/layout-blank/layout-blank.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.html
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.ts
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-switcher/layout-switcher.component.html
+++ b/CSETWebNg/src/app/layout/layout-switcher/layout-switcher.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/layout-switcher/layout-switcher.component.ts
+++ b/CSETWebNg/src/app/layout/layout-switcher/layout-switcher.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/logos/logo-cset/logo-cset.component.html
+++ b/CSETWebNg/src/app/layout/logos/logo-cset/logo-cset.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/logos/logo-cset/logo-cset.component.ts
+++ b/CSETWebNg/src/app/layout/logos/logo-cset/logo-cset.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/logos/logo-cyber-shield/logo-cyber-shield.component.html
+++ b/CSETWebNg/src/app/layout/logos/logo-cyber-shield/logo-cyber-shield.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/layout/logos/logo-cyber-shield/logo-cyber-shield.component.ts
+++ b/CSETWebNg/src/app/layout/logos/logo-cyber-shield/logo-cyber-shield.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/layout/logos/logo-tsa/logo-tsa.component.html
+++ b/CSETWebNg/src/app/layout/logos/logo-tsa/logo-tsa.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/logos/logo-tsa/logo-tsa.component.ts
+++ b/CSETWebNg/src/app/layout/logos/logo-tsa/logo-tsa.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/main.ts
+++ b/CSETWebNg/src/app/main.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/admin-save.model.ts
+++ b/CSETWebNg/src/app/models/admin-save.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/aggregation.model.ts
+++ b/CSETWebNg/src/app/models/aggregation.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/anonymous.model.ts
+++ b/CSETWebNg/src/app/models/anonymous.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/assessment-info.model.ts
+++ b/CSETWebNg/src/app/models/assessment-info.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/credit-union-details.model.ts
+++ b/CSETWebNg/src/app/models/credit-union-details.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/csi.model.ts
+++ b/CSETWebNg/src/app/models/csi.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/demographics-extended.model.ts
+++ b/CSETWebNg/src/app/models/demographics-extended.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/demographics-iod.model.ts
+++ b/CSETWebNg/src/app/models/demographics-iod.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/diagram-vulnerabilities.model.ts
+++ b/CSETWebNg/src/app/models/diagram-vulnerabilities.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/editable-user.model.ts
+++ b/CSETWebNg/src/app/models/editable-user.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/enums/cfstate.enum.ts
+++ b/CSETWebNg/src/app/models/enums/cfstate.enum.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export enum CFState{
     
 }

--- a/CSETWebNg/src/app/models/enums/role.model.ts
+++ b/CSETWebNg/src/app/models/enums/role.model.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export enum RoleType {
     ADMIN = 'ADMIN',
     USER = 'USER'

--- a/CSETWebNg/src/app/models/frameworks.model.ts
+++ b/CSETWebNg/src/app/models/frameworks.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/malcolm.model.ts
+++ b/CSETWebNg/src/app/models/malcolm.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/mat-detail.model.ts
+++ b/CSETWebNg/src/app/models/mat-detail.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/maturity.model.ts
+++ b/CSETWebNg/src/app/models/maturity.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/module-config.model.ts
+++ b/CSETWebNg/src/app/models/module-config.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/question-extras.model.ts
+++ b/CSETWebNg/src/app/models/question-extras.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/questions.model.ts
+++ b/CSETWebNg/src/app/models/questions.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/reports.model.ts
+++ b/CSETWebNg/src/app/models/reports.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/required-document.model.ts
+++ b/CSETWebNg/src/app/models/required-document.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/reset-pass.model.ts
+++ b/CSETWebNg/src/app/models/reset-pass.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/sal.model.ts
+++ b/CSETWebNg/src/app/models/sal.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/selectable-model.model.ts
+++ b/CSETWebNg/src/app/models/selectable-model.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/set-builder.model.ts
+++ b/CSETWebNg/src/app/models/set-builder.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/standards.model.ts
+++ b/CSETWebNg/src/app/models/standards.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/user.model.ts
+++ b/CSETWebNg/src/app/models/user.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/models/xmlCompletionItemProvider.model.ts
+++ b/CSETWebNg/src/app/models/xmlCompletionItemProvider.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-drop.directive.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-drop.directive.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Directive, EventEmitter, ElementRef, HostListener, Input, Output } from '@angular/core';
 
 import { FileUploader, FileUploaderOptions } from './file-uploader.class';

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-item.class.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-item.class.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { FileLikeObject } from './file-like-object.class';
 import { FileUploader, ParsedResponseHeaders, FileUploaderOptions } from './file-uploader.class';
 

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-like-object.class.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-like-object.class.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export class FileLikeObject {
   lastModifiedDate: any;
   size: any;

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-select.directive.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-select.directive.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Directive, EventEmitter, ElementRef, Input, HostListener, Output } from '@angular/core';
 
 import { FileUploader, FileUploaderOptions } from './file-uploader.class';

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-type.class.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-type.class.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { FileLikeObject } from '../index';
 
 export class FileType {

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-upload.module.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-upload.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 

--- a/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-uploader.class.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/file-upload/file-uploader.class.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { EventEmitter } from '@angular/core';
 import { FileLikeObject } from './file-like-object.class';
 import { FileItem } from './file-item.class';

--- a/CSETWebNg/src/app/modules/ng2-file-upload/index.ts
+++ b/CSETWebNg/src/app/modules/ng2-file-upload/index.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export * from  './file-upload/file-drop.directive';
 export * from  './file-upload/file-uploader.class';
 export * from './file-upload/file-item.class';

--- a/CSETWebNg/src/app/modules/ngx-ellipsis/directives/ellipsis.directive.spec.ts
+++ b/CSETWebNg/src/app/modules/ngx-ellipsis/directives/ellipsis.directive.spec.ts
@@ -1,0 +1,23 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////

--- a/CSETWebNg/src/app/modules/ngx-ellipsis/directives/ellipsis.directive.ts
+++ b/CSETWebNg/src/app/modules/ngx-ellipsis/directives/ellipsis.directive.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import {
     Directive,
     ElementRef,

--- a/CSETWebNg/src/app/modules/ngx-ellipsis/ellipsis.module.ts
+++ b/CSETWebNg/src/app/modules/ngx-ellipsis/ellipsis.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { NgModule } from '@angular/core';
 import { EllipsisDirective } from './directives/ellipsis.directive';
 

--- a/CSETWebNg/src/app/modules/tooltip/options.interface.ts
+++ b/CSETWebNg/src/app/modules/tooltip/options.interface.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export interface TooltipOptions {
     'placement'?: string;
     'autoPlacement'?: boolean;

--- a/CSETWebNg/src/app/modules/tooltip/options.service.ts
+++ b/CSETWebNg/src/app/modules/tooltip/options.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { InjectionToken } from '@angular/core';
 import { TooltipOptions } from './options.interface';
 

--- a/CSETWebNg/src/app/modules/tooltip/options.ts
+++ b/CSETWebNg/src/app/modules/tooltip/options.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export const defaultOptions = {
 	'placement': 'top',
 	'autoPlacement': true,

--- a/CSETWebNg/src/app/modules/tooltip/tooltip.component.html
+++ b/CSETWebNg/src/app/modules/tooltip/tooltip.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div *ngIf="isThemeLight" class="tooltip-arrow"></div>
 
 <div *ngIf="options['contentType'] === 'template' else htmlOrStringTemplate">

--- a/CSETWebNg/src/app/modules/tooltip/tooltip.component.ts
+++ b/CSETWebNg/src/app/modules/tooltip/tooltip.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import {Component, ElementRef, HostListener, HostBinding, Input, OnInit, EventEmitter, Renderer2} from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/modules/tooltip/tooltip.directive.ts
+++ b/CSETWebNg/src/app/modules/tooltip/tooltip.directive.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Directive, ElementRef, HostListener, Input, ComponentFactoryResolver, EmbeddedViewRef, ApplicationRef, Injector, ComponentRef, OnInit, Output, EventEmitter, OnDestroy, Inject, Optional, SimpleChanges } from '@angular/core';
 import { TooltipComponent } from './tooltip.component';
 import { TooltipOptionsService } from './options.service';

--- a/CSETWebNg/src/app/modules/tooltip/tooltip.module.ts
+++ b/CSETWebNg/src/app/modules/tooltip/tooltip.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TooltipDirective } from './tooltip.directive';

--- a/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.html
+++ b/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.html
@@ -1,5 +1,5 @@
 <!----------------------
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights

--- a/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.ts
+++ b/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.html
+++ b/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.html
@@ -1,5 +1,5 @@
 <!----------------------
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights

--- a/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.html
+++ b/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.html
@@ -1,5 +1,5 @@
 <!----------------------
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights

--- a/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.ts
+++ b/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/alt-justification-comments/alt-justification-comments.component.html
+++ b/CSETWebNg/src/app/reports/alt-justification-comments/alt-justification-comments.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/alt-justification-comments/alt-justification-comments.component.ts
+++ b/CSETWebNg/src/app/reports/alt-justification-comments/alt-justification-comments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/analysis-network-components/analysis-network-components.component.html
+++ b/CSETWebNg/src/app/reports/analysis-network-components/analysis-network-components.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/analysis-network-components/analysis-network-components.component.ts
+++ b/CSETWebNg/src/app/reports/analysis-network-components/analysis-network-components.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-donut/c2m2-donut.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-donut/c2m2-donut.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-donut/c2m2-donut.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-donut/c2m2-donut.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-objective-table/c2m2-objective-table.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-objective-table/c2m2-objective-table.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-objective-table/c2m2-objective-table.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-objective-table/c2m2-objective-table.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-cover-sheet/c2m2-cover-sheet.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-cover-sheet/c2m2-cover-sheet.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-cover-sheet/c2m2-cover-sheet.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-cover-sheet/c2m2-cover-sheet.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-detailed-results/c2m2-detailed-results.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-detailed-results/c2m2-detailed-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-detailed-results/c2m2-detailed-results.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-detailed-results/c2m2-detailed-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-introduction/c2m2-introduction.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-introduction/c2m2-introduction.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-introduction/c2m2-introduction.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-introduction/c2m2-introduction.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-list-of-partially-implemented-and-not-implemented-practices/c2m2-list-of-partially-implemented-and-not-implemented-practices.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-list-of-partially-implemented-and-not-implemented-practices/c2m2-list-of-partially-implemented-and-not-implemented-practices.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-list-of-partially-implemented-and-not-implemented-practices/c2m2-list-of-partially-implemented-and-not-implemented-practices.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-list-of-partially-implemented-and-not-implemented-practices/c2m2-list-of-partially-implemented-and-not-implemented-practices.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-model-architecture/c2m2-model-architecture.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-model-architecture/c2m2-model-architecture.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-model-architecture/c2m2-model-architecture.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-model-architecture/c2m2-model-architecture.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-self-evaluation-notes/c2m2-self-evaluation-notes.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-self-evaluation-notes/c2m2-self-evaluation-notes.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-self-evaluation-notes/c2m2-self-evaluation-notes.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-self-evaluation-notes/c2m2-self-evaluation-notes.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-side-toc/c2m2-side-toc.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-side-toc/c2m2-side-toc.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-side-toc/c2m2-side-toc.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-side-toc/c2m2-side-toc.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-domain-mil-bar-chart/c2m2-domain-mil-bar-chart.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-domain-mil-bar-chart/c2m2-domain-mil-bar-chart.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-domain-mil-bar-chart/c2m2-domain-mil-bar-chart.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-domain-mil-bar-chart/c2m2-domain-mil-bar-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-summary-results.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-summary-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-summary-results.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-summary-results/c2m2-summary-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-using-self-evaluation-results/c2m2-using-self-evaluation-results.component.html
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-using-self-evaluation-results/c2m2-using-self-evaluation-results.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-using-self-evaluation-results/c2m2-using-self-evaluation-results.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-using-self-evaluation-results/c2m2-using-self-evaluation-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.html
+++ b/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.spec.ts
+++ b/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-scoring-chart/cis-scoring-chart.component.html
+++ b/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-scoring-chart/cis-scoring-chart.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-scoring-chart/cis-scoring-chart.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-scoring-chart/cis-scoring-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.html
+++ b/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.html
+++ b/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/grouping-block-nested-report/grouping-block-nested-report.component.html
+++ b/CSETWebNg/src/app/reports/cis/grouping-block-nested-report/grouping-block-nested-report.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/cis/grouping-block-nested-report/grouping-block-nested-report.component.ts
+++ b/CSETWebNg/src/app/reports/cis/grouping-block-nested-report/grouping-block-nested-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/option-block-nested-report/option-block-nested-report.component.html
+++ b/CSETWebNg/src/app/reports/cis/option-block-nested-report/option-block-nested-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/option-block-nested-report/option-block-nested-report.component.ts
+++ b/CSETWebNg/src/app/reports/cis/option-block-nested-report/option-block-nested-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/question-block-nested-report/question-block-nested-report.component.html
+++ b/CSETWebNg/src/app/reports/cis/question-block-nested-report/question-block-nested-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/question-block-nested-report/question-block-nested-report.component.ts
+++ b/CSETWebNg/src/app/reports/cis/question-block-nested-report/question-block-nested-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/shared/disclaimer-blurb-a/disclaimer-blurb-a.component.html
+++ b/CSETWebNg/src/app/reports/cis/shared/disclaimer-blurb-a/disclaimer-blurb-a.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cis/shared/disclaimer-blurb-a/disclaimer-blurb-a.component.ts
+++ b/CSETWebNg/src/app/reports/cis/shared/disclaimer-blurb-a/disclaimer-blurb-a.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.html
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.html
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.html
+++ b/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/vadr-grouping-block/vadr-grouping-block.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 import { QuestionsService } from '../../../services/questions.service';
 

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.html
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.html
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { AssessmentService } from '../../../services/assessment.service';
 import { MaturityService } from '../../../services/maturity.service';

--- a/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.html
+++ b/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-appendix-cover/cmu-appendix-cover.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-appendix-cover/cmu-appendix-cover.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <img *ngIf="moduleName?.toUpperCase() == 'CRR'" src='assets/images/CRR/CRR_logo.png' class="row cmu-header-logo">
 <img *ngIf="moduleName?.toUpperCase() == 'IMR'" src='assets/images/IMR/IMR_logo.png' class="row cmu-header-logo">
 <div class="row align-items-center text-center">

--- a/CSETWebNg/src/app/reports/cmu/cmu-appendix-cover/cmu-appendix-cover.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-appendix-cover/cmu-appendix-cover.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/cmu/cmu-domain-compliance/cmu-domain-compliance.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-domain-compliance/cmu-domain-compliance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-domain-compliance/cmu-domain-compliance.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-domain-compliance/cmu-domain-compliance.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-domain-detail-table/cmu-domain-detail-table.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-goal-perf-stacked-bar/cmu-goal-perf-stacked-bar.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-goal-perf-stacked-bar/cmu-goal-perf-stacked-bar.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-goal-perf-stacked-bar/cmu-goal-perf-stacked-bar.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-goal-perf-stacked-bar/cmu-goal-perf-stacked-bar.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { CmuReportModel } from '../../../models/reports.model';
 import { CmuService } from '../../../services/cmu.service';

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-performance/cmu-nist-csf-cat-performance.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-performance/cmu-nist-csf-cat-performance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-performance/cmu-nist-csf-cat-performance.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-performance/cmu-nist-csf-cat-performance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-summary/cmu-nist-csf-cat-summary.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-summary/cmu-nist-csf-cat-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-summary/cmu-nist-csf-cat-summary.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-cat-summary/cmu-nist-csf-cat-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-summary/cmu-nist-csf-summary.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-summary/cmu-nist-csf-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-summary/cmu-nist-csf-summary.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-nist-csf-summary/cmu-nist-csf-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-other-remarks/cmu-other-remarks.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-other-remarks/cmu-other-remarks.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-other-remarks/cmu-other-remarks.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-other-remarks/cmu-other-remarks.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { AssessmentService } from '../../../services/assessment.service';
 

--- a/CSETWebNg/src/app/reports/cmu/cmu-performance/cmu-performance.component.html
+++ b/CSETWebNg/src/app/reports/cmu/cmu-performance/cmu-performance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cmu/cmu-performance/cmu-performance.component.ts
+++ b/CSETWebNg/src/app/reports/cmu/cmu-performance/cmu-performance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.html
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.html
+++ b/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/compare-report/compare-report.component.html
+++ b/CSETWebNg/src/app/reports/compare-report/compare-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/component-compliance/component-compliance.component.html
+++ b/CSETWebNg/src/app/reports/component-compliance/component-compliance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/component-compliance/component-compliance.component.ts
+++ b/CSETWebNg/src/app/reports/component-compliance/component-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/component-question-list/component-question-list.component.html
+++ b/CSETWebNg/src/app/reports/component-question-list/component-question-list.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/component-question-list/component-question-list.component.ts
+++ b/CSETWebNg/src/app/reports/component-question-list/component-question-list.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cover-page/cover-page.component.html
+++ b/CSETWebNg/src/app/reports/cover-page/cover-page.component.html
@@ -1,5 +1,5 @@
 <!----------------------
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights

--- a/CSETWebNg/src/app/reports/cover-page/cover-page.component.ts
+++ b/CSETWebNg/src/app/reports/cover-page/cover-page.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-bar-pie-stacked/cre-bar-pie-stacked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report-grid/cre-final-report-grid.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-goal-charts/cre-goal-charts.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-goal-charts/cre-goal-charts.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-goal-charts/cre-goal-charts.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-goal-charts/cre-goal-charts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-grouped-stacked-horizontal-chart/cre-grouped-stacked-horizontal-chart.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-grouped-stacked-horizontal-chart/cre-grouped-stacked-horizontal-chart.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-grouped-stacked-horizontal-chart/cre-grouped-stacked-horizontal-chart.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-grouped-stacked-horizontal-chart/cre-grouped-stacked-horizontal-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-explanations/cre-mil-explanations.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-pct-implemented/cre-mil-pct-implemented.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-pct-implemented/cre-mil-pct-implemented.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-pct-implemented/cre-mil-pct-implemented.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-pct-implemented/cre-mil-pct-implemented.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-yes-no/cre-mil-yes-no.component.html
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-yes-no/cre-mil-yes-no.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crePlus/cre-mil-yes-no/cre-mil-yes-no.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-mil-yes-no/cre-mil-yes-no.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-appendix-a-cover/crr-appendix-a-cover.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-appendix-a-cover/crr-appendix-a-cover.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-appendix-a-cover/crr-appendix-a-cover.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-appendix-a-cover/crr-appendix-a-cover.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-contact-information/crr-contact-information.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-contact-information/crr-contact-information.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-contact-information/crr-contact-information.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-contact-information/crr-contact-information.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet/crr-cover-sheet.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet/crr-cover-sheet.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet/crr-cover-sheet.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet/crr-cover-sheet.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet2/crr-cover-sheet2.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet2/crr-cover-sheet2.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet2/crr-cover-sheet2.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-cover-sheet2/crr-cover-sheet2.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-domain-detail/crr-domain-detail.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-domain-detail/crr-domain-detail.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-domain-detail/crr-domain-detail.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-domain-detail/crr-domain-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-intro-about/crr-intro-about.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-intro-about/crr-intro-about.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-intro-about/crr-intro-about.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-intro-about/crr-intro-about.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-main-toc/crr-main-toc.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-main-toc/crr-main-toc.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-main-toc/crr-main-toc.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-main-toc/crr-main-toc.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil-by-domain/crr-mil-by-domain.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil-by-domain/crr-mil-by-domain.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil-by-domain/crr-mil-by-domain.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil-by-domain/crr-mil-by-domain.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance-summary/crr-mil1-performance-summary.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance-summary/crr-mil1-performance-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance-summary/crr-mil1-performance-summary.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance-summary/crr-mil1-performance-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance/crr-mil1-performance.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance/crr-mil1-performance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance/crr-mil1-performance.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-mil1-performance/crr-mil1-performance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-performance/crr-nist-csf-cat-performance.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-performance/crr-nist-csf-cat-performance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-performance/crr-nist-csf-cat-performance.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-performance/crr-nist-csf-cat-performance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-summary/crr-nist-csf-cat-summary.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-summary/crr-nist-csf-cat-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-summary/crr-nist-csf-cat-summary.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-cat-summary/crr-nist-csf-cat-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-summary/crr-nist-csf-summary.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-summary/crr-nist-csf-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-summary/crr-nist-csf-summary.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-nist-csf-summary/crr-nist-csf-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-percentage-of-practices/crr-percentage-of-practices.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-percentage-of-practices/crr-percentage-of-practices.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-percentage-of-practices/crr-percentage-of-practices.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-percentage-of-practices/crr-percentage-of-practices.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-appendix-a/crr-performance-appendix-a.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-appendix-a/crr-performance-appendix-a.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-appendix-a/crr-performance-appendix-a.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-appendix-a/crr-performance-appendix-a.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-summary/crr-performance-summary.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-summary/crr-performance-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-summary/crr-performance-summary.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-performance-summary/crr-performance-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-resources/crr-resources.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-resources/crr-resources.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-resources/crr-resources.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-resources/crr-resources.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-side-toc/crr-side-toc.component.html
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-side-toc/crr-side-toc.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-side-toc/crr-side-toc.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-side-toc/crr-side-toc.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/document-library/document-library.component.html
+++ b/CSETWebNg/src/app/reports/document-library/document-library.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div *transloco="let t">
      <h1>
           {{t('reports.core.site summary.document library')}}

--- a/CSETWebNg/src/app/reports/document-library/document-library.component.ts
+++ b/CSETWebNg/src/app/reports/document-library/document-library.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.html
+++ b/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.spec.ts
+++ b/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm-flat/ng-flat-report.spec.ts
+++ b/CSETWebNg/src/app/reports/edm-flat/ng-flat-report.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm-flat/ng-flat-report.ts
+++ b/CSETWebNg/src/app/reports/edm-flat/ng-flat-report.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm-flat/x1.ts
+++ b/CSETWebNg/src/app/reports/edm-flat/x1.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/data.ts
+++ b/CSETWebNg/src/app/reports/edm/data.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-acronyms/edm-acronyms.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-acronyms/edm-acronyms.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-acronyms/edm-acronyms.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-acronyms/edm-acronyms.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-appendix-a-1/edm-appendix-a-1.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-appendix-a-1/edm-appendix-a-1.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-appendix-a-1/edm-appendix-a-1.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-appendix-a-1/edm-appendix-a-1.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-appendix-a-2/edm-appendix-a-2.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-appendix-a-2/edm-appendix-a-2.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-appendix-a-2/edm-appendix-a-2.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-appendix-a-2/edm-appendix-a-2.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend copy/edm-goal-question-legend.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend copy/edm-goal-question-legend.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend copy/edm-goal-question-legend.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend copy/edm-goal-question-legend.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend/edm-bar-chart-legend.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend/edm-bar-chart-legend.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend/edm-bar-chart-legend.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-bar-chart-legend/edm-bar-chart-legend.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-bar-chart.model.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-bar-chart.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-domain-detail/edm-domain-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-framework-summ/edm-framework-summ.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-framework-summ/edm-framework-summ.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-framework-summ/edm-framework-summ.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-framework-summ/edm-framework-summ.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-glossary/edm-glossary.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-glossary/edm-glossary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-glossary/edm-glossary.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-glossary/edm-glossary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-goal-question-summary/edm-goal-question-summary.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-goal-question-summary/edm-goal-question-summary.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-goal-question-summary/edm-goal-question-summary.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-goal-question-summary/edm-goal-question-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-intro-text/edm-intro-text.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-intro-text/edm-intro-text.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-intro-text/edm-intro-text.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-intro-text/edm-intro-text.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-legend-subquestions/edm-legend-subquestions.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-legend-subquestions/edm-legend-subquestions.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-legend-subquestions/edm-legend-subquestions.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-legend-subquestions/edm-legend-subquestions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-mil1/edm-perf-mil1.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-summ-all-mil/edm-perf-summ-all-mil.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-perf-summ-mil1/edm-perf-summ-mil1.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-summ-mil1/edm-perf-summ-mil1.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-perf-summ-mil1/edm-perf-summ-mil1.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-perf-summ-mil1/edm-perf-summ-mil1.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-source-references/edm-source-references.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-source-references/edm-source-references.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-source-references/edm-source-references.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-source-references/edm-source-references.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-summary-results/edm-summary-results.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm-toc/edm-toc.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm-toc/edm-toc.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/edm-toc/edm-toc.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm-toc/edm-toc.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm.component.html
+++ b/CSETWebNg/src/app/reports/edm/edm.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm.component.spec.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/edm.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/horizontal-bar-chart/horizontal-bar-chart.component.html
+++ b/CSETWebNg/src/app/reports/edm/horizontal-bar-chart/horizontal-bar-chart.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/horizontal-bar-chart/horizontal-bar-chart.component.ts
+++ b/CSETWebNg/src/app/reports/edm/horizontal-bar-chart/horizontal-bar-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.html
+++ b/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.spec.ts
+++ b/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.spec.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.ts
+++ b/CSETWebNg/src/app/reports/edm/mat-comments/mat-comments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/edm/triple-bar-chart/triple-bar-chart.component.html
+++ b/CSETWebNg/src/app/reports/edm/triple-bar-chart/triple-bar-chart.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/edm/triple-bar-chart/triple-bar-chart.component.ts
+++ b/CSETWebNg/src/app/reports/edm/triple-bar-chart/triple-bar-chart.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/eval-against-standards/eval-against-standards.component.html
+++ b/CSETWebNg/src/app/reports/eval-against-standards/eval-against-standards.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/eval-against-standards/eval-against-standards.component.ts
+++ b/CSETWebNg/src/app/reports/eval-against-standards/eval-against-standards.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.html
+++ b/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
+++ b/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/general/report-advisory/report-advisory.component.html
+++ b/CSETWebNg/src/app/reports/general/report-advisory/report-advisory.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/general/report-advisory/report-advisory.component.ts
+++ b/CSETWebNg/src/app/reports/general/report-advisory/report-advisory.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/general/report-disclaimer/report-disclaimer.component.html
+++ b/CSETWebNg/src/app/reports/general/report-disclaimer/report-disclaimer.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/general/report-disclaimer/report-disclaimer.component.ts
+++ b/CSETWebNg/src/app/reports/general/report-disclaimer/report-disclaimer.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.html
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/imr/imr-cover-sheet/imr-cover-sheet.component.html
+++ b/CSETWebNg/src/app/reports/imr/imr-cover-sheet/imr-cover-sheet.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div class="cover-page">
   <span class="d-flex justify-content-center">
     <img class="my-4" style="height: 18rem" src="assets/images/CISA_Logo_1831px.png" alt="cisa">

--- a/CSETWebNg/src/app/reports/imr/imr-cover-sheet/imr-cover-sheet.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-cover-sheet/imr-cover-sheet.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/imr/imr-intro-about/imr-intro-about.component.html
+++ b/CSETWebNg/src/app/reports/imr/imr-intro-about/imr-intro-about.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/imr/imr-intro-about/imr-intro-about.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-intro-about/imr-intro-about.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.html
+++ b/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/imr/imr-resources/imr-resources.component.html
+++ b/CSETWebNg/src/app/reports/imr/imr-resources/imr-resources.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/imr/imr-resources/imr-resources.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-resources/imr-resources.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/imr/imr-side-toc/imr-side-toc.component.html
+++ b/CSETWebNg/src/app/reports/imr/imr-side-toc/imr-side-toc.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/imr/imr-side-toc/imr-side-toc.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-side-toc/imr-side-toc.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component } from '@angular/core';
 
 @Component({

--- a/CSETWebNg/src/app/reports/info-block/info-block.component.html
+++ b/CSETWebNg/src/app/reports/info-block/info-block.component.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <div style="line-height: 150%;" class="me-4 text-start" *transloco="let t">
     <div>{{assessDetail?.assessmentName}}</div>
     <div>

--- a/CSETWebNg/src/app/reports/info-block/info-block.component.ts
+++ b/CSETWebNg/src/app/reports/info-block/info-block.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input, OnInit } from '@angular/core';
 import { ReportService } from '../../services/report.service';
 import { AssessmentDetail } from '../../models/assessment-info.model';

--- a/CSETWebNg/src/app/reports/logo-for-reports/logo-for-reports.component.html
+++ b/CSETWebNg/src/app/reports/logo-for-reports/logo-for-reports.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/logo-for-reports/logo-for-reports.component.ts
+++ b/CSETWebNg/src/app/reports/logo-for-reports/logo-for-reports.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/models/chart-results.model.ts
+++ b/CSETWebNg/src/app/reports/models/chart-results.model.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 export interface NameSeries {
      name: string,
      series: NameValue[]

--- a/CSETWebNg/src/app/reports/models/requirement-control.model.ts
+++ b/CSETWebNg/src/app/reports/models/requirement-control.model.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/guidance-block/guidance-block.component.html
+++ b/CSETWebNg/src/app/reports/module-content/guidance-block/guidance-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/guidance-block/guidance-block.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/guidance-block/guidance-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/model/mc-grouping/mc-grouping.component.html
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-grouping/mc-grouping.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/model/mc-grouping/mc-grouping.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-grouping/mc-grouping.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/model/mc-option/mc-option.component.html
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-option/mc-option.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/model/mc-option/mc-option.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-option/mc-option.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/model/mc-question/mc-question.component.html
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-question/mc-question.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/model/mc-question/mc-question.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/model/mc-question/mc-question.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/model/module-content-model/module-content-model.component.html
+++ b/CSETWebNg/src/app/reports/module-content/model/module-content-model/module-content-model.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/model/module-content-model/module-content-model.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/model/module-content-model/module-content-model.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.html
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/module-content-standard/module-content-standard.component.html
+++ b/CSETWebNg/src/app/reports/module-content/module-content-standard/module-content-standard.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/module-content-standard/module-content-standard.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-standard/module-content-standard.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/module-content/module-content.component.html
+++ b/CSETWebNg/src/app/reports/module-content/module-content/module-content.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/module-content/module-content.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content/module-content.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/references-block/references-block.component.html
+++ b/CSETWebNg/src/app/reports/module-content/references-block/references-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/references-block/references-block.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/references-block/references-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/module-content/related-q-block/related-q-block.component.html
+++ b/CSETWebNg/src/app/reports/module-content/related-q-block/related-q-block.component.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/app/reports/module-content/related-q-block/related-q-block.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/related-q-block/related-q-block.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/mvra/mvra-report.component.html
+++ b/CSETWebNg/src/app/reports/mvra/mvra-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
+++ b/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.html
+++ b/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
+++ b/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/overall-compliance/overall-compliance.component.html
+++ b/CSETWebNg/src/app/reports/overall-compliance/overall-compliance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/overall-compliance/overall-compliance.component.ts
+++ b/CSETWebNg/src/app/reports/overall-compliance/overall-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.html
+++ b/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.ts
+++ b/CSETWebNg/src/app/reports/pdf-reports/pdf-reports.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.html
+++ b/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
+++ b/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/question-comments/question-comments.component.html
+++ b/CSETWebNg/src/app/reports/question-comments/question-comments.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/question-comments/question-comments.component.ts
+++ b/CSETWebNg/src/app/reports/question-comments/question-comments.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/questions-marked-for-review/questions-marked-for-review.component.html
+++ b/CSETWebNg/src/app/reports/questions-marked-for-review/questions-marked-for-review.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/questions-marked-for-review/questions-marked-for-review.component.ts
+++ b/CSETWebNg/src/app/reports/questions-marked-for-review/questions-marked-for-review.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/questions-reviewed/questions-reviewed.component.html
+++ b/CSETWebNg/src/app/reports/questions-reviewed/questions-reviewed.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/questions-reviewed/questions-reviewed.component.ts
+++ b/CSETWebNg/src/app/reports/questions-reviewed/questions-reviewed.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/ranked-subject-areas/ranked-subject-areas.component.html
+++ b/CSETWebNg/src/app/reports/ranked-subject-areas/ranked-subject-areas.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/ranked-subject-areas/ranked-subject-areas.component.ts
+++ b/CSETWebNg/src/app/reports/ranked-subject-areas/ranked-subject-areas.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.html
+++ b/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sal-section/sal-section.component.html
+++ b/CSETWebNg/src/app/reports/sal-section/sal-section.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sal-section/sal-section.component.ts
+++ b/CSETWebNg/src/app/reports/sal-section/sal-section.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.html
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { AssessmentService } from '../../../services/assessment.service';

--- a/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.html
+++ b/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.ts
+++ b/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.html
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/site-detail/site-detail.component.html
+++ b/CSETWebNg/src/app/reports/site-detail/site-detail.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
+++ b/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/site-information/site-information.component.html
+++ b/CSETWebNg/src/app/reports/site-information/site-information.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/site-information/site-information.component.ts
+++ b/CSETWebNg/src/app/reports/site-information/site-information.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, Input } from '@angular/core';
 import { ReportService } from '../../services/report.service';
 import { AssessmentService } from '../../services/assessment.service';

--- a/CSETWebNg/src/app/reports/site-summary/site-summary.component.html
+++ b/CSETWebNg/src/app/reports/site-summary/site-summary.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
+++ b/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/standards-compliance/standards-compliance.component.html
+++ b/CSETWebNg/src/app/reports/standards-compliance/standards-compliance.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/standards-compliance/standards-compliance.component.ts
+++ b/CSETWebNg/src/app/reports/standards-compliance/standards-compliance.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/trend-report/trend-report.component.html
+++ b/CSETWebNg/src/app/reports/trend-report/trend-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
+++ b/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.html
+++ b/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.spec.ts
+++ b/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.spec.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TsaSdComponent } from './tsa-sd.component';

--- a/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.ts
+++ b/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { AssessmentService } from '../../services/assessment.service';

--- a/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.html
+++ b/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.html
+++ b/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/resource-library/resource-library.component.html
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.html
@@ -1,6 +1,6 @@
 <!-- --------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/resource-library/resource-library.component.ts
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.ts
@@ -1,5 +1,5 @@
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/routing/app-routing.module.ts
+++ b/CSETWebNg/src/app/routing/app-routing.module.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/routing/assessments-routing/assessment-routing.module.ts
+++ b/CSETWebNg/src/app/routing/assessments-routing/assessment-routing.module.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/routing/assessments-routing/assessment-tutorial.module.ts
+++ b/CSETWebNg/src/app/routing/assessments-routing/assessment-tutorial.module.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/routing/import-routing.module.ts
+++ b/CSETWebNg/src/app/routing/import-routing.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ImportComponent } from '../import/import.component';

--- a/CSETWebNg/src/app/routing/reports-routing/report-routing.module.ts
+++ b/CSETWebNg/src/app/routing/reports-routing/report-routing.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { KeyReportComponent } from '../../assessment/results/reports/key-report/key-report.component';

--- a/CSETWebNg/src/app/services/aggregation.service.ts
+++ b/CSETWebNg/src/app/services/aggregation.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/analysis.service.ts
+++ b/CSETWebNg/src/app/services/analysis.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/analytics.service.ts
+++ b/CSETWebNg/src/app/services/analytics.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ConfigService } from './config.service';

--- a/CSETWebNg/src/app/services/assess-compare-analytics.service.ts
+++ b/CSETWebNg/src/app/services/assess-compare-analytics.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/assessment.service.ts
+++ b/CSETWebNg/src/app/services/assessment.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/authentication.service.ts
+++ b/CSETWebNg/src/app/services/authentication.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/awwa.service.ts
+++ b/CSETWebNg/src/app/services/awwa.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable } from '@angular/core';
 
 /**

--- a/CSETWebNg/src/app/services/chart.service.ts
+++ b/CSETWebNg/src/app/services/chart.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cis-csi.service.ts
+++ b/CSETWebNg/src/app/services/cis-csi.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cis.service.ts
+++ b/CSETWebNg/src/app/services/cis.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cmmc-style.service.ts
+++ b/CSETWebNg/src/app/services/cmmc-style.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cmu.service.ts
+++ b/CSETWebNg/src/app/services/cmu.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/color.service.ts
+++ b/CSETWebNg/src/app/services/color.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/completion.service.ts
+++ b/CSETWebNg/src/app/services/completion.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/config.service.ts
+++ b/CSETWebNg/src/app/services/config.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/constants.service.ts
+++ b/CSETWebNg/src/app/services/constants.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/conversion.service.ts
+++ b/CSETWebNg/src/app/services/conversion.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cpg.service.ts
+++ b/CSETWebNg/src/app/services/cpg.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/cre.service.ts
+++ b/CSETWebNg/src/app/services/cre.service.ts
@@ -1,5 +1,5 @@
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/demographic-iod.service.ts
+++ b/CSETWebNg/src/app/services/demographic-iod.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/demographic.service.ts
+++ b/CSETWebNg/src/app/services/demographic.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/diagram.service.ts
+++ b/CSETWebNg/src/app/services/diagram.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/email.service.ts
+++ b/CSETWebNg/src/app/services/email.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/enable-feature.service.ts
+++ b/CSETWebNg/src/app/services/enable-feature.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/file-client.service.ts
+++ b/CSETWebNg/src/app/services/file-client.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/file-export.service.ts
+++ b/CSETWebNg/src/app/services/file-export.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/basic-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/basic-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/cmmc-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/cmmc-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/crr-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/crr-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/edm-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/edm-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/maturity-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/maturity-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/mvra-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/mvra-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/maturity-filtering/rra-filtering.service.ts
+++ b/CSETWebNg/src/app/services/filtering/maturity-filtering/rra-filtering.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/filtering/question-filter.service.ts
+++ b/CSETWebNg/src/app/services/filtering/question-filter.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/footer.service.ts
+++ b/CSETWebNg/src/app/services/footer.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable } from '@angular/core';
 
 @Injectable({

--- a/CSETWebNg/src/app/services/framework.service.ts
+++ b/CSETWebNg/src/app/services/framework.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/gallery.service.ts
+++ b/CSETWebNg/src/app/services/gallery.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/glossary.service.ts
+++ b/CSETWebNg/src/app/services/glossary.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/import-assessment.service.ts
+++ b/CSETWebNg/src/app/services/import-assessment.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/import-demographic.service.ts
+++ b/CSETWebNg/src/app/services/import-demographic.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/layout.service.ts
+++ b/CSETWebNg/src/app/services/layout.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/malcolm.service.ts
+++ b/CSETWebNg/src/app/services/malcolm.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { ConfigService } from './config.service';

--- a/CSETWebNg/src/app/services/maturity.service.ts
+++ b/CSETWebNg/src/app/services/maturity.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/navigation/nav-tree.service.ts
+++ b/CSETWebNg/src/app/services/navigation/nav-tree.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/navigation/navigation.service.ts
+++ b/CSETWebNg/src/app/services/navigation/navigation.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/navigation/page-visibility.service.ts
+++ b/CSETWebNg/src/app/services/navigation/page-visibility.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/navigationAggreg.service.ts
+++ b/CSETWebNg/src/app/services/navigationAggreg.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/observations.service.ts
+++ b/CSETWebNg/src/app/services/observations.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/questions-nested.service.ts
+++ b/CSETWebNg/src/app/services/questions-nested.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/questions.service.ts
+++ b/CSETWebNg/src/app/services/questions.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/report-analysis.service.ts
+++ b/CSETWebNg/src/app/services/report-analysis.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/report.service.ts
+++ b/CSETWebNg/src/app/services/report.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/required-document.service.ts
+++ b/CSETWebNg/src/app/services/required-document.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/resource-library.service.ts
+++ b/CSETWebNg/src/app/services/resource-library.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/rra-data.service.ts
+++ b/CSETWebNg/src/app/services/rra-data.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/sal.service.ts
+++ b/CSETWebNg/src/app/services/sal.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/selectable-groupings.service.ts
+++ b/CSETWebNg/src/app/services/selectable-groupings.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/set-builder.service.ts
+++ b/CSETWebNg/src/app/services/set-builder.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/ssg.service.ts
+++ b/CSETWebNg/src/app/services/ssg.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/standard.service.ts
+++ b/CSETWebNg/src/app/services/standard.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/storage.service.ts
+++ b/CSETWebNg/src/app/services/storage.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/theme.service.ts
+++ b/CSETWebNg/src/app/services/theme.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 
 import { Injectable, Renderer2, RendererFactory2, Inject } from '@angular/core';
 import { DOCUMENT } from '@angular/common';

--- a/CSETWebNg/src/app/services/tsa.service.ts
+++ b/CSETWebNg/src/app/services/tsa.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/user.service.ts
+++ b/CSETWebNg/src/app/services/user.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ConfigService } from './config.service';

--- a/CSETWebNg/src/app/services/utilities.service.ts
+++ b/CSETWebNg/src/app/services/utilities.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/vadr-data.service.ts
+++ b/CSETWebNg/src/app/services/vadr-data.service.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/app/services/version.service.ts
+++ b/CSETWebNg/src/app/services/version.service.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, of } from 'rxjs';

--- a/CSETWebNg/src/app/transloco-root.module.ts
+++ b/CSETWebNg/src/app/transloco-root.module.ts
@@ -1,3 +1,26 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+////////////////////////////////
 import { provideTransloco, TranslocoModule, Translation, TranslocoLoader } from '@jsverse/transloco';
 import { inject, Injectable, isDevMode, NgModule } from '@angular/core';
 import { HttpClient } from '@angular/common/http';

--- a/CSETWebNg/src/assets/app-startup-error.html
+++ b/CSETWebNg/src/assets/app-startup-error.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/assets/images/sals/svgtest.html
+++ b/CSETWebNg/src/assets/images/sals/svgtest.html
@@ -1,7 +1,7 @@
 <html lang="en">
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/assets/legalese/privacy.html
+++ b/CSETWebNg/src/assets/legalese/privacy.html
@@ -1,3 +1,25 @@
+<!----------------------
+
+  Copyright 2026 Battelle Energy Alliance, LLC
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+-------------------------->
 <html>
 <head>
     <style type="text/css">

--- a/CSETWebNg/src/assets/splash.html
+++ b/CSETWebNg/src/assets/splash.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/assets/splashCIE.html
+++ b/CSETWebNg/src/assets/splashCIE.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/assets/splashRENEW.html
+++ b/CSETWebNg/src/assets/splashRENEW.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/assets/splashTSA.html
+++ b/CSETWebNg/src/assets/splashTSA.html
@@ -1,6 +1,6 @@
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/environments/environment.prod.ts
+++ b/CSETWebNg/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/environments/environment.ts
+++ b/CSETWebNg/src/environments/environment.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/index.html
+++ b/CSETWebNg/src/index.html
@@ -1,6 +1,6 @@
 <!----------------------
 
-   Copyright 2025 Battelle Energy Alliance, LLC
+   Copyright 2026 Battelle Energy Alliance, LLC
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/main.ts
+++ b/CSETWebNg/src/main.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/polyfills.ts
+++ b/CSETWebNg/src/polyfills.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/test.ts
+++ b/CSETWebNg/src/test.ts
@@ -1,6 +1,6 @@
 ////////////////////////////////
 //
-//   Copyright 2025 Battelle Energy Alliance, LLC
+//   Copyright 2026 Battelle Energy Alliance, LLC
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/CSETWebNg/src/typings.d.ts
+++ b/CSETWebNg/src/typings.d.ts
@@ -1,6 +1,6 @@
 //////////////////////////////// 
 // 
-//   Copyright 2025 Battelle Energy Alliance, LLC  
+//   Copyright 2026 Battelle Energy Alliance, LLC  
 // 
 //  Permission is hereby granted, free of charge, to any person obtaining a copy 
 //  of this software and associated documentation files (the "Software"), to deal 

--- a/CSETWebNg/src/uploadAssessment.html
+++ b/CSETWebNg/src/uploadAssessment.html
@@ -1,7 +1,7 @@
 <html lang="en">
 <!---------------------- 
 
-   Copyright 2025 Battelle Energy Alliance, LLC  
+   Copyright 2026 Battelle Energy Alliance, LLC  
 
   Permission is hereby granted, free of charge, to any person obtaining a copy 
   of this software and associated documentation files (the "Software"), to deal 


### PR DESCRIPTION
## Summary
Updates all copyright headers from 2025 to 2026 (Battelle Energy Alliance, LLC) across the entire codebase. Adds missing copyright/license headers to files that lacked them.

## Commits
- `af1b6f3` chore(backend): update copyright year to 2026 in core layers
- `db361fe` chore(backend): update copyright year to 2026 in business layer
- `f377e69` chore(tests): update copyright year to 2026 in backend tests
- `60b7ad3` chore(frontend): update copyright year to 2026 in TypeScript files
- `6f63ad9` chore(frontend): update copyright year to 2026 in HTML templates

## Changes
- Updated copyright year from 2025 to 2026 in 1874 files across backend and frontend
- **Backend core layers** (558 files): DataLayer, Model, Interfaces, Constants, Enum, Helpers, CryptoBuffer, ExportCSV, DatabaseManager, Api, UpgradeLibrary
- **Backend business layer** (231 files): Assessment, Maturity, Analytics, Diagram, Question, Reports, Sal, and other business domain modules
- **Backend tests** (31 files): All CSETWebCore.Business.Tests project files
- **Frontend TypeScript** (619 files): Components, services, models, guards, directives, and helpers
- **Frontend HTML** (435 files): Angular templates and email templates with MIT license headers added

## Breaking Changes
None

## Test Plan
- [ ] Run `task build:backend` to verify backend compiles successfully
- [ ] Run `task test:backend` to verify all backend tests pass
- [ ] Run `npm run build` in CSETWebNg to verify frontend compiles
- [ ] Verify no functional changes — only copyright headers modified

## Release Notes
Updated copyright year to 2026 across all source files. Added missing copyright and license headers to files that previously lacked them.

## Checklist
- [ ] Tests pass locally
- [ ] No functional changes — copyright headers only
- [ ] Conventional commit format followed