### PR TITLE
perf(backend): eliminate N+1 queries in business layer

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Document/DocumentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Document/DocumentBusiness.cs
@@ -52,30 +52,16 @@ namespace CSETWebCore.Business.Document
         /// <returns></returns>
         public List<Model.Document.Document> GetDocumentsForAnswer(int answerId)
         {
-            List<Model.Document.Document> list = new List<Model.Document.Document>();
-
-            var files = _context.ANSWER
-                .Where(a => a.Answer_Id == answerId).FirstOrDefault()?.DOCUMENT_FILEs(_context).ToList();
-
-            if (files == null)
-            {
-                return list;
-            }
-
-            foreach (var file in files)
-            {
-                Model.Document.Document doc = new Model.Document.Document()
-                {
-                    Document_Id = file.Document_Id,
-                    Title = file.Title,
-                    FileName = file.Name,
-                    IsShared = file.IsGlobal
-                };
-
-                list.Add(doc);
-            }
-
-            return list;
+            return (from da in _context.DOCUMENT_ANSWERS
+                    join df in _context.DOCUMENT_FILE on da.Document_Id equals df.Document_Id
+                    where da.Answer_Id == answerId
+                    select new Model.Document.Document()
+                    {
+                        Document_Id = df.Document_Id,
+                        Title = df.Title,
+                        FileName = df.Name,
+                        IsShared = df.IsGlobal
+                    }).ToList();
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationsManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Observations/ObservationsManager.cs
@@ -127,10 +127,51 @@ namespace CSETWebCore.Business.Observations
                 throw new ArgumentException("Cannot save an Observation with both assessment and answer IDs");
             }
 
+            if (list.Count == 0)
+            {
+                return new List<Observation>();
+            }
 
             // get a list of all the questions for the list of FINDING
             var dictTitles = GetQuestionTitlesForObservations(list);
 
+
+            // Batch-load answer-to-assessment mappings for findings that need them
+            Dictionary<int, int> answerAssessmentMap = new Dictionary<int, int>();
+            if (assessmentId == null)
+            {
+                var answerIds = list.Where(o => o.Answer_Id != null).Select(o => (int)o.Answer_Id).Distinct().ToList();
+                if (answerIds.Count > 0)
+                {
+                    answerAssessmentMap = _context.ANSWER
+                        .Where(a => answerIds.Contains(a.Answer_Id))
+                        .ToDictionary(a => a.Answer_Id, a => a.Assessment_Id);
+                }
+            }
+
+            // Batch-load assessment contacts for all relevant assessments
+            var allAssessmentIds = new HashSet<int>();
+            if (assessmentId != null)
+            {
+                allAssessmentIds.Add((int)assessmentId);
+            }
+            else
+            {
+                foreach (var aid in answerAssessmentMap.Values)
+                {
+                    allAssessmentIds.Add(aid);
+                }
+            }
+
+            var contactsByAssessment = new Dictionary<int, List<ASSESSMENT_CONTACTS>>();
+            if (allAssessmentIds.Count > 0)
+            {
+                contactsByAssessment = _context.ASSESSMENT_CONTACTS
+                    .Where(x => allAssessmentIds.Contains(x.Assessment_Id))
+                    .ToList()
+                    .GroupBy(x => x.Assessment_Id)
+                    .ToDictionary(g => g.Key, g => g.ToList());
+            }
 
             List<Observation> observations = new List<Observation>();
 
@@ -166,26 +207,28 @@ namespace CSETWebCore.Business.Observations
                     obs.Importance = TinyMapper.Map<IMPORTANCE, Importance>(o.Importance);
                 }
 
-                // grabs all contacts attached to this assessment to allow the user to assign new Individuals Responsible
-                int assessIdForContacts = (int)(assessmentId != null ? obs.Assessment_Id :
-                    _context.ANSWER.Where(x => x.Answer_Id == obs.Answer_Id).Select(x => x.Assessment_Id).FirstOrDefault());
+                // Look up assessment ID for contacts from batch-loaded data
+                int assessIdForContacts = assessmentId != null
+                    ? (int)obs.Assessment_Id
+                    : (obs.Answer_Id != null && answerAssessmentMap.TryGetValue((int)obs.Answer_Id, out var mappedId) ? mappedId : 0);
 
