### PR TITLE
Enhanced heat map generation for CPG2 OT/IT question structure

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Dashboard/DashboardChartBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Dashboard/DashboardChartBusinessTests.cs
@@ -6,7 +6,7 @@
 ////////////////////////////////
 using CSETWebCore.Business.Dashboard;
 using CSETWebCore.DataLayer.Model;
-using CSETWebCore.Helpers;
+using CSETWebCore.Business.Maturity;
 using CSETWebCore.Interfaces.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Moq;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationMaturityBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Aggregation/AggregationMaturityBusiness.cs
@@ -4,16 +4,17 @@
 // 
 // 
 //////////////////////////////// 
+using CSETWebCore.Business.Maturity.Configuration;
 using CSETWebCore.DataLayer.Model;
+using CSETWebCore.Model.Aggregation;
+using CSETWebCore.Model.Charting;
+using CSETWebCore.Model.Maturity;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Xml.Linq;
-using CSETWebCore.Model.Charting;
-using CSETWebCore.Model.Aggregation;
-using System;
-using CSETWebCore.Business.Maturity.Configuration;
-using CSETWebCore.Model.Maturity;
+
 
 namespace CSETWebCore.Business.Aggregation
 {
@@ -64,7 +65,7 @@ namespace CSETWebCore.Business.Aggregation
                 _context.FillEmptyMaturityQuestionsForAnalysis(assessmentId);
 
                 var options = new StructureOptions() { IncludeQuestionText = false, IncludeSupplemental = false };
-                var ms = new Helpers.MaturityStructureAsXml(assessmentId, _context, options);
+                var ms = new Maturity.MaturityStructureAsXml(assessmentId, _context, options);
                 var mx = ms.ToXDocument();
 
                 // ignore assessment if it doesn't have a maturity model

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
@@ -78,6 +78,7 @@ namespace CSETWebCore.Business.Maturity
                 FullTitle = grouping.Title,
                 GroupingId = grouping.GroupingId,
                 Color = "red",
+                RollupColor = "red",
                 Children = []
             };
 
@@ -92,13 +93,28 @@ namespace CSETWebCore.Business.Maturity
                         heatmapNode.Children.Add(childNode);
 
 
-                        // look for followups
+                        // include followups
                         foreach (var followup in question.Followups)
                         {
                             var followupNode = ConvertToHeatmapNode(followup, modelId);
                             if (followupNode != null)
                             {
                                 childNode.Children.Add(followupNode);
+                            }
+                        }
+
+
+                        // if the question is not answerable, give it a color for rollup purposes.
+                        if (!question.IsAnswerable)
+                        {
+                            if (childNode.Children.Any(x => !unansweredColors.Contains(x.Color)))
+                            {
+                                childNode.RollupColor = "yellow";
+                            }
+
+                            if (childNode.Children.All(x => x.Color == "green"))
+                            {
+                                childNode.RollupColor = "green";
                             }
                         }
                     }
@@ -118,16 +134,18 @@ namespace CSETWebCore.Business.Maturity
                 }
             }
 
+
+            // Color-grade the group based on its children (color or rollup color)
             if (heatmapNode.Children.Count > 0)
             {
                 // if not all red or unanswered, promote to yellow
-                if (heatmapNode.Children.Any(x => !unansweredColors.Contains(x.Color)))
+                if (heatmapNode.Children.Any(x => (!unansweredColors.Contains(x.Color) || !unansweredColors.Contains(x.RollupColor))))
                 {
                     heatmapNode.Color = "yellow";
                 }
 
                 // if all green, promote to green
-                if (heatmapNode.Children.All(x => x.Color == "green"))
+                if (heatmapNode.Children.All(x => x.Color == "green" || x.RollupColor == "green"))
                 {
                     heatmapNode.Color = "green";
                 }
@@ -152,7 +170,8 @@ namespace CSETWebCore.Business.Maturity
                 Title = "Q",
                 FullTitle = source.DisplayNumber,
                 QuestionId = source.QuestionId,
-                Children = []
+                Children = [],
+                RollupColor = "lightgray"
             };
 
             // customize the question title 
@@ -188,10 +207,11 @@ namespace CSETWebCore.Business.Maturity
 
 
         /// <summary>
-        /// Builds a "Q1" type label to keep the heatmap
-        /// segments short.  
+        /// Builds a short label that will fit in the chiclet.
         /// 
