### PR TITLE
feat(my-assessments): add CISA-only JSON uploaded checkbox in assessment list

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
@@ -222,6 +222,18 @@ namespace CSETWebCore.Business.Assessment
                 x.lastName = result.LastName;
             });
 
+            // Batch-fetch JSON_UPLOADED flags for all assessments in one query
+            var assessmentIds = list.Select(x => x.AssessmentId).ToList();
+            var jsonUploadedMap = _context.DETAILS_DEMOGRAPHICS
+                .AsNoTracking()
+                .Where(x => assessmentIds.Contains(x.Assessment_Id) && x.DataItemName == "JSON_UPLOADED")
+                .ToDictionary(x => x.Assessment_Id, x => x.BoolValue ?? false);
+
+            list.ForEach(x =>
+            {
+                x.JsonUploaded = jsonUploadedMap.TryGetValue(x.AssessmentId, out bool val) ? val : false;
+            });
+
             return list;
         }
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/usp_Assessments_For_UserResult.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.DataLayer/Model/usp_Assessments_For_UserResult.cs
@@ -30,5 +30,6 @@ namespace CSETWebCore.DataLayer.Model
         public bool? Done { get; set; }
         public bool? Favorite { get; set; }
         public int? UserId { get; set; }
+        public bool JsonUploaded { get; set; }
     }
 }

--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -21,97 +21,148 @@
   SOFTWARE.
 -------------------------->
 <div *transloco="let t" class="assess-component d-flex flex-column justify-content-start flex-11a">
-
   <!-- Tabs -->
   <div class="mt-0 ps-0 d-flex flex-column justify-content-start flex-00a">
     <div class="d-flex justify-content-start flex-11a">
       <ul class="nav d-flex justify-content-start flex-00a bgc-secondary questions-tab-border">
-        <li class="d-flex align-items-center flex-00a" [ngClass]="{'nav-tab':expandNav, 'nav-tab-collapsed':!expandNav}"
-          class.active="false" (click)="toggleNav()">
-          <button class="icon-button-light mx-2 d-flex justify-content-start align-items-center flex-00a"
-            [matTooltip]="t('tooltip.nav collapse')" matTooltipPosition="below" [aria-label]="t('tooltip.nav collapse')">
-            <span class="fs-base-1 m-0"
-              [ngClass]="{'cset-icons-chevron-left':expandNav, 'cset-icons-chevron-right':!expandNav}"></span>
+        <li
+          class="d-flex align-items-center flex-00a"
+          [ngClass]="{ 'nav-tab': expandNav, 'nav-tab-collapsed': !expandNav }"
+          class.active="false"
+          (click)="toggleNav()"
+        >
+          <button
+            class="icon-button-light mx-2 d-flex justify-content-start align-items-center flex-00a"
+            [matTooltip]="t('tooltip.nav collapse')"
+            matTooltipPosition="below"
+            [aria-label]="t('tooltip.nav collapse')"
+          >
+            <span
+              class="fs-base-1 m-0"
+              [ngClass]="{ 'cset-icons-chevron-left': expandNav, 'cset-icons-chevron-right': !expandNav }"
+            ></span>
           </button>
         </li>
       </ul>
       <ul class="nav nav-tabs d-flex flex-11a questions-tab-border">
-        <li class="d-flex align-items-center flex-00a" [class.active]="assessSvc.currentTab === 'prepare'"
-          (click)="setTab('prepare')">
-
-          <button class="btn bgc-trans d-flex align-items-center flex-00a h-100" data-toggle="tab"
-            (click)="navSvc.navDirect('phase-prepare')" tabindex="0">
+        <li
+          class="d-flex align-items-center flex-00a"
+          [class.active]="assessSvc.currentTab === 'prepare'"
+          (click)="setTab('prepare')"
+        >
+          <button
+            class="btn bgc-trans d-flex align-items-center flex-00a h-100"
+            data-toggle="tab"
+            (click)="navSvc.navDirect('phase-prepare')"
+            tabindex="0"
+          >
             <span class="tab-icon cset-icons-clipboard-pencil" id="prepareIcon"></span>
-            <span class="nav-tab-text ms-2">{{t('titles.prepare')}}</span>
+            <span class="nav-tab-text ms-2">{{ t('titles.prepare') }}</span>
           </button>
         </li>
-        <li class="d-flex align-items-center flex-00a" [class.active]="assessSvc.currentTab === 'questions'"
-          (click)="setTab('questions')">
-          <button class="btn bgc-trans d-flex align-items-center flex-00a h-100" data-toggle="tab"
-            (click)="navSvc.navDirect('phase-assessment')" tabindex="0">
+        <li
+          class="d-flex align-items-center flex-00a"
+          [class.active]="assessSvc.currentTab === 'questions'"
+          (click)="setTab('questions')"
+        >
+          <button
+            class="btn bgc-trans d-flex align-items-center flex-00a h-100"
+            data-toggle="tab"
+            (click)="navSvc.navDirect('phase-assessment')"
+            tabindex="0"
+          >
             <span class="tab-icon cset-icons-question-mark" id="questionsIcon"></span>
-            <span class="nav-tab-text ms-2">{{assessmentAlias}}</span>
+            <span class="nav-tab-text ms-2">{{ assessmentAlias }}</span>
           </button>
         </li>
-        <li class="d-flex align-items-center flex-00a" [class.active]="assessSvc.currentTab === 'results'"
-          (click)="setTab('results')">
-          <button class="btn bgc-trans d-flex align-items-center flex-00a h-100" data-toggle="tab"
-            (click)="navSvc.navDirect('phase-results')" tabindex="0">
+        <li
+          class="d-flex align-items-center flex-00a"
+          [class.active]="assessSvc.currentTab === 'results'"
+          (click)="setTab('results')"
+        >
+          <button
+            class="btn bgc-trans d-flex align-items-center flex-00a h-100"
+            data-toggle="tab"
+            (click)="navSvc.navDirect('phase-results')"
+            tabindex="0"
+          >
             <span class="tab-icon cset-icons-results"></span>
