### PR TITLE
More fixes to demographics/crit svc pages

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_12_4_0_4_to_13_0_0_0_Upgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/CSET_12_4_0_4_to_13_0_0_0_Upgrade.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace CSETWebCore.Business.AssessmentIO.Import;
 
-internal class CSET_12_4_0_4_to_12_4_0_5_Upgrade : ICSETJSONFileUpgrade
+internal class CSET_12_4_0_4_to_13_0_0_0_Upgrade : ICSETJSONFileUpgrade
 {
     /// <summary>
     ///     this is the string we will be upgrading to

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportUpgradeManager.cs
@@ -35,8 +35,8 @@ namespace CSETWebCore.Business.AssessmentIO.Import
             upgraders.Add("10.2.0.0", new CSET_10_2_0_to_12_4_0_4_Upgrade());
             upgraders.Add("10.3.0.0", new CSET_10_2_0_to_12_4_0_4_Upgrade());
             upgraders.Add("12.4.0.3", new CSET_10_2_0_to_12_4_0_4_Upgrade());
-            upgraders.Add("12.4.0.4", new CSET_12_4_0_4_to_12_4_0_5_Upgrade());
-            upgraders.Add("12.4.0.5", null);
+            upgraders.Add("12.4.0.4", new CSET_12_4_0_4_to_13_0_0_0_Upgrade());
+            upgraders.Add("13.0.0.0", null);
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicBusiness.cs
@@ -49,16 +49,17 @@ namespace CSETWebCore.Business.Demographic
 
             var extBiz = new DemographicExtBusiness(_context);
             demographics.CisaRegion = (int?)extBiz.GetX(assessmentId, "CISA-REGION");
-            demographics.OrgPointOfContact = (int?)extBiz.GetX(assessmentId, "ORG-POC");
             demographics.SelfAssessment = ((bool?)extBiz.GetX(assessmentId, "SELF-ASSESS")) ?? false;
             demographics.TechDomain = extBiz.GetX(assessmentId, "TECH-DOMAIN")?.ToString();
             demographics.CriticalService = (string)extBiz.GetX(assessmentId, "CRIT-SERVICE");
-            demographics.PointOfContact = (int?)extBiz.GetX(assessmentId, "POC");
+            demographics.CriticalServiceDescription = (string)extBiz.GetX(assessmentId, "CRIT-SERVICE-DESC");
+            demographics.CriticalServicePointOfContact = (int?)extBiz.GetX(assessmentId, "CRIT-SERVICE-POC");
             demographics.Agency = (string)extBiz.GetX(assessmentId, "BUSINESS-UNIT");
             demographics.FacilitatorId = (int?)extBiz.GetX(assessmentId, "FACILITATOR");
             demographics.IsScoped = (bool?)extBiz.GetX(assessmentId, "SCOPED");
             demographics.OrganizationName = (string)extBiz.GetX(assessmentId, "ORG-NAME");
             demographics.OrganizationType = (int?)extBiz.GetX(assessmentId, "ORG-TYPE");
+            demographics.OrgPointOfContact = (int?)extBiz.GetX(assessmentId, "ORG-POC");
             demographics.Acknowledgement = (bool?)extBiz.GetX(assessmentId, Constants.Constants.ACK_SECTOR_UPDATED_PPD21) ?? false;
 
             var assetId = (int?)extBiz.GetX(assessmentId, "ASSET-VALUE");
@@ -126,16 +127,17 @@ namespace CSETWebCore.Business.Demographic
             // Store values in DETAILS-DEMOGRAPHICS
             var extBiz = new DemographicExtBusiness(_context);
             extBiz.SaveX(demographics.AssessmentId, "CISA-REGION", demographics.CisaRegion);
+            extBiz.SaveX(demographics.AssessmentId, "ORG-NAME", demographics.OrganizationName);
+            extBiz.SaveX(demographics.AssessmentId, "ORG-TYPE", demographics.OrganizationType == 0 ? null : demographics.OrganizationType);
             extBiz.SaveX(demographics.AssessmentId, "ORG-POC", demographics.OrgPointOfContact);
             extBiz.SaveX(demographics.AssessmentId, "SELF-ASSESS", demographics.SelfAssessment);
             extBiz.SaveX(demographics.AssessmentId, "TECH-DOMAIN", demographics.TechDomain);
-            extBiz.SaveX(demographics.AssessmentId, "ORG-NAME", demographics.OrganizationName);
             extBiz.SaveX(demographics.AssessmentId, "BUSINESS-UNIT", demographics.Agency);
-            extBiz.SaveX(demographics.AssessmentId, "ORG-TYPE", demographics.OrganizationType == 0 ? null : demographics.OrganizationType);
             extBiz.SaveX(demographics.AssessmentId, "SECTOR-DIRECTIVE", demographics.SectorDirective);
             extBiz.SaveX(demographics.AssessmentId, "SCOPED", demographics.IsScoped);
-            extBiz.SaveX(demographics.AssessmentId, "POC", demographics.PointOfContact == 0 ? null : demographics.PointOfContact);
             extBiz.SaveX(demographics.AssessmentId, "CRIT-SERVICE", demographics.CriticalService);
+            extBiz.SaveX(demographics.AssessmentId, "CRIT-SERVICE-DESC", demographics.CriticalServiceDescription);
+            extBiz.SaveX(demographics.AssessmentId, "CRIT-SERVICE-POC", demographics.CriticalServicePointOfContact == 0 ? null : demographics.CriticalServicePointOfContact);
             extBiz.SaveX(demographics.AssessmentId, "FACILITATOR", demographics.FacilitatorId == 0 ? null : demographics.FacilitatorId);
             extBiz.SaveX(demographics.AssessmentId, "ASSET-VALUE", assetValue?.OptionValue);
             extBiz.SaveX(demographics.AssessmentId, "SIZE", assetSize?.OptionValue);

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Model/Assessment/Demographics.cs
@@ -52,7 +52,8 @@ namespace CSETWebCore.Model.Assessment
 
         public bool SelfAssessment { get; set; }
         public string? CriticalService { get; set; }
-        public int? PointOfContact { get; set; }
+        public string? CriticalServiceDescription { get; set; }
+        public int? CriticalServicePointOfContact { get; set; }
         public bool? IsScoped { get; set; }
         public bool? Acknowledgement { get; set; }
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
@@ -139,7 +139,7 @@
             <div class="col">
                 <label class="form-label" for="critSvcPointOfContact">{{t('crit svc poc')}}</label>
                 <select class="form-select" id="critSvcPointOfContact" tabindex="0" name="critSvcPointOfContact"
-                    [(ngModel)]="demographicData.pointOfContact" (ngModelChange)="update($event)">
+                    [(ngModel)]="demographicData.criticalServicePointOfContact" (ngModelChange)="update($event)">
                     <option [ngValue]="null">-- {{t('select')}} --</option>
                     <option *ngFor="let contact of contacts" [ngValue]="contact.assessmentContactId">
                         {{contact.firstName}}

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
@@ -87,14 +87,14 @@
 
   <!-- #3 -->
   <div class="mb-5">
-    <label for="totalAnnualRevenue" *ngIf="demographicData.organizationType == 1" class="form-label"> What is the total
-      annual revenue for your organization?
+    <label for="totalAnnualRevenue" *ngIf="demographicData.organizationType == 1" class="form-label">
+      What is the total annual revenue for your organization?
     </label>
     <label for="totalAnnualRevenue" *ngIf="demographicData.organizationType != 1" class="form-label">
       What is the total annual funding for your governmental organization or agency?
     </label>
 
-    <select class="form-select" id="totalAnnualRevenue"
+    <select [ngClass]="{ 'is-invalid' : !demographicData.annualRevenue }" class="form-select" id="totalAnnualRevenue"
       tabindex="0" name="totalAnnualRevenue" [(ngModel)]="demographicData.annualRevenue"
       (ngModelChange)="update($event)">
       <option [ngValue]="null">-- {{t('select')}} --</option>

--- a/CSETWebNg/src/app/assessment/prepare/csi/critical-service.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/csi/critical-service.component.html
@@ -41,16 +41,16 @@
     </div>
 
     <div class="mb-4">
-      <label class="form-label" for="critSvcPointOfContact">Critical Service Point of
-        Contact</label>
+      <label class="form-label" for="critSvcPointOfContact">Critical Service Point of Contact</label>
       <select class="form-select" id="critSvcPointOfContact" tabindex="0" name="critSvcPointOfContact"
-        (change)="updateDemographics()" [(ngModel)]="demographics.pointOfContact">
+        (change)="updateDemographics()" [(ngModel)]="demographics.criticalServicePointOfContact">
         <option [ngValue]="null">-- {{t('select')}} --</option>
         <option *ngFor="let contact of contacts" [ngValue]="contact.assessmentContactId">
           {{ contact.firstName }} {{ contact.lastName }}
         </option>
       </select>
     </div>
+
 
     <!-- #6 -->
     <div class="mb-4">

--- a/CSETWebNg/src/app/assessment/prepare/csi/critical-service.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/csi/critical-service.component.ts
@@ -28,6 +28,9 @@ import { DemographicIodService } from '../../../services/demographic-iod.service
 import { CsiServiceDemographic } from '../../../models/csi.model';
 import { CsiService } from '../../../services/cis-csi.service';
 import { ConfigService } from '../../../services/config.service';
+import { AssessmentContactsResponse } from '../../../models/assessment-info.model';
+import { AssessmentService } from '../../../services/assessment.service';
+import { User } from '../../../models/user.model';
 
 @Component({
   selector: 'app-csi',
@@ -47,9 +50,11 @@ export class CriticalServiceComponent implements OnInit {
 
   csiServiceDemographic: CsiServiceDemographic = {};
   serviceComposition: any = {};
+  contacts: User[];
 
 
   constructor(
+    public assessSvc: AssessmentService,
     public configSvc: ConfigService,
     public navSvc: NavigationService,
     public demoSvc: DemographicService,
@@ -71,6 +76,8 @@ export class CriticalServiceComponent implements OnInit {
     this.csiSvc.getCsiServiceDemographic().subscribe((result: CsiServiceDemographic) => {
       this.csiServiceDemographic = result;
     });
+
+    this.refreshContacts();
   }
 
   updateServiceComp(): void {
@@ -83,6 +90,14 @@ export class CriticalServiceComponent implements OnInit {
 
   updateDemographicsIod() {
     this.iodDemoSvc.updateDemographic(this.iodDemographics);
+  }
+
+  refreshContacts() {
+    if (this.assessSvc.id()) {
+      this.assessSvc.getAssessmentContacts().then((data: AssessmentContactsResponse) => {
+        this.contacts = data.contactList;
+      });
+    }
   }
 
 

--- a/CSETWebNg/src/app/models/assessment-info.model.ts
+++ b/CSETWebNg/src/app/models/assessment-info.model.ts
@@ -147,7 +147,7 @@ export interface Demographic {
     criticalService?: string;
 
     // Critical Service POC
-    pointOfContact?: number;
+    criticalServicePointOfContact?: number;
 
     // An EDM-only field
     isScoped?: boolean;

--- a/CSETWebNg/src/assets/i18n/en.json
+++ b/CSETWebNg/src/assets/i18n/en.json
@@ -40,8 +40,8 @@
   "tech domain": {
     "label": "Technology Domain for Assessment",
     "select": "Select Technology Domain",
-    "ot": "Cross-Sector Goals - Operational Technology (OT)",
-    "it": "Cross-Sector Goals - Information Technology (IT)",
+    "ot": "Operational Technology (OT)",
+    "it": "Information Technology (IT)",
     "ot+it": "Both OT and IT"
   },
   "crit svc poc": "Critical Service Point of Contact",


### PR DESCRIPTION
This pull request updates the handling of demographic information related to critical services, specifically how the "Critical Service Point of Contact" is stored and referenced throughout the codebase. It introduces new fields for critical service descriptions and point of contact, updates model and UI bindings, and modifies the upgrade path for assessment data versions.

**Demographics model and data handling updates:**

* Replaced the generic `pointOfContact` field with `criticalServicePointOfContact` in the `Demographics` model and related TypeScript interfaces, and added a new `criticalServiceDescription` field. All code now saves and retrieves these new fields instead of the old one. [[1]](diffhunk://#diff-62c5e6f867829b13b276578546594568fbf3545b910d9b8ceae159b6700b7a58L52-R62) [[2]](diffhunk://#diff-62c5e6f867829b13b276578546594568fbf3545b910d9b8ceae159b6700b7a58R130-R140) [[3]](diffhunk://#diff-406cbf86740cd5ff0da5a7a3dbadbab5fce5d67e4ef6c2d5e23c70d6b9b4d843L55-R56) [[4]](diffhunk://#diff-37f4f8bb2f18a727a6f3a86890f5e90d3b87ffa9b5613a4bdc4f86f9608ba092L150-R150)
* Updated Angular components and templates to use `criticalServicePointOfContact` instead of `pointOfContact` for critical service demographic data, ensuring form fields and data bindings are consistent. [[1]](diffhunk://#diff-882f17effcfab62f0b0ecb90df14b502877479b56995555cc679389f859c50c0L142-R142) [[2]](diffhunk://#diff-c605fa8bd8ec9923411dbc92b3cd3c873d9d2c695c671a6faa117b1dce98256bL44-R54)

**UI and validation improvements:**

* Improved the annual revenue/funding select field in the demographics UI to show validation errors when not selected, enhancing user experience.
* Updated labels and select options for technology domains in the English translation file for clarity.

**Assessment data upgrade path:**

* Renamed and updated the assessment data upgrader class to handle upgrades from version `12.4.0.4` directly to `13.0.0.0`, and updated the upgrade manager to reflect this change. [[1]](diffhunk://#diff-708a092cb9b11df4c9868ce490c7cec635e1237395a7a00217eb74f70ed2475fL15-R15) [[2]](diffhunk://#diff-5c29f18cc65d614850001a8c090e55c479570336fb8607f2a62bcd43b69b8eb0L38-R39)

**Angular service and component enhancements:**

* Modified the `CriticalServiceComponent` to load and refresh the list of assessment contacts for use as possible critical service points of contact. [[1]](diffhunk://#diff-2c15a03ef2b0c85c56738bb425dfff1c3467622349c0f8ef7c3a56bf2318c98eR31-R33) [[2]](diffhunk://#diff-2c15a03ef2b0c85c56738bb425dfff1c3467622349c0f8ef7c3a56bf2318c98eR53-R57) [[3]](diffhunk://#diff-2c15a03ef2b0c85c56738bb425dfff1c3467622349c0f8ef7c3a56bf2318c98eR79-R80) [[4]](diffhunk://#diff-2c15a03ef2b0c85c56738bb425dfff1c3467622349c0f8ef7c3a56bf2318c98eR95-R102)

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