-        /// This may need to be expanded if used for other
+        /// Default is a "Q1" type label.  
+        /// 
+        /// This method can be enhanced if used for other
         /// models with different question naming conventions.
         /// </summary>
         private string CustomizeTitle(Model.Nested.Question q, int modelId)

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
@@ -6,8 +6,10 @@
 ////////////////////////////////
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
+using CSETWebCore.Model.Maturity;
 using System.Collections.Generic;
 using System.Linq;
+
 
 namespace CSETWebCore.Business.Maturity
 {
@@ -63,40 +65,52 @@ namespace CSETWebCore.Business.Maturity
         /// Converts a Grouping to a node.  It colors the
         /// node depending on the child Question scoring.
         /// </summary>
-        public HeatmapNode ConvertToHeatmapNode(Model.Nested.Grouping source, int modelId)
+        public HeatmapNode ConvertToHeatmapNode(Model.Nested.Grouping grouping, int modelId)
         {
-            if (source == null)
+            if (grouping == null)
             {
                 return null;
             }
 
             var heatmapNode = new HeatmapNode
             {
-                Title = source.Title,
-                FullTitle = source.Title,
-                GroupingId = source.GroupingId,
+                Title = grouping.Title,
+                FullTitle = grouping.Title,
+                GroupingId = grouping.GroupingId,
                 Color = "red",
                 Children = []
             };
 
-            if (source.Questions != null && source.Questions.Any())
+
+            if (grouping.Questions != null && grouping.Questions.Any())
             {
-                foreach (var question in source.Questions)
+                foreach (var question in grouping.Questions)
                 {
                     var childNode = ConvertToHeatmapNode(question, modelId);
                     if (childNode != null)
                     {
                         heatmapNode.Children.Add(childNode);
+
+
+                        // look for followups
+                        foreach (var followup in question.Followups)
+                        {
+                            var followupNode = ConvertToHeatmapNode(followup, modelId);
+                            if (followupNode != null)
+                            {
+                                childNode.Children.Add(followupNode);
+                            }
+                        }
                     }
                 }
             }
 
             // Recursively convert all groupings to children
-            if (source.Groupings != null && source.Groupings.Any())
+            if (grouping.Groupings != null && grouping.Groupings.Any())
             {
-                foreach (var grouping in source.Groupings)
+                foreach (var g in grouping.Groupings)
                 {
-                    var childNode = ConvertToHeatmapNode(grouping, modelId);
+                    var childNode = ConvertToHeatmapNode(g, modelId);
                     if (childNode != null)
                     {
                         heatmapNode.Children.Add(childNode);
@@ -111,6 +125,7 @@ namespace CSETWebCore.Business.Maturity
                 {
                     heatmapNode.Color = "yellow";
                 }
+
                 // if all green, promote to green
                 if (heatmapNode.Children.All(x => x.Color == "green"))
                 {
@@ -163,6 +178,11 @@ namespace CSETWebCore.Business.Maturity
                     break;
             }
 
+            if (!source.IsAnswerable)
+            {
+                heatmapNode.Color = "lightgray";
+            }
+
             return heatmapNode;
         }
 
@@ -172,12 +192,23 @@ namespace CSETWebCore.Business.Maturity
         /// segments short.  
         /// 
         /// This may need to be expanded if used for other
-        /// models with different question namging conventions.
+        /// models with different question naming conventions.
         /// </summary>
         private string CustomizeTitle(Model.Nested.Question q, int modelId)
         {
             if (modelId == Constants.Constants.Model_CPG2)
             {
+                // create labels for OT/IT followups in CPG2
+                if (q.IsOT)
+                {
+                    return "OT";
+                }
+                if (q.IsIT)
+                {
+                    return "IT";
+                }
+
+
                 // 5.A
                 return q.DisplayNumber;
             }
@@ -187,19 +218,5 @@ namespace CSETWebCore.Business.Maturity
             int dotIdx = q.DisplayNumber.LastIndexOf(".") + 1;
             return "Q" + q.DisplayNumber.Substring(dotIdx);
         }
-    }
-
-
-    public class HeatmapNode
-    {
-        public int GroupingId { get; set; }
-        public int QuestionId { get; set; }
-        public string Title { get; set; }
-        /// <summary>
-        /// The question's title as defined with no formatting
-        /// </summary>
-        public string FullTitle { get; set; }
-        public string Color { get; set; }
-        public List<HeatmapNode> Children { get; set; } = [];
     }
 }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityStructureAsXml.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityStructureAsXml.cs
@@ -12,7 +12,7 @@ using CSETWebCore.Model.Maturity;
 using CSETWebCore.Model.Question;
 using Microsoft.EntityFrameworkCore;
 
-namespace CSETWebCore.Helpers
+namespace CSETWebCore.Business.Maturity
 {
     /// <summary>
     /// The idea is a lightweight XDocument based 
@@ -28,7 +28,7 @@ namespace CSETWebCore.Helpers
 
         private XDocument xDoc { get; set; }
 
-        private AdditionalSupplemental _addlSuppl { get; set; }
+        private Helpers.AdditionalSupplemental _addlSuppl { get; set; }
 
 
         private bool _includeQuestionText = true;
@@ -58,7 +58,7 @@ namespace CSETWebCore.Helpers
             this._includeSupplemental = options.IncludeSupplemental;
             this._includeOtherText = options.IncludeOtherText;
 
-            this._addlSuppl = new AdditionalSupplemental(context);
+            this._addlSuppl = new Helpers.AdditionalSupplemental(context);
 
             LoadStructureAsXml();
         }
@@ -201,7 +201,7 @@ namespace CSETWebCore.Helpers
                     xQuestion.SetAttributeValue("displaynumber", myQ.Question_Title);
                     xQuestion.SetAttributeValue("answer", answer?.a.Answer_Text ?? "");
                     xQuestion.SetAttributeValue("comment", answer?.a.Comment ?? "");
-                    xQuestion.SetAttributeValue("isparentquestion", B2S(parentQuestionIDs.Contains(myQ.Mat_Question_Id)));
+                    xQuestion.SetAttributeValue("isparentquestion", parentQuestionIDs.Contains(myQ.Mat_Question_Id) ? "true" : "false");
 
                     if (_includeQuestionText)
                     {
@@ -288,18 +288,7 @@ namespace CSETWebCore.Helpers
         /// <returns></returns>
         public string ToJson()
         {
-            return CustomJsonWriter.Serialize(this.xDoc.Root);
-        }
-
-
-        /// <summary>
-        /// Bool-to-string
-        /// </summary>
-        /// <param name="b"></param>
-        /// <returns></returns>
-        public static string B2S(bool b)
-        {
-            return b ? "true" : "false";
+            return Helpers.CustomJsonWriter.Serialize(this.xDoc.Root);
         }
     }
 }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityStructureForModel.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/MaturityStructureForModel.cs
@@ -11,7 +11,9 @@ using System.Linq;
 using CSETWebCore.Model.Nested;
 using CSETWebCore.Model.Question;
 
-namespace CSETWebCore.Helpers
+
+
+namespace CSETWebCore.Business.Maturity
 {
     /// <summary>
     /// Represents a maturity model's questions
@@ -56,6 +58,9 @@ namespace CSETWebCore.Helpers
         private bool _includeText = true;
 
 
+        private QuestionScopeAnalyzer _questionScope = null;
+
+
         /// <summary>
         /// Returns a populated instance of the maturity grouping
         /// and question structure for a maturity model.
@@ -72,6 +77,21 @@ namespace CSETWebCore.Helpers
             _selectedGroupings = _context.GROUPING_SELECTION.Where(x => x.Assessment_Id == _assessmentId).Select(x => x.Grouping_Id).ToList();
 
             _context.FillEmptyMaturityQuestionsForAnalysis(assessmentId);
+
+
+            // Spin up the generic scope analyzer or a maturity model-specific one
+            _questionScope = new QuestionScopeAnalyzer(assessmentId);
+
+            // CPG 2.0
+            if (modelId == Constants.Constants.Model_CPG2)
+            {
+                var _techDomain = _context.DETAILS_DEMOGRAPHICS
+                    .Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "TECH-DOMAIN")
+                    .FirstOrDefault()?.StringValue ?? null;
+
+                _questionScope = new QuestionScopeAnalyzer(assessmentId, _context, _techDomain);
+            }
+
 
             LoadStructure();
         }