-            <span class="nav-tab-text ms-2">{{t('titles.results')}}</span>
+            <span class="nav-tab-text ms-2">{{ t('titles.results') }}</span>
           </button>
         </li>
       </ul>
-
     </div>
-
   </div>
 
   <!-- Content -->
   <div class="side-nav-container p-0 d-flex flex-column justify-content-start flex-11a">
     <mat-sidenav-container id="sidenav-container" class="d-flex flex-column flex-11a">
       <mat-sidenav [mode]="sidenavMode()" [opened]="expandNav" id="sidenav" (openedChange)="openStateChange($event)">
-        
-        <button class="btn btn-home" (click)="goHome()" [matTooltip]="t('tooltip.view assessment list')" [aria-label]="t('tooltip.view assessment list')">
+        <button
+          class="btn btn-home"
+          (click)="goHome()"
+          [matTooltip]="t('tooltip.view assessment list')"
+          [aria-label]="t('tooltip.view assessment list')"
+        >
           <i class="fas fa-home"></i>
         </button>
 
-        <mat-tree [dataSource]="navTreeSvc?.dataSource" [treeControl]="navTreeSvc?.tocControl" style="padding-right:10px" class="mb-5">
-
+        <mat-tree
+          [dataSource]="navTreeSvc?.dataSource"
+          [treeControl]="navTreeSvc?.tocControl"
+          style="padding-right: 10px"
+          class="mb-5"
+        >
           <!-- leaf nodes -->
-          <mat-nested-tree-node *matTreeNodeDef="let node; when: !navTreeSvc?.hasNestedChild" [hidden]="!node.visible" class="ms-1"
-            [class.current-node]="node?.isCurrent" [id]="node?.value">
+          <mat-nested-tree-node
+            *matTreeNodeDef="let node; when: !navTreeSvc?.hasNestedChild"
+            [hidden]="!node.visible"
+            class="ms-1"
+            [class.current-node]="node?.isCurrent"
+            [id]="node?.value"
+          >
             <!--isNodeDisabled(node?.disabled) ||-->
-            <button (click)="selectNavItem(node?.value)" [disabled]="!(node?.enabled)" tabindex="0"
-              class="btn btn-link no-underline ta-left tw:w-full tw:py-2 tw:px-3 tw:rounded-md tw:text-left tw:dark:text-text-primary tw:border tw:border-transparent tw:hover:border-[#6b7280]  tw:transition-colors"
-                    [ngClass]="{
-               'tw:dark:bg-cset-secondary tw:dark:text-white tw:dark:hover:bg-cset-secondary-hover': node?.isCurrent,
-                'tw:opacity-50 tw:cursor-not-allowed': !(node?.enabled)
-              }">
+            <button
+              (click)="selectNavItem(node?.value)"
+              [disabled]="!node?.enabled"
+              tabindex="0"
+              class="btn btn-link no-underline ta-left tw:w-full tw:py-2 tw:px-3 tw:rounded-md tw:text-left tw:dark:text-text-primary tw:border tw:border-transparent tw:hover:border-[#6b7280] tw:transition-colors"
+              [ngClass]="{
+                'tw:dark:bg-cset-secondary tw:dark:text-white tw:dark:hover:bg-cset-secondary-hover': node?.isCurrent,
+                'tw:opacity-50 tw:cursor-not-allowed': !node?.enabled
+              }"
+            >
               <span class="menu-link ws-normal">
-                {{node?.label}}
+                {{ node?.label }}
               </span>
             </button>
           </mat-nested-tree-node>
 
           <!-- branch nodes -->
           <mat-nested-tree-node *matTreeNodeDef="let node; when: navTreeSvc?.hasNestedChild" [hidden]="!node.visible">
-            <button class="btn btn-trans btn-link no-underline tw:w-full tw:py-2 tw:px-3 tw:rounded-md tw:dark:text-text-primary tw:border  tw:border-transparent tw:hover:border-[#6b7280]  tw:transition-colors" matTreeNodeToggle tabindex="0">
+            <button
+              class="btn btn-trans btn-link no-underline tw:w-full tw:py-2 tw:px-3 tw:rounded-md tw:dark:text-text-primary tw:border tw:border-transparent tw:hover:border-[#6b7280] tw:transition-colors"
+              matTreeNodeToggle
+              tabindex="0"
+            >
               <div class="menu-link d-flex">
