### PR TITLE
Change display order of IT and OT sub-questions in CPG2

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -112,8 +112,8 @@
         <select class="form-select" id="techDomain" tabindex="0" name="techDomain" (change)="updateDemographics()"
           [(ngModel)]="demographics.techDomain">
           <option [ngValue]="null">-- {{t('tech domain.select')}} --</option>
-          <option value="OT">{{t('tech domain.ot')}}</option>
           <option value="IT">{{t('tech domain.it')}}</option>
+          <option value="OT">{{t('tech domain.ot')}}</option>
           <option value="OT+IT">{{t('tech domain.ot+it')}}</option>
         </select>
       </div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -90,8 +90,8 @@
             <select class="form-select" id="techDomain" tabindex="0" name="techDomain" (change)="updateDemographics()"
                 [(ngModel)]="demographics.techDomain">
                 <option [ngValue]="null">-- {{t('tech domain.select')}} --</option>
-                <option value="OT">{{t('tech domain.ot')}}</option>
                 <option value="IT">{{t('tech domain.it')}}</option>
+                <option value="OT">{{t('tech domain.ot')}}</option>
                 <option value="OT+IT">{{t('tech domain.ot+it')}}</option>
             </select>
         </div>

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practice-table/cpg-practice-table.component.html
@@ -89,14 +89,15 @@
                     </td>
                     <!-- CPG 2.0 has child answers for OT/IT -->
                     <td *ngIf="model?.modelId == 21">
-                        <div *ngIf="model.techDomain == 'OT' || model.techDomain == 'OT+IT' || model.techDomain == null" class="mb-3">
-                            <div class="sub-header-1">{{t('reports.core.cpg.ot-abbrev')}}</div>
-                            <app-cpg-answer-block [answer]="findChild(d, q, 'OT')?.answer"></app-cpg-answer-block>
-                        </div>
-
-                        <div *ngIf="model.techDomain == 'IT' || model.techDomain == 'OT+IT' || model.techDomain == null" class="mb-3">
+                        <div *ngIf="model.techDomain == 'IT' || model.techDomain == 'OT+IT' || model.techDomain == null"
+                            class="mb-3">
                             <div class="sub-header-1">{{t('reports.core.cpg.it-abbrev')}}</div>
                             <app-cpg-answer-block [answer]="findChild(d, q, 'IT')?.answer"></app-cpg-answer-block>
+                        </div>
+                        <div *ngIf="model.techDomain == 'OT' || model.techDomain == 'OT+IT' || model.techDomain == null"
+                            class="mb-3">
+                            <div class="sub-header-1">{{t('reports.core.cpg.ot-abbrev')}}</div>
+                            <app-cpg-answer-block [answer]="findChild(d, q, 'OT')?.answer"></app-cpg-answer-block>
                         </div>
                     </td>
                     <td>

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-score/cpg-score.component.html
@@ -21,10 +21,10 @@
   SOFTWARE. 
 -------------------------->
 <div class="border border-secondary p-3 rounded mb-4 w-fit">
-     <div *ngIf="TECH_DOMAIN_OT.includes(techDomain)">
-          Operation Technology (OT): {{otScore | number:'1.1-2'}}%
-     </div>
      <div *ngIf="TECH_DOMAIN_IT.includes(techDomain)">
           Information Technology (IT): {{itScore | number:'1.1-2'}}%
+     </div>
+     <div *ngIf="TECH_DOMAIN_OT.includes(techDomain)">
+          Operation Technology (OT): {{otScore | number:'1.1-2'}}%
      </div>
 </div>

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-summary/cpg-summary.component.html
@@ -50,20 +50,20 @@
 
         <!-- CPG 2.0 chart/table -->
         <ng-container *ngIf="modelId == 21">
-            <div class="mb-5" *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
-                <h4>{{t('reports.core.cpg.ot')}}</h4>
-                <app-cpg-domain-summary [distrib]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary>
-
-                <p>{{t('reports.core.cpg.report.p.2')}}</p>
-                <app-cpg-domain-summary-table [data]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary-table>
-            </div>
-
             <div class="mb-5" *ngIf="techDomain == 'IT' || techDomain == 'OT+IT' || techDomain == null">
                 <h4>{{t('reports.core.cpg.it')}}</h4>
                 <app-cpg-domain-summary [distrib]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary>
 
                 <p>{{t('reports.core.cpg.report.p.2')}}</p>
                 <app-cpg-domain-summary-table [data]="answerDistribByDomainIt?.distrib"></app-cpg-domain-summary-table>
+            </div>
+
+             <div class="mb-5" *ngIf="techDomain == 'OT' || techDomain == 'OT+IT' || techDomain == null">
+                <h4>{{t('reports.core.cpg.ot')}}</h4>
+                <app-cpg-domain-summary [distrib]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary>
+
+                <p>{{t('reports.core.cpg.report.p.2')}}</p>
+                <app-cpg-domain-summary-table [data]="answerDistribByDomainOt?.distrib"></app-cpg-domain-summary-table>
             </div>
         </ng-container>
 


### PR DESCRIPTION
Display IT first

This pull request primarily reorganizes the display order of OT (Operational Technology) and IT (Information Technology) related sections and options in various assessment and results components. The main goal is to present IT before OT in dropdowns and summary/report sections for consistency and improved user experience. No logic or functionality changes were made—only the order of UI elements was adjusted.

**UI Consistency and Display Order Adjustments:**

* Changed the order of options in the technology domain dropdowns to list IT before OT in both `assessment-detail.component.html` and `assessment-config-iod.component.html`. [[1]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL93-R94) [[2]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L115-R116)
* Reordered the display of IT and OT answer blocks in the CPG practice table so that IT is shown before OT.
* Adjusted the order of IT and OT score displays in the CPG score component to show IT before OT.
* Moved the IT summary section above the OT summary section in the CPG summary component for model 21 assessments.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
