### PR TITLE
chore(import): remove dead Monaco worker URL configuration

### DIFF
--- a/CSETWebNg/src/app/import/import.component.ts
+++ b/CSETWebNg/src/app/import/import.component.ts
@@ -346,8 +346,6 @@ export class ImportComponent implements OnInit, OnDestroy {
     if (this.uploader === undefined) {
       this.initializeUploader();
     }
-    this.configureMonacoEnvironment();
-
     // Subscribe to theme changes to update Monaco editor theme
     this.subscriptions.push(
       this.themeSvc.theme$.subscribe(() => {
@@ -367,26 +365,6 @@ export class ImportComponent implements OnInit, OnDestroy {
     }
   }
 
-  private configureMonacoEnvironment() {
-    // Configure Monaco Editor environment to load assets from correct path
-    (window as any).MonacoEnvironment = {
-      getWorkerUrl: function (moduleId: string, label: string) {
-        if (label === 'json') {
-          return './assets/monaco/vs/language/json/jsonWorker.js';
-        }
-        if (label === 'css' || label === 'scss' || label === 'less') {
-          return './assets/monaco/vs/language/css/cssWorker.js';
-        }
-        if (label === 'html' || label === 'handlebars' || label === 'razor') {
-          return './assets/monaco/vs/language/html/htmlWorker.js';
-        }
-        if (label === 'typescript' || label === 'javascript') {
-          return './assets/monaco/vs/language/typescript/tsWorker.js';
-        }
-        return './assets/monaco/vs/base/worker/workerMain.js';
-      }
-    };
-  }
 
   private initializeUploader() {
     this.referenceUrl = this.configSvc.refDocUrl;


### PR DESCRIPTION
## Summary
Removes the dead `configureMonacoEnvironment()` method from `ImportComponent` that referenced Monaco Editor worker files (`jsonWorker.js`, `cssWorker.js`, etc.) which no longer exist in the installed version of `monaco-editor`.

## Changes
- Removed `configureMonacoEnvironment()` method and its call in `ngOnInit`
- The method set `window.MonacoEnvironment.getWorkerUrl` with paths like `vs/language/json/jsonWorker.js`
- These files do not exist — the current `monaco-editor` version uses hashed filenames under `min/vs/assets/` (e.g., `json.worker-DKiEKt88.js`) and resolves workers internally

## Breaking Changes
None

## Test Plan
- [ ] Verify Monaco Editor still loads and functions correctly in the import component
- [ ] Confirm JSON syntax highlighting works in the import code editor
- [ ] No console errors related to Monaco worker loading

## Release Notes
Removed non-functional Monaco Editor worker configuration that referenced files no longer present in the current version of the library.

## Checklist
- [ ] Tests pass locally (`task test`)
- [ ] Linting passes (`task lint`)
- [ ] Conventional commit format followed