-                <mat-icon style="position: relative; top: -.1rem;">
-                  {{navTreeSvc?.tocControl?.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+                <mat-icon style="position: relative; top: -0.1rem">
+                  {{ navTreeSvc?.tocControl?.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
                 </mat-icon>
                 <div class="text-wrap text-start u-hover tw:ml-2">
-                  {{node?.label}}
+                  {{ node?.label }}
                 </div>
               </div>
             </button>
 
-            <ul role="tree" class="mat-tree-node tw:ml-4 tw:pl-2 tw:border-l tw:border-[#6b7280]" *ngIf="navTreeSvc?.tocControl?.isExpanded(node)">
+            <ul
+              role="tree"
+              class="mat-tree-node tw:ml-4 tw:pl-2 tw:border-l tw:border-[#6b7280]"
+              *ngIf="navTreeSvc?.tocControl?.isExpanded(node)"
+            >
               <ng-container matTreeNodeOutlet></ng-container>
             </ul>
           </mat-nested-tree-node>
-
         </mat-tree>
 
         <div *ngIf="navSvc.isNavLoading">
@@ -119,16 +170,17 @@
             <div class="spinner-size-50"></div>
           </div>
         </div>
-
       </mat-sidenav>
 
-      <mat-sidenav-content class="d-flex flex-column flex-11a oy-auto ">
+      <mat-sidenav-content class="d-flex flex-column flex-11a oy-auto">
         <div class="max-1000 h-0 d-flex flex-column flex-11a" id="sidenav-content">
-          <div class="assessment-header tw:flex tw:justify-between tw:items-center  tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3 ">
+          <div
+            class="assessment-header tw:flex tw:justify-between tw:items-center tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3"
+          >
             <!-- Assessment Name -->
             <div class="tw:flex-1 tw:min-w-0">
-              <h6 class="tw:text-lg tw:font-semibold tw:mb-0 tw:truncate ">
-                {{this.assessment?.assessmentName || 'Loading ...'}}
+              <h6 class="tw:text-lg tw:font-semibold tw:mb-0 tw:truncate">
+                {{ this.assessment?.assessmentName || 'Loading ...' }}
               </h6>
             </div>
 
@@ -139,8 +191,8 @@
                   class="tw:w-24 tw:h-4 tw:cursor-pointer tw:rounded-full tw:appearance-none"
                   [value]="completionPercentage"
                   [matTooltip]="getProgressTooltip()"
-                  max="100">
-                </progress>
+                  max="100"
+                ></progress>
                 <span class="tw:text-sm tw:font-medium tw:min-w-[3rem]">{{ completionPercentage }}%</span>
               </div>
 
@@ -149,26 +201,32 @@
 
               <!-- CISA-only JSON upload indicator -->
               <div *ngIf="configSvc.userIsCisaAssessor" class="tw:flex tw:items-center tw:gap-2">
-                <input type="checkbox"
-                       id="jsonUploadedSwitch"
-                       class="tw:toggle"
-                       [(ngModel)]="jsonUploaded"
-                       (change)="saveJsonUploaded()">
-                <label for="jsonUploadedSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap">JSON export uploaded</label>
+                <label for="jsonUploadedSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap"
+                  >JSON export uploaded</label
+                >
+                <input
+                  type="checkbox"
+                  id="jsonUploadedSwitch"
+                  class="tw:toggle"
+                  [(ngModel)]="jsonUploaded"
+                  (change)="saveJsonUploaded()"
+                />
               </div>
 
               <!-- Divider -->
               <div *ngIf="configSvc.userIsCisaAssessor" class="tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
               <div class="tw:flex tw:items-center tw:gap-3">
-                <label for="assessmentDoneSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap">Mark Assessment Done</label>
+                <label for="assessmentDoneSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap"
+                  >Mark Assessment Done</label
+                >
                 <input
                   type="checkbox"
                   class="tw:toggle"
                   id="assessmentDoneSwitch"
                   [checked]="assessment?.done"
                   (change)="setAssessmentDone()"
-                >
+                />
               </div>
             </div>
           </div>
@@ -177,9 +235,5 @@
         </div>
       </mat-sidenav-content>
     </mat-sidenav-container>
-
   </div>
-
-
-
 </div>

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
@@ -28,7 +28,6 @@
       </div>
     </div>
     <div>
-
       <div *ngIf="browserIsIE" class="alert alert-danger text-start">
         {{ t('welcome page.internet explorer') }}
       </div>
@@ -37,105 +36,152 @@
         <div class="mt-1 mb-1 d-flex flex-column justify-content-between flex-00a">
           <div class="d-flex justify-content-between flex-00a">
             <div class="d-flex flex-row">
-              <button *ngIf="configSvc.showExportAllButton()" tabindex="0"
-                      class="m-0 btn btn-secondary d-flex align-items-center flex-00a"
-                      (click)="exportAllAssessments()" matTooltip="{{ t('tooltip.export all') }}"
-                      [disabled]="exportAllInProgress">
+              <button
+                *ngIf="configSvc.showExportAllButton()"
+                tabindex="0"
+                class="m-0 btn btn-secondary d-flex align-items-center flex-00a"
+                (click)="exportAllAssessments()"
+                matTooltip="{{ t('tooltip.export all') }}"
+                [disabled]="exportAllInProgress"
+              >
                 <span class="cset-icons-export-up fs-base-2 me-2"></span>
-                <span class="icon-link-button-text-dark">{{t('export all')}}</span>
+                <span class="icon-link-button-text-dark">{{ t('export all') }}</span>
               </button>
             </div>
           </div>
-          <div *ngIf="unsupportedImportFile"
-               class="alert-danger mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-00a">
+          <div
+            *ngIf="unsupportedImportFile"
+            class="alert-danger mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-00a"
+          >
             <span class="p-2 fs-large cset-icons-exclamation-triangle"></span>
             <div class="p-2 d-flex flex-column justify-content-center flex-01a">
               <span class="fs-base-3">{{ t('errors.import unsuported file 1') }}</span>
-              <span class="fs-base-1"><a
-                href="{{this.configSvc.docUrl}}htmlhelp/importing_a__cset_file.htm" target="_blank"
-                tabindex="0" rel="noopener noreferrer">
-                                    {{ t('errors.import unsuported file 2') }}</a></span>
+              <span class="fs-base-1"
+                ><a
+                  href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
+                  target="_blank"
+                  tabindex="0"
+                  rel="noopener noreferrer"
+                >
+                  {{ t('errors.import unsuported file 2') }}</a
+                ></span
+              >
             </div>
           </div>
         </div>
       </ng-container>
-      <div *ngIf="sortedAssessments != null" class="tw:justify-between tw:items-center tw:mb-2 tw:grid tw:grid-cols-1 tw:lg:grid-cols-2 tw:lg:gap-36 px-4">
+      <div
+        *ngIf="sortedAssessments != null"
+        class="tw:justify-between tw:items-center tw:mb-2 tw:grid tw:grid-cols-1 tw:lg:grid-cols-2 tw:lg:gap-36 px-4"
+      >
         <div class="tw:flex tw:w-full sm:tw:w-auto">
-          <div class="tw:flex tw:w-full sm:tw:w-auto tw:bg-transparent tw:rounded-lg tw:p-1 tw:border tw:border-gray-200 tw:shadow-sm">
-            <button type="button"
-                    class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
-                    [class]="currentFilter === 'all' ? 'tw:bg-blue-100 tw:text-cset-primary' : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'"
-                    (click)="setFilter('all')">
+          <div
+            class="tw:flex tw:w-full sm:tw:w-auto tw:bg-transparent tw:rounded-lg tw:p-1 tw:border tw:border-gray-200 tw:shadow-sm"
+          >
+            <button
+              type="button"
+              class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
+              [class]="
+                currentFilter === 'all'
+                  ? 'tw:bg-blue-100 tw:text-cset-primary'
+                  : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
+              "
+              (click)="setFilter('all')"
+            >
               {{ t('filters.view all') || 'View all' }}
             </button>
-            <button type="button"
-                    class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
-                    [class]="currentFilter === 'done' ? 'tw:bg-blue-100 tw:text-cset-primary' : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'"
-                    (click)="setFilter('done')">
+            <button
+              type="button"
+              class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
+              [class]="
+                currentFilter === 'done'
+                  ? 'tw:bg-blue-100 tw:text-cset-primary'
+                  : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
+              "
+              (click)="setFilter('done')"
+            >
               {{ t('filters.done') || 'Done' }}
             </button>
-            <button type="button"
-                    class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
-                    [class]="currentFilter === 'favorite' ? 'tw:bg-blue-100 tw:text-cset-primary' : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'"
-                    (click)="setFilter('favorite')">
+            <button
+              type="button"
+              class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
+              [class]="
+                currentFilter === 'favorite'
+                  ? 'tw:bg-blue-100 tw:text-cset-primary'
+                  : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
+              "
+              (click)="setFilter('favorite')"
+            >
               {{ t('filters.favorites') || 'Favorites' }}
             </button>
           </div>
         </div>
         <div class="tw:flex tw:flex-col tw:sm:flex-row tw:gap-3 flex-wrap mt-2">
           <!-- Import Button (Local) -->
-          <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-                 tabindex="0"
-                 class="btn btn-secondary tw:flex btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center h-12 px-6 tw:shadow-sm w-50"
-                 matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+          <label
+            *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+            tabindex="0"
+            class="btn btn-secondary tw:flex btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center h-12 px-6 tw:shadow-sm w-50"
+            matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
+          >
             <span class="tw:mr-3 tw:text-lg cset-icons-import"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('buttons.import') }} local</span>
-            <input type="file"
-                   tabindex="0"
-                   class="tw:hidden"
-                   id="importFile"
-                   multiple
-                   accept="{{ importExtensions }},.cset"
-                   (change)="importAssessmentFile($event)">
+            <input
+              type="file"
+              tabindex="0"
+              class="tw:hidden"
+              id="importFile"
+              multiple
+              accept="{{ importExtensions }},.cset"
+              (change)="importAssessmentFile($event)"
+            />
           </label>
 
           <!-- Import Button (Non-Local) -->
-          <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-                 class="btn btn-outline btn-neutral tw:h-12 tw:flex tw:justify-center tw:items-center px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit cursor-pointer tw:border tw:border-border"
-                 matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+          <label
+            *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+            class="btn btn-outline btn-neutral tw:h-12 tw:flex tw:justify-center tw:items-center px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit cursor-pointer tw:border tw:border-border"
+            matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
+          >
             <span class="tw:mr-3 tw:text-lg cset-icons-import"></span>
-            <span class="tw:text-sm tw:font-medium ">{{ t('buttons.import') }}</span>
-            <input type="file"
-                   tabindex="-1"
-                   class="tw:hidden"
-                   id="importFile"
-                   multiple
-                   accept="{{ importExtensions }}"
-                   (change)="importAssessmentFile($event)">
+            <span class="tw:text-sm tw:font-medium">{{ t('buttons.import') }}</span>
+            <input
+              type="file"
+              tabindex="-1"
+              class="tw:hidden"
+              id="importFile"
+              multiple
+              accept="{{ importExtensions }}"
+              (change)="importAssessmentFile($event)"
+            />
           </label>
 
           <!-- New Assessment Button -->
-          <button class="btn btn-primary tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-                  (click)="clickNewAssessmentButton()"
-                  matTooltip="{{ t('welcome page.new assessment tooltip') }}">
+          <button
+            class="btn btn-primary tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
+            (click)="clickNewAssessmentButton()"
+            matTooltip="{{ t('welcome page.new assessment tooltip') }}"
+          >
             <span class="tw:mr-3 tw:text-lg cset-icons-cset-lock"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('welcome page.new assessment') }}</span>
           </button>
 
           <!-- Export All Button -->
