### PR TITLE
fix(docker): add platform specification for MSSQL container

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -46,6 +46,7 @@ services:
     container_name: cset-mssql-dev
     hostname: mssql
     image: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
+    platform: linux/amd64
     restart: unless-stopped
     env_file:
       - .env

--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,7 @@ services:
     container_name: cset-mssql
     hostname: mssql
     image: "mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04"
+    platform: linux/amd64
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
## Summary
Adds explicit `platform: linux/amd64` to the MSSQL service definition in both Docker Compose files, ensuring SQL Server containers work correctly on ARM-based hosts (e.g., Apple Silicon Macs).

## Changes
- Added `platform: linux/amd64` to `mssql` service in `compose.yml`
- Added `platform: linux/amd64` to `mssql` service in `compose.dev.yml`

## Breaking Changes
None

## Test Plan
- [ ] Run `task up:dev` on an ARM-based Mac and verify the MSSQL container starts successfully
- [ ] Run `task up:dev` on an x86 host and verify no regression
- [ ] Verify database connectivity after container startup

## Release Notes
Docker Compose configurations now explicitly specify the `linux/amd64` platform for the SQL Server container, fixing startup issues on ARM-based hosts such as Apple Silicon Macs.

## Checklist
- [x] Conventional commit format followed
- [ ] Tested on ARM host
- [ ] Tested on x86 host