### PR TITLE
fix(backend): resolve compiler warnings in import and CMU reports

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ImportManager.cs
@@ -308,7 +308,7 @@ namespace CSETWebCore.Business.AssessmentIO.Import
                 }
 
             }
-            catch (ZipException ex)
+            catch (ZipException)
             {
                 throw;
             }

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmuController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/ReportsCmuController.cs
@@ -107,9 +107,9 @@ namespace CSETWebCore.Api.Controllers
         /// </summary>
         private IActionResult SecureHtmlContent(string content)
         {
-            Response.Headers.Add("X-Content-Type-Options", "nosniff");
-            Response.Headers.Add("X-Frame-Options", "DENY");
-            Response.Headers.Add("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'");
+            Response.Headers["X-Content-Type-Options"] = "nosniff";
+            Response.Headers["X-Frame-Options"] = "DENY";
+            Response.Headers["Content-Security-Policy"] = "default-src 'none'; style-src 'unsafe-inline'";
             return Content(content, "text/html; charset=utf-8");
         }
 
@@ -119,8 +119,8 @@ namespace CSETWebCore.Api.Controllers
         /// </summary>
         private IActionResult SecureSvgContent(string content)
         {
-            Response.Headers.Add("X-Content-Type-Options", "nosniff");
-            Response.Headers.Add("Content-Security-Policy", "default-src 'none'");
+            Response.Headers["X-Content-Type-Options"] = "nosniff";
+            Response.Headers["Content-Security-Policy"] = "default-src 'none'";
             return Content(content, "image/svg+xml; charset=utf-8");
         }
 


### PR DESCRIPTION
## Summary
Fixes two compiler warnings introduced by .NET 10 — an unused catch variable in the import manager and obsolete `Headers.Add()` calls in the CMU reports controller.

## Commits
- `371b673` fix(import): remove unused exception variable in ZipException catch
- `6bf94eb` fix(reports): replace obsolete Headers.Add() with indexer syntax

## Changes
- `ImportManager.cs`: Removed unused `ex` variable from `catch (ZipException ex)` block — exception is immediately re-thrown so the variable is never used (CS0168)
- `ReportsCmuController.cs`: Replaced 5 `Response.Headers.Add(key, value)` calls with `Response.Headers[key] = value` indexer syntax in `SecureHtmlContent` and `SecureSvgContent` helpers — the `Add()` overload is obsolete in .NET 10

## Breaking Changes
None

## Test Plan
- [ ] Run `task build:backend` — verify no compiler warnings for the changed files
- [ ] Run `task test:backend` — verify all tests pass
- [ ] Manually invoke a CMU report endpoint and confirm security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Content-Security-Policy`) are present in the response
- [ ] Upload a valid assessment ZIP via the import flow and confirm it succeeds
- [ ] Upload an invalid/corrupt ZIP and confirm a `ZipException` is properly surfaced

## Related Issues
None

## Release Notes
Internal code quality fixes: removed a compiler warning from the assessment import path and modernized response header assignment in the CMU reports controller. No user-facing behavior changes.

## Checklist
- [x] Conventional commit format followed
- [x] No behavior changes — purely compiler warning / API modernization fixes
- [x] Tests pass locally