-          <button *ngIf="configSvc.showExportAllButton()"
-                  tabindex="0"
-                  class="btn btn-secondary flex tw:justify-center tw:items-center h-12 px-6 tw:shadow-sm w-50"
-                  (click)="exportAllAssessments()"
-                  matTooltip="{{ t('tooltip.export all') }}"
-                  [disabled]="exportAllInProgress">
+          <button
+            *ngIf="configSvc.showExportAllButton()"
+            tabindex="0"
+            class="btn btn-secondary flex tw:justify-center tw:items-center h-12 px-6 tw:shadow-sm w-50"
+            (click)="exportAllAssessments()"
+            matTooltip="{{ t('tooltip.export all') }}"
+            [disabled]="exportAllInProgress"
+          >
             <span class="cset-icons-export-up tw:text-lg tw:mr-3"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('export all') }}</span>
           </button>
         </div>
         <ng-template #noAssessmentsElseBlock>
           <h2 class="mt-0" *ngIf="sortedAssessments?.length == 0">
-            <div>{{ t('welcome page.welcome to', { appTitle:appTitle }) }}</div>
+            <div>{{ t('welcome page.welcome to', { appTitle: appTitle }) }}</div>
           </h2>
           <p>{{ t('welcome page.to get started') }}</p>
           <div class="tw:mt-3 tw:mb-4 tw:flex-column tw:d-flex tw:justify-content-between tw:flex-11a">