@@ -103,6 +123,7 @@ namespace CSETWebCore.Helpers
             allQuestions = _context.MATURITY_QUESTIONS
                 .Include(x => x.Maturity_Level)
                 .Include(x => x.MATURITY_REFERENCE_TEXT)
+                .Include(x => x.MATURITY_QUESTION_PROPS)
                 .Where(q =>
                 _modelId == q.Maturity_Model_Id).ToList();
 
@@ -151,7 +172,7 @@ namespace CSETWebCore.Helpers
                 var nodeName = System.Text.RegularExpressions
                     .Regex.Replace(sg.Type.Grouping_Type_Name, " ", "_");
 
-                var grouping = new Grouping()
+                var grouping = new Model.Nested.Grouping()
                 {
                     GroupType = nodeName,
                     Abbreviation = sg.Abbreviation,
@@ -170,9 +191,9 @@ namespace CSETWebCore.Helpers
                     ((ModelStructure)oParent).Groupings.Add(grouping);
                 }
 
-                if (oParent is Grouping)
+                if (oParent is Model.Nested.Grouping)
                 {
-                    ((Grouping)oParent).Groupings.Add(grouping);
+                    ((Model.Nested.Grouping)oParent).Groupings.Add(grouping);
                 }
 
 
@@ -186,7 +207,7 @@ namespace CSETWebCore.Helpers
                     var answer = AllAnswers
                         .FirstOrDefault(x => x.Question_Or_Requirement_Id == myQ.Mat_Question_Id && x.Mat_Option_Id == null);
 