-                List<ASSESSMENT_CONTACTS> contactsInThisAssess = _context.ASSESSMENT_CONTACTS.Where(x => x.Assessment_Id == assessIdForContacts).ToList();
-
-                foreach (ASSESSMENT_CONTACTS ac in contactsInThisAssess)
+                if (contactsByAssessment.TryGetValue(assessIdForContacts, out var contactsInThisAssess))
                 {
-                    FINDING_CONTACT fc = o.FINDING_CONTACT.Where(x => x.Assessment_Contact_Id == ac.Assessment_Contact_Id).FirstOrDefault();
-                    if (fc == null)
+                    foreach (ASSESSMENT_CONTACTS ac in contactsInThisAssess)
                     {
-                        fc = new FINDING_CONTACT();
-                    }
+                        FINDING_CONTACT fc = o.FINDING_CONTACT.Where(x => x.Assessment_Contact_Id == ac.Assessment_Contact_Id).FirstOrDefault();
+                        if (fc == null)
+                        {
+                            fc = new FINDING_CONTACT();
+                        }
 
-                    ObservationContact webFc = TinyMapper.Map<FINDING_CONTACT, ObservationContact>(fc);
-                    webFc.Assessment_Contact_Id = ac.Assessment_Contact_Id;
-                    webFc.Observation_Id = o?.Finding_Id ?? 0;
-                    webFc.Selected = (fc.Finding_Id > 0);
-                    webFc.Name = $"{ac.PrimaryEmail} -- {ac.FirstName} {ac.LastName}".Trim();
-                    obs.Observation_Contacts.Add(webFc);
+                        ObservationContact webFc = TinyMapper.Map<FINDING_CONTACT, ObservationContact>(fc);
+                        webFc.Assessment_Contact_Id = ac.Assessment_Contact_Id;
+                        webFc.Observation_Id = o?.Finding_Id ?? 0;
+                        webFc.Selected = (fc.Finding_Id > 0);
+                        webFc.Name = $"{ac.PrimaryEmail} -- {ac.FirstName} {ac.LastName}".Trim();
+                        obs.Observation_Contacts.Add(webFc);
+                    }
                 }
 
                 observations.Add(obs);

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionDetailsBusiness.cs
@@ -14,7 +14,6 @@ using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Interfaces.Question;
 using CSETWebCore.Interfaces.Standards;
 using CSETWebCore.Model.Question;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
