### PR TITLE
Revert "refactor(frontend): simplify report and resource library URL routing"

### DIFF
--- a/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/compare-analytics/compare-analytics.component.ts
@@ -63,7 +63,7 @@ export class CompareAnalyticsComponent implements OnInit {
   }
 
   generateReport(reportType: string) {
-    const url = '/report/' + reportType;
+    const url = '/index.html?returnPath=report/' + reportType;
     window.open(url, "_blank");
   }
 }

--- a/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
+++ b/CSETWebNg/src/app/aggregation/trend-analytics/trend-analytics.component.ts
@@ -105,7 +105,7 @@ export class TrendAnalyticsComponent implements OnInit {
   }
 
   generateReport(reportType: string) {
-    const url = '/report/' + reportType;
+    const url = '/index.html?returnPath=report/' + reportType;
     window.open(url, "_blank");
   };
 }

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.ts
@@ -179,7 +179,7 @@ export class ReportsComponent implements OnInit, AfterViewInit {
    * and into their own sub-components.
    */
   clickReportLink(reportType: string) {
-    const url = '/report/' + reportType;
+    const url = '/index.html?returnPath=report/' + reportType;
     localStorage.setItem('REPORT-' + reportType.toUpperCase(), print.toString());
 
     window.open(url, '_blank');

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.html
@@ -103,7 +103,7 @@
 
 
     <div *ngIf="showResourceLibraryLink()">
-        <a mat-button class="navbar-menu-header ws-no-wrap" href="/resource-library"
+        <a mat-button class="navbar-menu-header ws-no-wrap" href="index.html?returnPath=resource-library"
             target="_blank">
             <span class="cset-icons-library fs-base-4 me-2 align-middle"></span>
             <span>{{t('menu.resource library')}}</span>

--- a/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
+++ b/CSETWebNg/src/app/layout/top-menus/top-menus.component.ts
@@ -135,7 +135,7 @@ export class TopMenusComponent implements OnInit {
     // Resource Library
     this._hotkeysService.add(
       new Hotkey('alt+l', (event: KeyboardEvent): boolean => {
-        const url = '/resource-library';
+        const url = 'index.html?returnPath=resource-library';
         window.open(url, '_blank');
         return false; // Prevent bubbling
       })

--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
@@ -218,7 +218,7 @@ export class ModuleContentLaunchComponent implements OnInit {
    *
    */
   launchModelReport() {
-    const url = '/report/module-content?mm=' + this.selectedModel;
+    const url = '/index.html?returnPath=report/module-content?mm=' + this.selectedModel;
     window.open(url, '_blank');
   }
 
@@ -226,7 +226,7 @@ export class ModuleContentLaunchComponent implements OnInit {
    *
    */
   launchStandardReport() {
-    const url = '/report/module-content?m=' + this.selectedStandard;
+    const url = '/index.html?returnPath=report/module-content?m=' + this.selectedStandard;
     window.open(url, '_blank');
   }
 

--- a/CSETWebNg/src/app/services/report.service.ts
+++ b/CSETWebNg/src/app/services/report.service.ts
@@ -153,7 +153,7 @@ export class ReportService {
    * Opens a new window/tab
    */
   clickReportLink(reportType: string, print: boolean = false) {
-    const url = '/report/' + reportType;
+    const url = '/index.html?returnPath=report/' + reportType;
     localStorage.setItem('REPORT-' + reportType.toUpperCase(), print.toString());
     localStorage.setItem('report-confidentiality', this.confidentiality);
     window.open(url, '_blank');


### PR DESCRIPTION
Reverts cisagov/cset#5268
Fixes bug/CSET-3512

When running as an Electron app, Angular's default push-state routing breaks when navigating in new windows due to the file:// protocol — the OS attempts to resolve routes as literal file paths rather than delegating them to Angular's router.
To work around this, a returnPath query parameter was introduced so the Electron wrapper could intercept new window navigations and redirect them to the correct route.