-                    var question = new Question()
+                    var question = new Model.Nested.Question()
                     {
                         QuestionId = myQ.Mat_Question_Id,
                         Sequence = myQ.Sequence,
@@ -241,18 +262,25 @@ namespace CSETWebCore.Helpers
         /// <param name="allQuestions"></param>
         /// <param name="parentId"></param>
         /// <returns></returns>
-        private List<Question> GetFollowupQuestions(int parentId)
+        private List<Model.Nested.Question> GetFollowupQuestions(int parentId)
         {
-            var qList = new List<Question>();
+            var qList = new List<Model.Nested.Question>();
 
             var myQuestions = allQuestions.Where(x => x.Parent_Question_Id == parentId && x.Parent_Option_Id == null).ToList();
 
             foreach (var myQ in myQuestions.OrderBy(s => s.Sequence))
             {
+                // Before doing anything, see if the question should be included in the response
+                if (_questionScope.OutOfScopeQuestionIds.Contains(myQ.Mat_Question_Id))
+                {
+                    continue;
+                }
+
+
                 var answer = AllAnswers
                     .FirstOrDefault(x => x.Question_Or_Requirement_Id == myQ.Mat_Question_Id && x.Mat_Option_Id == null);
 
-                var question = new Question()
+                var question = new Model.Nested.Question()
                 {
                     QuestionId = myQ.Mat_Question_Id,
                     Sequence = myQ.Sequence,
@@ -267,6 +295,15 @@ namespace CSETWebCore.Helpers
                     Comment = answer?.Comment ?? "",
                     Options = GetOptions(myQ.Mat_Question_Id)
                 };
+
+                foreach (var p in myQ.MATURITY_QUESTION_PROPS)
+                {
+                    question.Properties.Add(new QuestionProp()
+                    {
+                        Name = p.PropertyName,
+                        Value = p.PropertyValue
+                    });
+                }
 
 
                 if (_includeText)
@@ -289,8 +326,9 @@ namespace CSETWebCore.Helpers
             return qList;
         }
 
+
         /// <summary>
-        /// Build options for a question.
+        /// Build answer options for a question.
         /// </summary>
         /// <param name="questionId"></param>
         /// <returns></returns>
@@ -317,7 +355,7 @@ namespace CSETWebCore.Helpers
 
                 foreach (var myQ in myQuestions.OrderBy(s => s.Sequence))
                 {
-                    var question = new Question()
+                    var question = new Model.Nested.Question()
                     {
                         QuestionId = myQ.Mat_Question_Id,
                         Sequence = myQ.Sequence,
@@ -352,6 +390,9 @@ namespace CSETWebCore.Helpers
         }
 
 
+        /// <summary>
+        /// 
+        /// </summary>
         private void GetReferences(int questionId, out List<ReferenceDocLink> sourceDocs,
                 out List<ReferenceDocLink> additionalDocs)
         {
@@ -361,17 +402,6 @@ namespace CSETWebCore.Helpers
 
             sourceDocs = s;
             additionalDocs = r;
-        }
-
-
-        /// <summary>
-        /// Bool-to-string
-        /// </summary>
-        /// <param name="b"></param>
-        /// <returns></returns>
-        public static string B2S(bool b)
-        {
-            return b ? "true" : "false";
         }
     }
 }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionScopeAnalyzer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/QuestionScopeAnalyzer.cs
@@ -14,6 +14,8 @@ namespace CSETWebCore.Business.Maturity
     /// <summary>
     /// Provides a way to exclude certain questions from a model
     /// based on current conditions. 
+    /// 
+    /// Example:  A CPG2 assessmenet might be OT only.  The IT followup questions are out of scope.
     /// </summary>
     public class QuestionScopeAnalyzer
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cis/CisModels.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Cis/CisModels.cs
@@ -5,6 +5,7 @@
 // 
 //////////////////////////////// 
 using System.Collections.Generic;
+using System.Linq;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Question;
 
@@ -91,6 +92,9 @@ namespace CSETWebCore.Model.Nested
         public List<ReferenceDocLink> SourceDocuments { get; set; }
         public List<ReferenceDocLink> AdditionalDocuments { get; set; }
 
+
+        public List<QuestionProp> Properties { get; set; } = [];
+
         public List<string> CSF { get; set; } = new List<string>();
         public List<TTPReference> TTP { get; set; } = new List<TTPReference>();
 
@@ -103,11 +107,30 @@ namespace CSETWebCore.Model.Nested
         public bool HasObservation { get; set; }
         public string Feedback { get; set; }
         public bool MarkForReview { get; set; }
-        public List<int> DocumentIds { get; set; } = new List<int>();
+        public List<int> DocumentIds { get; set; } = [];
 
         public string BaselineAnswerText { get; set; }
         public string BaselineAnswerMemo { get; set; }
+
+
+
+        public bool IsOT
+        {
+            get
+            {
+                return this.Properties.Any(x => x.Name == "IS-OT" && x.Value == "1");
+            }
+        }
+
+        public bool IsIT
+        {
+            get
+            {
+                return this.Properties.Any(x => x.Name == "IS-IT" && x.Value == "1");
+            }
+        }
     }
