### PR TITLE
Added property to sector-subsector for 'required' behavior

### DIFF
--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.html
@@ -49,7 +49,7 @@
     </div>
     <form>
         <div class="row mb-3">
-            <app-sector-subsector [demographicData]="demographicData" [multi]="false"></app-sector-subsector>
+            <app-sector-subsector [demographicData]="demographicData" [multi]="false" [required]="false"></app-sector-subsector>
         </div>
 
         <!-- show SSG sector selection control for CPG2 assessments -->

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.html
@@ -53,7 +53,7 @@
   </div>
 
   <div class="row mb-3">
-    <app-sector-subsector [demographicData]="demographicData" [multi]="true"></app-sector-subsector>
+    <app-sector-subsector [demographicData]="demographicData" [multi]="true" [required]="true"></app-sector-subsector>
   </div>
 
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.html
@@ -27,7 +27,7 @@
 
                     <div class="col">
                          <label for="sector-{{i}}" class="form-label">{{ t('sector') }}</label>
-                         <select [ngClass]="{ 'is-invalid' : !ssPair.sectorId}" class="form-select" id="sector-{{i}}"
+                         <select [ngClass]="{ 'is-invalid' : required && !ssPair.sectorId}" class="form-select" id="sector-{{i}}"
                               tabindex="0" name="sector-{{i}}" [(ngModel)]="ssPair.sectorId"
                               (ngModelChange)="onChangeSector($event, ssPair)">
                               <option [ngValue]="null">-- {{ t('select') }} --</option>
@@ -42,7 +42,7 @@
                          <label for="subsector-{{i}}" class="form-label">{{ t('subsector') }}</label>
                          <div class="row">
                               <div [class]="(sectorList.length > 1) ? 'col-11' : 'col-12'">
-                                   <select [ngClass]="{ 'is-invalid' : !ssPair.subsectorId }" class="form-select"
+                                   <select [ngClass]="{ 'is-invalid' : required && !ssPair.subsectorId }" class="form-select"
                                         id="subsector-{{i}}" tabindex="0" name="subsector-{{i}}"
                                         [(ngModel)]="ssPair.subsectorId"
                                         (ngModelChange)="onChangeSector($event, ssPair)">

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/sector-subsector/sector-subsector.component.ts
@@ -48,6 +48,12 @@ export class SectorSubsectorComponent implements OnInit, OnChanges {
   @Input()
   multi: boolean = true;
 
+  /**
+   * Turn on required field validation if desired.
+   */
+  @Input()
+  required: boolean = true;
+
   sectorList: SectorSub[];
 
 


### PR DESCRIPTION
This pull request updates the sector/subsector selection components to support configurable required field validation. The main change is the addition of a `required` input to the `SectorSubsectorComponent`, allowing parent components to specify whether sector and subsector fields should be validated as required. This improves flexibility and ensures the UI matches the validation requirements of different assessment contexts.

**Sector/Subsector validation improvements:**

* Added a `required` input property to the `SectorSubsectorComponent` to control whether sector and subsector fields are validated as required.
* Updated the sector `<select>` field to apply the `is-invalid` class only when the `required` input is true and the sector is not selected.
* Updated the subsector `<select>` field to apply the `is-invalid` class only when the `required` input is true and the subsector is not selected.

**Parent component configuration:**

* Set `[required]="false"` for the sector/subsector selection in `assessment-demographics.component.html`, making the field optional in this context.
* Set `[required]="true"` for the sector/subsector selection in `demographics-iod.component.html`, making the field required in this context.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