@@ -68,7 +67,7 @@ namespace CSETWebCore.Business.Question
         /// <returns></returns>
         public QuestionDetails GetQuestionDetails(int? questionId, int assessmentId, string questionType)
         {
-            if (_context.MATURITY_QUESTION_TYPES.ToList().Exists(x => x.Mat_Question_Type.Equals(questionType, StringComparison.OrdinalIgnoreCase)))
+            if (_context.MATURITY_QUESTION_TYPES.Any(x => x.Mat_Question_Type == questionType))
             {
                 questionType = "Maturity";
             }
@@ -229,41 +228,14 @@ namespace CSETWebCore.Business.Question
             }
             else if (question.IsComponent)
             {
-                var exploded = _context.Answer_Components_Exploded
-                    .AsNoTracking()
-                    .Where(c => c.Assessment_Id == assessment_id)
-                    .Select(c => new usp_getExplodedComponent
-                    {
-                        UniqueKey = c.UniqueKey,
-                        Assessment_Id = c.Assessment_Id,
-                        Answer_Id = c.Answer_Id,
-                        Question_Id = c.Question_Id,
-                        Answer_Text = c.Answer_Text,
-                        Comment = c.Comment,
-                        Alternate_Justification = c.Alternate_Justification,
-                        Question_Number = c.Question_Number,
-                        QuestionText = c.QuestionText,
-                        ComponentName = c.ComponentName,
-                        Component_Symbol_Id = c.Component_Symbol_Id,
-                        Is_Component = c.Is_Component,
-                        Component_GUID = c.Component_Guid,
-                        Layer_Id = c.Layer_Id,
-                        LayerName = c.LayerName,
-                        Container_Id = c.Container_Id,
-                        ZoneName = c.ZoneName,
-                        SAL = c.SAL,
-                        Mark_For_Review = c.Mark_For_Review,
-                        Feedback = c.FeedBack
-                    })
-                    .ToList();
-
-                var stuff = from a in exploded
-                            join l in _context.UNIVERSAL_SAL_LEVEL on a.SAL equals l.Full_Name_Sal
-                            where a.Assessment_Id == assessment_id && a.Question_Id == question.Question_or_Requirement_ID
-                            select new { a.Component_Symbol_Id, a.SAL, l.Sal_Level_Order };
+                var stuff = (from c in _context.Answer_Components_Exploded.AsNoTracking()
+                             join l in _context.UNIVERSAL_SAL_LEVEL on c.SAL equals l.Full_Name_Sal
+                             where c.Assessment_Id == assessment_id && c.Question_Id == question.Question_or_Requirement_ID
+                             select new { c.Component_Symbol_Id, c.SAL, l.Sal_Level_Order })
+                            .ToList();
 
                 Dictionary<int, ComponentTypeSalData> dictionaryComponentTypes = new Dictionary<int, ComponentTypeSalData>();
-                foreach (var item in stuff.ToList())
+                foreach (var item in stuff)
                 {
                     ComponentTypeSalData salData;
 
@@ -285,8 +257,12 @@ namespace CSETWebCore.Business.Question
                     }
                 }
                 if (response.SymbolInfo == null)
+                {
+                    var neededIds = dictionaryComponentTypes.Keys.ToList();
                     response.SymbolInfo = _context.COMPONENT_SYMBOLS
-                    .ToDictionary(x => x.Component_Symbol_Id, data => data);
+                        .Where(x => neededIds.Contains(x.Component_Symbol_Id))
+                        .ToDictionary(x => x.Component_Symbol_Id, data => data);
+                }
 
 
                 //select component_type, ComponentName, SAL from Answer_Components_Exploded


### PR DESCRIPTION
## Summary
Replaces per-iteration database round trips with batch-loaded queries in three backend business classes, eliminating N+1 query patterns that degrade performance as assessment data grows.

## Changes
- **DocumentBusiness**: Replaced ANSWER navigation-property traversal with a direct `DOCUMENT_ANSWERS ⋈ DOCUMENT_FILE` join query — one DB call instead of loading an entity and calling a nav-property method
- **ObservationsManager**: Batch-loads answer→assessment mappings and assessment contacts *before* the observation loop; adds early-exit for empty lists — reduces from O(n) queries to 2 queries regardless of observation count
- **QuestionDetailsBusiness**: Pushes the `Answer_Components_Exploded ⋈ UNIVERSAL_SAL_LEVEL` join to the database instead of loading all exploded rows into memory; filters `COMPONENT_SYMBOLS` to only the referenced symbol IDs; replaces `ToList().Exists()` with server-side `.Any()`

## Breaking Changes
None

## Test Plan
- [ ] Load an assessment with observations and verify the Observations panel loads correctly
- [ ] Open question details for a component-type question and verify symbol/SAL data renders
- [ ] Attach a document to an answer and verify it appears in the document list
- [ ] Run backend tests: `task test:backend`
- [ ] Verify no formatting regressions: `task verify:backend`

## Release Notes
Performance improvement: assessment pages with many observations or component questions now require significantly fewer database round trips, reducing load time at scale.

## Checklist
- [x] Conventional commit format followed
- [ ] Tests pass locally (`task test:backend`)
- [ ] Formatting verified (`task verify:backend`)
- [ ] No breaking changes