+
 
     public class Option
     {

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/HeatmapNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/HeatmapNode.cs
@@ -1,0 +1,32 @@
+﻿//////////////////////////////// 
+// 
+//   Copyright 2026 Battelle Energy Alliance, LLC  
+// 
+// 
+//////////////////////////////// 
+using System.Collections.Generic;
+
+
+namespace CSETWebCore.Model.Maturity
+{
+    /// <summary>
+    /// Represents a 'chiclet' on the heatmap display
+    /// </summary>
+    public class HeatmapNode
+    {
+        public int GroupingId { get; set; }
+
+        public int QuestionId { get; set; }
+
+        public string Title { get; set; }
+
+        /// <summary>
+        /// The question's title as defined with no formatting
+        /// </summary>
+        public string FullTitle { get; set; }
+
+        public string Color { get; set; }
+
+        public List<HeatmapNode> Children { get; set; } = [];
+    }
+}

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/HeatmapNode.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Maturity/HeatmapNode.cs
@@ -27,6 +27,12 @@ namespace CSETWebCore.Model.Maturity
 
         public string Color { get; set; }
 
+        /// <summary>
+        /// A non-displayed internal color for non-answered nodes to 
+        /// hold a rollup color value based on their children.
+        /// </summary>
+        public string RollupColor { get; set; }
+
         public List<HeatmapNode> Children { get; set; } = [];
     }
 }

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/HeatmapController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/HeatmapController.cs
@@ -4,15 +4,15 @@
 //
 //
 ////////////////////////////////
+using CSETWebCore.Business.Authorization;
 using CSETWebCore.Business.Maturity;
 using CSETWebCore.Business.Question;
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Interfaces.Reports;
 using Microsoft.AspNetCore.Mvc;
-using System.Linq;
 using System;
