### PR TITLE
feat: add CISA-only JSON export uploaded indicator to assessment header

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -241,6 +241,53 @@ namespace CSETWebCore.Api.Controllers
 
 
         /// <summary>
+        /// Gets whether the JSON export has been uploaded to the external CISA system.
+        /// </summary>
+        [HttpGet]
+        [Route("api/demographics/json-uploaded")]
+        public async Task<IActionResult> GetJsonUploaded()
+        {
+            int assessmentId = _token.AssessmentForUser();
+            var row = await _context.DETAILS_DEMOGRAPHICS
+                .AsNoTracking()
+                .Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "JSON_UPLOADED")
+                .FirstOrDefaultAsync();
+            return Ok(row?.BoolValue ?? false);
+        }
+
+
+        /// <summary>
+        /// Persists whether the JSON export has been uploaded to the external CISA system.
+        /// </summary>
+        [HttpPost]
+        [Route("api/demographics/json-uploaded")]
+        public async Task<IActionResult> PostJsonUploaded([FromBody] bool value)
+        {
+            int assessmentId = _token.AssessmentForUser();
+            var row = await _context.DETAILS_DEMOGRAPHICS
+                .Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "JSON_UPLOADED")
+                .FirstOrDefaultAsync();
+
+            if (row == null)
+            {
+                _context.DETAILS_DEMOGRAPHICS.Add(new DETAILS_DEMOGRAPHICS
+                {
+                    Assessment_Id = assessmentId,
+                    DataItemName = "JSON_UPLOADED",
+                    BoolValue = value
+                });
+            }
+            else
+            {
+                row.BoolValue = value;
+            }
+
+            await _context.SaveChangesAsync();
+            return Ok();
+        }
+
+
+        /// <summary>
         /// Delete a sector/subsector record from the assessment.
         /// </summary>
         /// <param name="seq"></param>

--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -147,6 +147,19 @@
               <!-- Divider -->
               <div class="tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
+              <!-- CISA-only JSON upload indicator -->
+              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:flex tw:items-center tw:gap-2">
+                <input type="checkbox"
+                       id="jsonUploadedSwitch"
+                       class="tw:toggle"
+                       [(ngModel)]="jsonUploaded"
+                       (change)="saveJsonUploaded()">
+                <label for="jsonUploadedSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap">JSON export uploaded</label>
+              </div>
+
+              <!-- Divider -->
+              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
+
               <div class="tw:flex tw:items-center tw:gap-3">
                 <label for="assessmentDoneSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap">Mark Assessment Done</label>
                 <input

--- a/CSETWebNg/src/app/assessment/assessment.component.ts
+++ b/CSETWebNg/src/app/assessment/assessment.component.ts
@@ -108,6 +108,7 @@ export class AssessmentComponent implements OnInit {
 
    assessmentAlias = this.tSvc.translate('titles.assessment');
    assessment: AssessmentDetail = {};
+   jsonUploaded: boolean = false;
 
    @Output() navSelected = new EventEmitter<string>();
    isSet: boolean;
@@ -130,7 +131,7 @@ export class AssessmentComponent implements OnInit {
       public navTreeSvc: NavTreeService,
       public layoutSvc: LayoutService,
       public tSvc: TranslocoService,
-      private configSvc: ConfigService,
+      public configSvc: ConfigService,
       private appRef: ApplicationRef,
       private completionSvc: CompletionService,
       private demoSvc: DemographicService,
@@ -181,6 +182,12 @@ export class AssessmentComponent implements OnInit {
          this.getAssessmentDetail();
          this.loadCompletionStats();
 
+         if (this.configSvc.userIsCisaAssessor) {
+            this.demoSvc.getJsonUploaded().subscribe((value: boolean) => {
+               this.jsonUploaded = value;
+            });
+         }
+
          this.assessSvc.completionRefreshRequested$.subscribe((stats) => {
             if (stats) {
                this.completedQuestions = stats.completedCount;
@@ -209,6 +216,10 @@ export class AssessmentComponent implements OnInit {
          this.assessment = data;
          this.assessSvc.assessment = data;
       });
+   }
+
+   saveJsonUploaded() {
+      this.demoSvc.saveJsonUploaded(this.jsonUploaded).subscribe();
    }
 
    setAssessmentDone() {

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -107,7 +107,7 @@ export class AssessmentDemographicsComponent implements OnInit {
         if (this.demoSvc.id) {
             this.getDemographics();
         }
-        
+
         this.refreshContacts();
         this.getOrganizationTypes();
     }

--- a/CSETWebNg/src/app/services/demographic.service.ts
+++ b/CSETWebNg/src/app/services/demographic.service.ts
@@ -109,6 +109,14 @@ export class DemographicService {
       });
   }
 
+  getJsonUploaded() {
+    return this.http.get<boolean>(this.apiUrl + 'json-uploaded');
+  }
+
+  saveJsonUploaded(value: boolean) {
+    return this.http.post(this.apiUrl + 'json-uploaded', value, headers);
+  }
+
   importDemographics(demographic: Demographic) {
     return this.http.post(this.apiUrl + 'import', JSON.stringify(demographic), headers)
       .subscribe(() => { });


### PR DESCRIPTION
## Summary
Adds a CISA assessor-only toggle to the assessment header bar that lets a CISA assessor record whether the assessment's JSON export has been uploaded to the external CISA system. The toggle persists immediately and is invisible to non-CISA-assessor users.

## Commits
- `f3d9ac5` feat(demographics): add JSON_UPLOADED indicator endpoints
- `8e28b15` feat(assessment): add CISA-only JSON export uploaded indicator

## Changes
- Added `GET /api/demographics/json-uploaded` — reads `DETAILS_DEMOGRAPHICS` where `DataItemName = 'JSON_UPLOADED'`, returns `BoolValue ?? false`
- Added `POST /api/demographics/json-uploaded` — upserts the `DETAILS_DEMOGRAPHICS` row with the new boolean value
- Added `getJsonUploaded()` and `saveJsonUploaded(value)` methods to `DemographicService`
- Added `jsonUploaded` state and `saveJsonUploaded()` handler to `AssessmentComponent`
- Rendered a DaisyUI toggle labelled **"JSON export uploaded"** in the assessment header bar, inline between the progress bar and the "Mark Assessment Done" toggle, with a conditional divider — both gated by `*ngIf="configSvc.userIsCisaAssessor"`
- No database migration required: uses the existing `DETAILS_DEMOGRAPHICS` EAV table

## Breaking Changes
None

## Test Plan
- [ ] Log in as a CISA assessor — toggle should appear in the assessment header between the progress bar and "Mark Assessment Done"
- [ ] Check the toggle — verify the value is persisted (reload the page and confirm it remains checked)
- [ ] Uncheck the toggle — verify `BoolValue` is updated to `false`
- [ ] Log in as a non-CISA assessor — toggle should not be visible
- [ ] Confirm `GET /api/demographics/json-uploaded` returns `false` for a new assessment with no stored row

## Related Issues
N/A

## Release Notes
CISA assessors can now mark whether an assessment's JSON export has been uploaded to the external CISA system directly from the assessment header bar. The indicator is hidden from all other user roles.

## Checklist
- [ ] Tests pass locally (`task test:backend`)
- [ ] Linting passes (`task lint:backend`)
- [ ] No schema migration needed (EAV pattern reused)
- [ ] Conventional commit format followed