@@ -144,41 +190,65 @@
                 <button
                   class="m-0 p-3 tw:me-sm-2 tw:me-md-3 tw:me-lg-4 btn btn-primary d-flex align-items-center flex-11a lp-btn-mw-lg"
                   (click)="clickNewAssessmentButton()"
-                  matTooltip="{{ t('welcome page.new assessment tooltip') }}">
+                  matTooltip="{{ t('welcome page.new assessment tooltip') }}"
+                >
                   <span class="tw:me-3 landing-icon landing-icon-sm cset-icons-cset-lock"></span>
                   <span class="landing-button-text landing-button-text-sm">{{ t('welcome page.new assessment') }}</span>
                 </button>
                 <!-- <hr class="landing my-4"> -->
-                <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-                       class="tw:mt-3 tw:mt-sm-3 tw:mt-md-0 tw:p-3 tw:c-gray-900 btn btn-secondary tw:d-flex tw:align-items-center tw:flex-11a tw:lp-btn-mw-lg"
-                       matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+                <label
+                  *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+                  class="tw:mt-3 tw:mt-sm-3 tw:mt-md-0 tw:p-3 tw:c-gray-900 btn btn-secondary tw:d-flex tw:align-items-center tw:flex-11a tw:lp-btn-mw-lg"
+                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
+                >
                   <span class="tw:me-3 tw:landing-icon tw:landing-icon-sm cset-icons-import"></span>
                   <label for="importFile" class="tw:m-0 tw:landing-button-text tw:landing-button-text-sm">
                     {{ t('welcome page.import assessment') }}
                   </label>
-                  <input type="file" class="display-none" id="importFile" multiple
-                         accept="{{ importExtensions }},.cset" (change)="importAssessmentFile($event)">
+                  <input
+                    type="file"
+                    class="display-none"
+                    id="importFile"
+                    multiple
+                    accept="{{ importExtensions }},.cset"
+                    (change)="importAssessmentFile($event)"
+                  />
                 </label>
-                <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-                       class="p-3 m-0 mt-3 mt-sm-0 c-gray-900 btn btn-secondary d-flex align-items-center flex-11a lp-btn-mw-lg"
-                       matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+                <label
+                  *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+                  class="p-3 m-0 mt-3 mt-sm-0 c-gray-900 btn btn-secondary d-flex align-items-center flex-11a lp-btn-mw-lg"
+                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
+                >
                   <span class="me-3 landing-icon landing-icon-sm cset-icons-import"></span>
                   <label for="importFile" class="m-0 landing-button-text landing-button-text-sm">
                     {{ t('welcome page.import assessment') }}
                   </label>
-                  <input type="file" class="display-none" id="importFile" multiple
-                         accept="{{ importExtensions }}" (change)="importAssessmentFile($event)">
+                  <input
+                    type="file"
+                    class="display-none"
+                    id="importFile"
+                    multiple
+                    accept="{{ importExtensions }}"
+                    (change)="importAssessmentFile($event)"
+                  />
                 </label>
               </div>
             </div>
-            <div *ngIf="unsupportedImportFile"
-                 class="alert-danger my-4 d-flex flex-row justify-content-center align-items-center flex-11a">
+            <div
+              *ngIf="unsupportedImportFile"
+              class="alert-danger my-4 d-flex flex-row justify-content-center align-items-center flex-11a"
+            >
               <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
               <div class="p-md-3 p-2 d-flex flex-column justify-content-center flex-01a">
                 <span class="fs-base-3">{{ t('errors.import unsuported file 1') }}</span>
-                <span class="fs-base-1 mt-2"><a
-                  href="{{this.configSvc.docUrl}}htmlhelp/importing_a__cset_file.htm" target="_blank"
-                  rel="noopener noreferrer">{{ t('errors.import unsuported file 2') }}</a></span>
+                <span class="fs-base-1 mt-2"
+                  ><a
+                    href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >{{ t('errors.import unsuported file 2') }}</a
+                  ></span
+                >
               </div>
             </div>
           </div>
@@ -191,43 +261,59 @@
             <div class="spinner-size-50"></div>
           </div>
         </div>
-
       </div>
 
       <div *ngIf="sortedAssessments?.length > 0" class="px-4 d-flex flex-column flex-11a oy-auto">
         <!-- table for handset portrait -->
-        <table *ngIf="layoutSvc.hp" role="presentation" aria-label="assessments" matSort
-               (matSortChange)="sortData($event)" class="assessment-summary" style="overflow-x:auto">
-          <th aria-label="assessment name" mat-sort-header="assessment" style="width: 25%;">{{ t('assessment name') }}
+        <table
+          *ngIf="layoutSvc.hp"
+          role="presentation"
+          aria-label="assessments"
+          matSort
+          (matSortChange)="sortData($event)"
+          class="assessment-summary"
+          style="overflow-x: auto"
+        >
+          <th aria-label="assessment name" mat-sort-header="assessment" style="width: 25%">
+            {{ t('assessment name') }}
           </th>