-using CSETWebCore.Business.Authorization;
+using System.Linq;
 
 namespace CSETWebCore.Api.Controllers
 {

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.html
@@ -21,94 +21,95 @@
   SOFTWARE.
 -------------------------->
 <div class="light-mode-wrapper" data-theme="light" data-bs-theme="light">
-<div class="report-body mb-5" *transloco="let t">
+    <div class="report-body mb-5" *transloco="let t">
 
-    <app-cover-page [assessDetail]="info" [title]="'reports.core.cpg.report title' | transloco | uppercase" />
-
-
-    <div class="page-break">
-        <h1>{{t('reports.core.cpg.report.performance summary')}}</h1>
-        <p>
-            {{t('reports.core.cpg.report.p.a')}}
-        </p>
-
-        <!-- CPG 1.1 chart/table -->
-        <ng-container *ngIf="modelId == 11">
-            <app-cpg-domain-summary [distrib]="answerDistribByDomain?.distrib"></app-cpg-domain-summary>
-
-            <p>{{t('reports.core.cpg.report.p.2')}}</p>
-            <app-cpg-domain-summary-table [data]="answerDistribByDomain?.distrib"></app-cpg-domain-summary-table>
-        </ng-container>
+        <app-cover-page [assessDetail]="info" [title]="'reports.core.cpg.report title' | transloco | uppercase" />
 
 
-        <!-- CPG 2.0 chart/table -->
-        <ng-container *ngIf="modelId == 21">
-            <div style="margin-top: 4rem; margin-bottom: 4rem"
-                *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
-                <h4>{{t('reports.core.cpg.ot')}}</h4>
-                <app-cpg-domain-summary [distrib]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary>
+        <div class="page-break">
+            <h1>{{t('reports.core.cpg.report.performance summary')}}</h1>
+            <p>
+                {{t('reports.core.cpg.report.p.a')}}
+            </p>
+
+            <!-- CPG 1.1 chart/table -->
+            <ng-container *ngIf="modelId == 11">
+                <app-cpg-domain-summary [distrib]="answerDistribByDomain?.distrib"></app-cpg-domain-summary>
 
                 <p>{{t('reports.core.cpg.report.p.2')}}</p>
-                <app-cpg-domain-summary-table [data]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary-table>
-            </div>
-
-            <div style="margin-top: 4rem; margin-bottom: 4rem"
-                *ngIf="techDomain == 'IT' || techDomain == 'OT+IT' || techDomain == null">
-                <h4>{{t('reports.core.cpg.it')}}</h4>
-                <app-cpg-domain-summary [distrib]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary>
-
-                <p>{{t('reports.core.cpg.report.p.2')}}</p>
-                <app-cpg-domain-summary-table [data]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary-table>
-            </div>
-        </ng-container>
+                <app-cpg-domain-summary-table [data]="answerDistribByDomain?.distrib"></app-cpg-domain-summary-table>
+            </ng-container>
 
 
-        <!-- SSG chart/table -->
-        <ng-container *ngFor="let dssg of answerDistribsSsg">
-            <div style="margin-top: 4rem; margin-bottom: 4rem">
-                <h4>{{t('reports.core.ssg.ssg1')}} - {{t(`reports.core.ssg.${dssg.modelId}`)}}</h4>
-                <app-cpg-domain-summary [distrib]="dssg.distribution.distrib"></app-cpg-domain-summary>
+            <!-- CPG 2.0 chart/table -->
+            <ng-container *ngIf="modelId == 21">
+                <div style="margin-top: 4rem; margin-bottom: 4rem"
+                    *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
+                    <h4>{{t('reports.core.cpg.ot')}}</h4>
+                    <app-cpg-domain-summary [distrib]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary>
 
-                <p>{{t('reports.core.cpg.report.p.2')}}</p>
-                <app-cpg-domain-summary-table [data]="dssg.distribution.distrib"></app-cpg-domain-summary-table>
-            </div>
-        </ng-container>
-    </div>
+                    <p>{{t('reports.core.cpg.report.p.2')}}</p>
+                    <app-cpg-domain-summary-table
+                        [data]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary-table>
+                </div>
+
+                <div style="margin-top: 4rem; margin-bottom: 4rem"
+                    *ngIf="techDomain == 'IT' || techDomain == 'OT+IT' || techDomain == null">
+                    <h4>{{t('reports.core.cpg.it')}}</h4>
+                    <app-cpg-domain-summary [distrib]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary>
+
+                    <p>{{t('reports.core.cpg.report.p.2')}}</p>
+                    <app-cpg-domain-summary-table
+                        [data]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary-table>
+                </div>
+            </ng-container>
 
 
-    <div class="page-break">
-        <h1>{{t('reports.core.cpg.report.security practice checklist')}}</h1>
-        <p class="mb-0">{{t('reports.core.cpg.report.p.b')}}</p>
+            <!-- SSG chart/table -->
+            <ng-container *ngFor="let dssg of answerDistribsSsg">
+                <div style="margin-top: 4rem; margin-bottom: 4rem">
+                    <h4>{{t('reports.core.ssg.ssg1')}} - {{t(`reports.core.ssg.${dssg.modelId}`)}}</h4>
+                    <app-cpg-domain-summary [distrib]="dssg.distribution.distrib"></app-cpg-domain-summary>
 
-        <app-cpg-practice-table [modelId]="modelId"></app-cpg-practice-table>
+                    <p>{{t('reports.core.cpg.report.p.2')}}</p>
+                    <app-cpg-domain-summary-table [data]="dssg.distribution.distrib"></app-cpg-domain-summary-table>
+                </div>
+            </ng-container>
+        </div>
 
-        <!-- heatmap - waiting for approval to enable this -->
-        <div *ngIf="true">
-            <h2 style="font-size: 1.4rem">{{ t('reports.core.heatmap.title') }}</h2>
-            <div class="d-flex flex-row">
-                <p style="width: 70%" class="me-4">
-                    {{ t('reports.core.heatmap.p1') }}
-                </p>
-                <app-key-display-1></app-key-display-1>
-            </div>
 
-            <div *ngFor="let d of heatmapModelCpg" class="mb-3">
-                <app-heatmap [scores]="[d]"></app-heatmap>
+        <div class="page-break">
+            <h1>{{t('reports.core.cpg.report.security practice checklist')}}</h1>
+            <p class="mb-0">{{t('reports.core.cpg.report.p.b')}}</p>
+
+            <app-cpg-practice-table [modelId]="modelId"></app-cpg-practice-table>
+
+            <!-- heatmap - waiting for approval to enable this -->
+            <div *ngIf="true">
+                <h2 style="font-size: 1.4rem">{{ t('reports.core.heatmap.title') }}</h2>
+                <div class="d-flex flex-row">
+                    <p style="width: 70%" class="me-4">
+                        {{ t('reports.core.heatmap.p1') }}
+                    </p>
+                    <app-key-display-1></app-key-display-1>
+                </div>
+
+                <div *ngFor="let d of heatmapModelCpg" class="mb-3">
+                    <app-heatmap [scores]="[d]"></app-heatmap>
+                </div>
             </div>
         </div>
-    </div>
 
 
-    <!-- a table for SSG answers, if applicable -->
-    <div *ngFor="let s of ssgBonusModelIds" [id]="'ssg-section-' + s">
-        <hr class="page-line">
-        <h1>{{t('reports.core.cpg.report.ssg.2')}} - {{t(`reports.core.ssg.${s}`)}}</h1>
-        <p>{{t('reports.core.cpg.report.ssg.1')}}</p>
+        <!-- a table for SSG answers, if applicable -->
+        <div *ngFor="let s of ssgBonusModelIds" [id]="'ssg-section-' + s">
+            <hr class="page-line">
+            <h1>{{t('reports.core.cpg.report.ssg.2')}} - {{t(`reports.core.ssg.${s}`)}}</h1>
+            <p>{{t('reports.core.cpg.report.ssg.1')}}</p>
 
-        <app-cpg-practice-table [ssgModelId]="s"></app-cpg-practice-table>
+            <app-cpg-practice-table [ssgModelId]="s"></app-cpg-practice-table>
 
-        <!-- heatmap - waiting for approval to enable this -->
-        <div *ngIf="true">
+            <!-- heat map -->
             <h2 style="font-size: 1.4rem">{{ t('reports.core.heatmap.title') }}</h2>
             <div class="d-flex flex-row">
                 <p style="width: 70%" class="me-4">
@@ -120,8 +121,8 @@
             <div *ngFor="let d of ssgHeatmaps[s]" class="mb-3">
                 <app-heatmap [scores]="[d]"></app-heatmap>
             </div>
+            
         </div>
-    </div>
 
-</div>
+    </div>
 </div>

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -143,10 +143,6 @@ export class CpgReportComponent implements OnInit {
       this.initCpg2();
 
       this.heatmapModelCpg = await firstValueFrom(this.reportSvc.getHeatmap(21));
-
-
-
-      console.log(this.heatmapModelCpg);
     }
 
     // SSG

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -143,6 +143,10 @@ export class CpgReportComponent implements OnInit {
       this.initCpg2();
 
       this.heatmapModelCpg = await firstValueFrom(this.reportSvc.getHeatmap(21));
+
+
+
+      console.log(this.heatmapModelCpg);
     }
 
     // SSG

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.html
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.html
@@ -27,8 +27,13 @@
     </div>
     <div class="goal-content">
       <div class="question-group" *ngFor="let q of goal.children">
-        <div class="score-cell" [ngClass]="q.scoreClass">
-          {{q.title}}
+        <div class="question-column">
+          <div class="score-cell" [ngClass]="q.scoreClass">
+            {{q.title}}
+          </div>
+          <div class="score-cell" [ngClass]="f.scoreClass" *ngFor="let f of q.children">
+            {{f.title}}
+          </div>
         </div>
       </div>
     </div>

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.scss
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.scss
@@ -34,6 +34,11 @@
   gap: 2px;
 }
 
