### PR TITLE
fix(module-builder): fix FK constraint violations when deleting copied set data

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Dashboard/DashboardChartBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Dashboard/DashboardChartBusiness.cs
@@ -6,7 +6,6 @@
 ////////////////////////////////
 using CSETWebCore.Business.Maturity;
 using CSETWebCore.DataLayer.Model;
-using CSETWebCore.Helpers;
 using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Model.Dashboard;
 using CSETWebCore.Model.Dashboard.BarCharts;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Import/DemographicsImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicIO/Import/DemographicsImportManager.cs
@@ -148,8 +148,8 @@ namespace CSETWebCore.Business.Demographic.Import
             await context.SaveChangesAsync();
 
             // import all sectors - but only take the first one if not in assessor workflow
-            foreach (var jSector in isAssessorWorkflow 
-                ? model.jASSESSMENT_SECTOR_SUBSECTOR 
+            foreach (var jSector in isAssessorWorkflow
+                ? model.jASSESSMENT_SECTOR_SUBSECTOR
                 : model.jASSESSMENT_SECTOR_SUBSECTOR.Take(1))
             {
                 var dbASS = new ASSESSMENT_SECTOR_SUBSECTOR()

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/C2M2Business.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/C2M2Business.cs
@@ -4,7 +4,6 @@
 // 
 // 
 //////////////////////////////// 
-using CSETWebCore.Helpers;
 using CSETWebCore.Model.C2M2.Charts;
 using CSETWebCore.Model.C2M2.Tables;
 using System.Collections.Generic;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -235,18 +235,34 @@ namespace CSETWebCore.Business.ModuleBuilder
                 throw new InvalidOperationException("Destination set is not a custom set. Standard sets cannot be modified.");
             }
 
-            // Delete from all related tables in the correct order
+            // Phase 1: Remove question/requirement mappings and custom questions.
+            // Child tables (NQS, RQS, RS) must be deleted before NEW_QUESTION
+            // because the FK from NEW_QUESTION to USCH uses NO_ACTION at the DB
+            // level and ClientSetNull in EF Core — neither cascades automatically.
             _context.REQUIREMENT_SETS.RemoveRange(
                 _context.REQUIREMENT_SETS.Where(rs => rs.Set_Name == setName));
 
             _context.REQUIREMENT_QUESTIONS_SETS.RemoveRange(
                 _context.REQUIREMENT_QUESTIONS_SETS.Where(rqs => rqs.Set_Name == setName));
 
-            _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.RemoveRange(
-                _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.Where(usch => usch.Set_Name == setName));
-
             _context.NEW_QUESTION_SETS.RemoveRange(
                 _context.NEW_QUESTION_SETS.Where(nqs => nqs.Set_Name == setName));
+
+            _context.NEW_QUESTION.RemoveRange(
+                _context.NEW_QUESTION.Where(nq => nq.Original_Set_Name == setName));
+
+            _context.SaveChanges();
+
+            // Phase 2: Delete USCH rows for this set, but only those not still
+            // referenced by a NEW_QUESTION from another set. GetHeadingPair uses
+            // FirstOrDefault without filtering by Set_Name, so a question in a
+            // different set may have been assigned a Heading_Pair_Id that belongs
+            // to this set's USCH. Skipping those avoids the NO_ACTION FK violation.
+            var safeToDeleteUsch = _context.UNIVERSAL_SUB_CATEGORY_HEADINGS
+                .Where(usch => usch.Set_Name == setName)
+                .Where(usch => !_context.NEW_QUESTION.Any(nq => nq.Heading_Pair_Id == usch.Heading_Pair_Id))
+                .ToList();
+            _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.RemoveRange(safeToDeleteUsch);
 
             _context.NEW_REQUIREMENT.RemoveRange(
                 _context.NEW_REQUIREMENT.Where(nr => nr.Original_Set_Name == setName));
@@ -374,6 +390,7 @@ namespace CSETWebCore.Business.ModuleBuilder
 
             if (newRequirements.Count > 0)
             {
+                _context.Database.ExecuteSqlRaw("DBCC CHECKIDENT('NEW_REQUIREMENT', RESEED)");
                 _context.NEW_REQUIREMENT.AddRange(newRequirements);
                 _context.SaveChanges();
             }


### PR DESCRIPTION
## Summary
Fixes foreign key constraint violations in the Module Builder's `DeleteCopiedSetData` method that occurred when deleting custom set data due to incorrect deletion ordering and shared `UNIVERSAL_SUB_CATEGORY_HEADINGS` references.

## Changes
- Reordered deletion to remove `NEW_QUESTION` rows before `UNIVERSAL_SUB_CATEGORY_HEADINGS` to respect FK dependencies
- Split deletion into two phases with an intermediate `SaveChanges()` to flush child-table removals before parent-table cleanup
- Added safety check to only delete USCH rows not still referenced by questions from other sets (avoids NO_ACTION FK violations)
- Added `DBCC CHECKIDENT` reseed for `NEW_REQUIREMENT` before bulk insert to prevent identity collisions
- Removed unused `CSETWebCore.Helpers` imports from `DashboardChartBusiness` and `C2M2Business`
- Fixed trailing whitespace in `DemographicsImportManager`

## Breaking Changes
None

## Test Plan
- [ ] Clone a base standard into a new custom set in Module Builder
- [ ] Modify the custom set, then re-clone a different base standard into it (triggers delete + re-copy)
- [ ] Verify no FK constraint errors are thrown during the delete phase
- [ ] Verify the custom set contains the correct questions and requirements after re-cloning
- [ ] Run `task test:backend` to verify all unit tests pass

## Release Notes
Fixed a crash in the Module Builder when re-cloning a base standard into an existing custom set. The delete operation now correctly handles shared heading references across sets.

## Checklist
- [ ] Tests pass locally (`task test:backend`)
- [ ] Linting passes (`task lint:backend`)
- [ ] Breaking changes documented
- [x] Conventional commit format followed