-          <th aria-label="date" mat-sort-header="date" style="width:15%;">{{ t('last modified') }}</th>
+          <th aria-label="date" mat-sort-header="date" style="width: 15%">{{ t('last modified') }}</th>
           <th [aria-label]="tSvc.translate('actions')" style="width: 5%" *ngIf="layoutSvc.hp"></th>
-          <tr *ngFor="let assessment of filteredAssessments;  let i = index">
+          <tr *ngFor="let assessment of filteredAssessments; let i = index">
             <td>
-              <button tabindex="0"
-                      class="btn btn-link btn-link-dark d-flex justify-content-start align-items-start flex-00a wrap-text text-start"
-                      (click)="this.navSvc.beginAssessment(assessment.assessmentId)">
-                {{assessment.assessmentName}}
+              <button
+                tabindex="0"
+                class="btn btn-link btn-link-dark d-flex justify-content-start align-items-start flex-00a wrap-text text-start"
+                (click)="this.navSvc.beginAssessment(assessment.assessmentId)"
+              >
+                {{ assessment.assessmentName }}
               </button>
             </td>
-            <td>{{systemTimeTranslator(assessment.lastModifiedDate, 'med')}}</td>
+            <td>{{ systemTimeTranslator(assessment.lastModifiedDate, 'med') }}</td>
             <td class="text-nowrap ps-1">
-              <button tabindex="0" class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
-                      (click)="removeAssessment(assessment, i)" matTooltip="{{ t('tooltip.remove assessment') }}">
+              <button
+                tabindex="0"
+                class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
+                (click)="removeAssessment(assessment, i)"
+                matTooltip="{{ t('tooltip.remove assessment') }}"
+              >
                 <span class="cset-icons-trash-x fs-base-2"></span>
               </button>
-              <button tabindex="0" class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
-                      (click)="clickDownloadLink(assessment.assessmentId)"
-                      matTooltip="{{ t('tooltip.export assessment') }} ({{ exportExtension }}).">
+              <button
+                tabindex="0"
+                class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
+                (click)="clickDownloadLink(assessment.assessmentId)"
+                matTooltip="{{ t('tooltip.export assessment') }} ({{ exportExtension }})."
+              >
                 <span class="cset-icons-export-up fs-base-2"></span>
               </button>
             </td>
           </tr>
         </table>
         <div *ngIf="sortedAssessments?.length > 0 && !layoutSvc.hp" class="mt-4 flex flex-col flex-1">
-          <div class="overflow-x-auto rounded-lg border border-gray-200" style="border-radius:10px;">
+          <div class="overflow-x-auto rounded-lg border border-gray-200" style="border-radius: 10px">
             <ag-grid-angular
-              class="ag-theme-alpine tw:w-full tw:rounded-lg tw:[&_.ag-header-cell-label]:text-white  tw:[&_.ag-icon-filter]:text-white tw:[&_.ag-root-wrapper]:rounded-lg tw:[&_.ag-header]:rounded-t-lg tw:[&_.ag-body-viewport]:rounded-b-lg tw:[&_.ag-icon-asc]:text-white tw:[&_.ag-icon-desc]:text-white tw:[&_.ag-sort-indicator-icon]:text-white"
+              class="ag-theme-alpine tw:w-full tw:rounded-lg tw:[&_.ag-header-cell-label]:text-white tw:[&_.ag-icon-filter]:text-white tw:[&_.ag-root-wrapper]:rounded-lg tw:[&_.ag-header]:rounded-t-lg tw:[&_.ag-body-viewport]:rounded-b-lg tw:[&_.ag-icon-asc]:text-white tw:[&_.ag-icon-desc]:text-white tw:[&_.ag-sort-indicator-icon]:text-white"
               theme="legacy"
               [columnDefs]="columnDefs"
               [defaultColDef]="defaultColDef"
@@ -241,7 +327,8 @@
               (firstDataRendered)="onFirstDataRendered()"
               (cellClicked)="onCellClicked($event)"
               [style.height.px]="dynamicGridHeight"
-              style="width: 100%">
+              style="width: 100%"
+            >
             </ag-grid-angular>
           </div>
         </div>
@@ -261,28 +348,42 @@
             {{ t('welcome page.to get started') }}
           </p>
           <div class="tw:flex tw:gap-3">
-            <button class="btn btn-primary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-                    (click)="clickNewAssessmentButton()">
+            <button
+              class="btn btn-primary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
+              (click)="clickNewAssessmentButton()"
+            >
               <span class="mr-2 cset-icons-cset-lock"></span>
               {{ t('welcome page.new assessment') }}
             </button>
 
             <!-- Local import button -->
-            <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-                   class="btn btn-secondary cursor-pointer tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center">
+            <label
+              *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+              class="btn btn-secondary cursor-pointer tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
+            >
               <span class="mr-2 cset-icons-import"></span>
               {{ t('welcome page.import assessment') }}
-              <input type="file" class="hidden" accept="{{ importExtensions }},.cset"
-                     (change)="importAssessmentFile($event)">
+              <input
+                type="file"
+                class="hidden"
+                accept="{{ importExtensions }},.cset"
+                (change)="importAssessmentFile($event)"
+              />
             </label>
 
             <!-- Non-local import button -->
-            <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-                   class="btn btn-secondary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center">
+            <label
+              *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+              class="btn btn-secondary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
+            >
               <span class="mr-2 cset-icons-import"></span>
               {{ t('welcome page.import assessment') }}