+.question-column {
+  display: grid;
+  gap: 2px;
+}
+
 .score-cell {
   font-size: .6rem;
   padding: 3px;

--- a/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
+++ b/CSETWebNg/src/app/reports/heatmap/heatmap.component.ts
@@ -57,7 +57,8 @@ export class HeatmapComponent implements OnInit {
     'blue': 'blue-score',
     'green': 'green-score',
     'lightgray': 'light-gray-score',
-    'default': 'default-score'
+    'default': 'default-score',
+    'outline': 'outline-score'
   };
 
 

--- a/CSETWebNg/src/app/reports/reports.scss
+++ b/CSETWebNg/src/app/reports/reports.scss
@@ -1511,6 +1511,12 @@ h1.pageHeader {
   color: #fff;
 }
 
+.outline-score,
+.outline-score div {
+  border: 1px solid #999;
+  color: #000;
+}
+
 @media print {
   * {
     print-color-adjust: exact;


### PR DESCRIPTION
This pull request refactors and enhances the maturity model structure and heatmap generation logic. The main focus is on moving maturity-related classes from the `Helpers` namespace to a new `Business.Maturity` namespace, improving the heatmap coloring logic for better accuracy, and enhancing the handling of follow-up questions and question properties in maturity models.

**Refactoring and Namespace Updates:**

* Moved `MaturityStructureAsXml` and `MaturityStructureForModel` from the `Helpers` namespace to `Business.Maturity`, updating all references and file locations accordingly. [[1]](diffhunk://#diff-0cdc8793be054380f0b57e164eb63226df9e8122ea19a3520224ab23ca5e0198L15-R15) [[2]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L14-R16)
* Updated usages of `MaturityStructureAsXml` and related classes in files such as `AggregationMaturityBusiness.cs` and test files to reflect the new namespace. [[1]](diffhunk://#diff-52065d5cff3c37b2a85127f80f180f177e7fbafb12da42111f4da9f0bc0055f1R7-R17) [[2]](diffhunk://#diff-52065d5cff3c37b2a85127f80f180f177e7fbafb12da42111f4da9f0bc0055f1L67-R68) [[3]](diffhunk://#diff-4fd7ad98f693e1051c6601653bba56012dbcea463c50624fed8f19bf48eb58a4L9-R9)

**Heatmap Generation Enhancements:**

* Improved the `ConvertToHeatmapNode` method in `HeatmapGenerator.cs` to handle rollup colors, follow-up questions, and proper coloring for unanswered and out-of-scope questions. Added support for CPG2 model-specific labels and logic. [[1]](diffhunk://#diff-47c6814ee7b8ff24b01171b4cb43e107abf3baa2c9edc8e53d5607c9771df5adL66-R148) [[2]](diffhunk://#diff-47c6814ee7b8ff24b01171b4cb43e107abf3baa2c9edc8e53d5607c9771df5adL140-R174) [[3]](diffhunk://#diff-47c6814ee7b8ff24b01171b4cb43e107abf3baa2c9edc8e53d5607c9771df5adR200-R231)
* Refined the logic for coloring nodes and rollup colors based on child question status, including handling "green", "yellow", and "lightgray" states for better visualization. [[1]](diffhunk://#diff-47c6814ee7b8ff24b01171b4cb43e107abf3baa2c9edc8e53d5607c9771df5adL66-R148) [[2]](diffhunk://#diff-47c6814ee7b8ff24b01171b4cb43e107abf3baa2c9edc8e53d5607c9771df5adL140-R174)

**Maturity Model Structure Improvements:**

* Enhanced `MaturityStructureForModel` to use a `QuestionScopeAnalyzer` for filtering out-of-scope questions, especially for CPG2 models where technical domain filtering is required. [[1]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55R61-R63) [[2]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55R81-R95) [[3]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L244-R283)
* Updated the structure-building logic to include question properties from `MATURITY_QUESTION_PROPS` and attach them to each question, improving the data available for downstream processing. [[1]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55R126) [[2]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55R299-R307)

**Code Quality and Consistency:**

* Standardized naming and type usage for `Grouping` and `Question` to always use `Model.Nested` types, reducing ambiguity and potential bugs. [[1]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L154-R175) [[2]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L173-R196) [[3]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L189-R210) [[4]](diffhunk://#diff-ebd8d295ab1da2c0d2b9e84daff819cd01d083665bf0385194e7abb4e10aaa55L244-R283)
* Removed redundant helper methods (such as `B2S`) and updated serialization calls to use the correct helper classes. [[1]](diffhunk://#diff-0cdc8793be054380f0b57e164eb63226df9e8122ea19a3520224ab23ca5e0198L204-R204) [[2]](diffhunk://#diff-0cdc8793be054380f0b57e164eb63226df9e8122ea19a3520224ab23ca5e0198L291-R291)

These changes collectively modernize the maturity model infrastructure, improve maintainability, and enhance the accuracy and clarity of maturity model visualizations.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