-              <input type="file" class="tw:hidden" accept="{{ importExtensions }}"
-                     (change)="importAssessmentFile($event)">
+              <input
+                type="file"
+                class="tw:hidden"
+                accept="{{ importExtensions }}"
+                (change)="importAssessmentFile($event)"
+              />
             </label>
           </div>
         </div>
@@ -297,32 +398,42 @@
         </h2>
         <p class="tw:text-text-secondary mb-4">{{ t('welcome page.to get started') }}</p>
         <div class="flex flex-col gap-3">
-          <button class="btn btn-primary w-full tw:justify-center tw:items-center"
-                  (click)="clickNewAssessmentButton()">
+          <button class="btn btn-primary w-full tw:justify-center tw:items-center" (click)="clickNewAssessmentButton()">
             <span class="mr-2 cset-icons-cset-lock"></span>
             {{ t('welcome page.new assessment') }}
           </button>
 
           <!-- Local import button for mobile -->
-          <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-                 class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center">
+          <label
+            *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center"
+          >
             <span class="mr-2 cset-icons-import"></span>
             {{ t('welcome page.import assessment') }}
-            <input type="file" class="tw:hidden" accept="{{ importExtensions }},.cset"
-                   (change)="importAssessmentFile($event)">
+            <input
+              type="file"
+              class="tw:hidden"
+              accept="{{ importExtensions }},.cset"
+              (change)="importAssessmentFile($event)"
+            />
           </label>
 
           <!-- Non-local import button for mobile -->
-          <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-                 class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center">
+          <label
+            *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center"
+          >
             <span class="mr-2 cset-icons-import"></span>
             {{ t('welcome page.import assessment') }}
-            <input type="file" class="tw:hidden" accept="{{ importExtensions }}"
-                   (change)="importAssessmentFile($event)">
+            <input
+              type="file"
+              class="tw:hidden"
+              accept="{{ importExtensions }}"
+              (change)="importAssessmentFile($event)"
+            />
           </label>
         </div>
       </div>
     </div>
-
   </div>
 </ng-container>

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -50,6 +50,7 @@ import { DateTime } from 'luxon';
 import { TranslocoService } from '@jsverse/transloco';
 import { DateAdapter } from '@angular/material/core';
 import { ConversionService } from '../../services/conversion.service';
+import { DemographicService } from '../../services/demographic.service';
 import { FileExportService } from '../../services/file-export.service';
 import { ColDef, GridApi, GridReadyEvent } from 'ag-grid-community';
 import { HostListener } from '@angular/core';
@@ -79,6 +80,7 @@ interface UserAssessment {
   favorite?: boolean;
   firstName?: string;
   lastName?: string;
+  jsonUploaded?: boolean;
 }
 
 @Component({
@@ -137,7 +139,8 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
     public layoutSvc: LayoutService,
     public dateAdapter: DateAdapter<any>,
     public reportSvc: ReportService,
-    public conversionSvc: ConversionService
+    public conversionSvc: ConversionService,
+    private demoSvc: DemographicService
   ) {
   }
 
@@ -302,7 +305,7 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
         cellRenderer: this.actionsRenderer.bind(this),
         sortable: false,
         filter: false,
-        width: this.showColumn('export json') ? 345 : 200,
+        width: this.showColumn('export json') ? 470 : 200,
         pinned: 'right'
       }
     ];
@@ -717,7 +720,21 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
     `;
     }
 
-    return `<div class="tw:flex tw:h-full tw:gap-1">${buttons}</div>`;
+    let jsonIndicator = '';
+    if (this.showColumn('export json')) {
+      const uploaded = !!assessment.jsonUploaded;
+      const title = uploaded ? 'JSON export has been uploaded' : 'JSON export not yet uploaded';
+      jsonIndicator = `
+      <div class="tw:flex tw:items-center tw:border-l tw:border-base-300 tw:pl-2 tw:ml-1" title="${title}">
+        <input type="checkbox" ${uploaded ? 'checked' : ''}
+               data-action="toggleJsonUploaded"
+               data-assessment-id="${assessmentId}"
+               style="width:14px;height:14px;flex-shrink:0;cursor:pointer;">
+      </div>
+    `;
+    }
+
+    return `<div class="tw:flex tw:items-center tw:h-full tw:gap-1">${buttons}${jsonIndicator}</div>`;
   }
 
   /**
@@ -792,6 +809,14 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
       case 'exportJson':
         this.clickDownloadLink(assessmentId, true);
         break;
+
+      case 'toggleJsonUploaded':
+        const newValue = (actionElement as HTMLInputElement).checked;
+        const assessmentToToggle = this.filteredAssessments.find(a => a.assessmentId === assessmentId);
+        if (assessmentToToggle) {
+          this.toggleJsonUploaded(assessmentToToggle, newValue);
+        }
+        break;
     }
   }
 
@@ -819,6 +844,34 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
       });
     });
   }
+
+  toggleJsonUploaded(assessment: UserAssessment, newValue: boolean): void {
+    // Optimistically update so any intermediate grid re-renders show the correct state
+    assessment.jsonUploaded = newValue;
+
+    this.assessSvc.getAssessmentToken(assessment.assessmentId).then(() => {
+      this.demoSvc.saveJsonUploaded(newValue).subscribe({
+        next: () => {
+          if (this.gridApi && !this.gridApi.isDestroyed()) {
+            try {
+              this.gridApi.setGridOption('rowData', this.filteredAssessments);
+            } catch (error) {
+              console.error('Error refreshing grid cells:', error);
+            }
+          }
+        },
+        error: (error) => {
+          console.error('Failed to update JSON uploaded status:', error);
+          // Revert the optimistic update on failure
+          assessment.jsonUploaded = !newValue;
+          if (this.gridApi && !this.gridApi.isDestroyed()) {
+            this.gridApi.setGridOption('rowData', this.filteredAssessments);
+          }
+        }
+      });
+    });
+  }
+
   private calculateGridHeight(): void {
     if (typeof window === 'undefined') return;
 

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -305,7 +305,7 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
         cellRenderer: this.actionsRenderer.bind(this),
         sortable: false,
         filter: false,
-        width: this.showColumn('export json') ? 470 : 200,
+        width: this.showColumn('export json') ? 530 : 200,
         pinned: 'right'
       }
     ];
@@ -723,13 +723,13 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
     let jsonIndicator = '';
     if (this.showColumn('export json')) {
       const uploaded = !!assessment.jsonUploaded;
-      const title = uploaded ? 'JSON export has been uploaded' : 'JSON export not yet uploaded';
       jsonIndicator = `
-      <div class="tw:flex tw:items-center tw:border-l tw:border-base-300 tw:pl-2 tw:ml-1" title="${title}">
-        <input type="checkbox" ${uploaded ? 'checked' : ''}
+      <div class="tw:flex tw:items-center tw:border-l tw:border-base-300 tw:pl-2 tw:ml-1" title="Check to indicate that the JSON file has been submitted to CISA">
+        <input type="checkbox" id="json-uploaded-${assessmentId}" ${uploaded ? 'checked' : ''}
+               class="checkbox-custom"
                data-action="toggleJsonUploaded"
-               data-assessment-id="${assessmentId}"
-               style="width:14px;height:14px;flex-shrink:0;cursor:pointer;">
+               data-assessment-id="${assessmentId}">
+        <label class="checkbox-custom-label tw:my-0 tw:items-center" for="json-uploaded-${assessmentId}">Submitted</label>
       </div>
     `;
     }

--- a/CSETWebNg/src/styles.scss
+++ b/CSETWebNg/src/styles.scss
@@ -353,3 +353,77 @@ progress::-webkit-progress-bar {
     color: rgba(255, 255, 255, 0.6) !important;
   }
 }
+
+/* Bootstrap custom-checkbox styles for AG-Grid cell renderers (globally scoped) */
+.custom-control {
+  position: relative;
+  display: block;
+  min-height: 1.5rem;
+  padding-left: 1.5rem;
+}
+
+.custom-control-input {
+  position: absolute;
+  z-index: -1;
+  opacity: 0;
+}
+
+.custom-control-input:checked ~ .custom-control-label::before {
+  color: #fff;
+  background-color: #007bff;
+}
+
+.custom-control-input:disabled ~ .custom-control-label {
+  color: #6c757d;
+}
+
+.custom-control-input:disabled ~ .custom-control-label::before {
+  background-color: #e9ecef;
+}
+
+.custom-control-label {
+  position: relative;
+  margin-bottom: 0;
+}
+
+.custom-control-label::before {
+  position: absolute;
+  top: 0.25rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  pointer-events: none;
+  content: "";
+  user-select: none;
+  background-color: #dee2e6;
+}
+
+.custom-control-label::after {
+  position: absolute;
+  top: 0.25rem;
+  left: -1.5rem;
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  content: "";
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 50% 50%;
+}
+
+.custom-checkbox .custom-control-label::before {
+  border-radius: 0.25rem;
+}
+
+.custom-checkbox .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #007bff;
+}
+
+.custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E");
+}
+
+.custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
+  background-color: rgba(0, 123, 255, 0.5);
+}


### PR DESCRIPTION
## Summary

Adds a JSON uploaded checkbox indicator to the My Assessments grid (visible only to CISA assessors), allowing assessors to see and toggle the `JSON_UPLOADED` status for each assessment without opening each one individually. The existing toggle in the assessment header (`assessment.component.html`) remains the canonical control; this list-view checkbox is an additional convenience.

## Changes

- **Backend** (`AssessmentBusiness.cs`, `usp_Assessments_For_UserResult.cs`): Batch-fetch `DETAILS_DEMOGRAPHICS` `JSON_UPLOADED` flags for all assessments in a single EF Core `IN (...)` query and expose them as `JsonUploaded` on the list response.
- **Frontend** (`my-assessments.component.ts`): Add a native checkbox rendered inside the AG-Grid actions cell for CISA assessors. Clicking calls `getAssessmentToken()` then `DemographicService.saveJsonUploaded()` to persist. An optimistic update prevents the checkbox from visually reverting during the async window before the save completes.
- **Styles** (`styles.scss`): Ensure Bootstrap `custom-control`/`custom-checkbox` rules are globally available (AG-Grid cell renderers inject HTML outside Angular's component CSS scope). Also fixes an unclosed brace in the angular-editor dark mode block.
- **HTML templates**: Formatting-only reformats for readability (no functional changes).

## Breaking Changes

None

## Test Plan

- [ ] Log in as a CISA assessor — confirm a checkbox appears in the actions column of the My Assessments grid for each assessment
- [ ] Click a checkbox to toggle JSON uploaded on — verify the checkbox stays checked after clicking (no revert)
- [ ] Open that assessment, confirm "JSON export uploaded" toggle reflects the updated state
- [ ] Toggle back off from the list view — verify it stays unchecked
- [ ] Log in as a non-CISA assessor — confirm the checkbox column is not visible
- [ ] Verify `GET /api/assessmentsforuser` response includes `jsonUploaded: true/false` for each item

## Related Issues

Follows up on PR #5403 (`feat/cisa-json-export-indicator`) which added the per-assessment JSON export uploaded toggle.

## Release Notes

CISA assessors can now see and toggle the JSON export uploaded status directly from the My Assessments list view, without opening each assessment individually.

## Checklist

- [x] Conventional commit format followed
- [x] No functional changes to non-CISA assessor views
- [x] Optimistic update prevents checkbox state revert on async save