### PR TITLE
Looking up components more defensively

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/ComponentQuestionBusiness.cs
@@ -32,9 +32,9 @@ namespace CSETWebCore.Business.Question
         public List<SubCategoryAnswersPlus> SubCatAnswers;
 
         /// <summary>
-        /// Dictionary for O(1) lookup of answers by Question_Or_Requirement_Id
+        /// Dictionary for O(1) lookup of answers by Question_Or_Requirement_Id plus GUID
         /// </summary>
-        private Dictionary<int, FullAnswer> _answersByQuestionId = new Dictionary<int, FullAnswer>();
+        private Dictionary<string, FullAnswer> _answersByQuestionIdAndGuid = new Dictionary<string, FullAnswer>();
 
         /// <summary>
         /// Dictionary for O(1) lookup of SubCatAnswers by HeadingId
@@ -319,7 +319,7 @@ namespace CSETWebCore.Business.Question
 
             if (!answers.Any())
             {
-                _answersByQuestionId = new Dictionary<int, FullAnswer>();
+                _answersByQuestionIdAndGuid = new Dictionary<string, FullAnswer>();
                 return;
             }
 
@@ -342,8 +342,8 @@ namespace CSETWebCore.Business.Question
                 .ToDictionaryAsync(x => x.AnswerId, x => x.Count);
 
             // 4. Build O(1) lookup dictionary with computed status
-            _answersByQuestionId = answers.ToDictionary(
-                a => a.Question_Or_Requirement_Id,
+            _answersByQuestionIdAndGuid = answers.ToDictionary(
+                a => $"{a.Question_Or_Requirement_Id}{a.Component_Guid}",
                 a =>
                 {
                     documentCounts.TryGetValue(a.Answer_Id, out var docCount);
@@ -384,7 +384,7 @@ namespace CSETWebCore.Business.Question
 
             if (!answers.Any())
             {
-                _answersByQuestionId = new Dictionary<int, FullAnswer>();
+                _answersByQuestionIdAndGuid = new Dictionary<string, FullAnswer>();
                 return;
             }
 
@@ -407,8 +407,8 @@ namespace CSETWebCore.Business.Question
                 .ToDictionary(x => x.AnswerId, x => x.Count);
 
             // 4. Build O(1) lookup dictionary with computed status
-            _answersByQuestionId = answers.ToDictionary(
-                a => a.Question_Or_Requirement_Id,
+            _answersByQuestionIdAndGuid = answers.ToDictionary(
+                a => $"{a.Question_Or_Requirement_Id}{a.Component_Guid}",
                 a =>
                 {
                     documentCounts.TryGetValue(a.Answer_Id, out var docCount);
@@ -768,7 +768,8 @@ namespace CSETWebCore.Business.Question
                 };
 
                 // O(1) dictionary lookup instead of O(N) linear search
-                _answersByQuestionId.TryGetValue(qa.QuestionId, out var answer);
+                var k = $"{qa.QuestionId}{qa.ComponentGuid}";
+                _answersByQuestionIdAndGuid.TryGetValue(k, out var answer);
                 if (answer != null)
                 {
                     TinyMapper.Bind<VIEW_QUESTIONS_STATUS, QuestionAnswer>();
@@ -865,7 +866,8 @@ namespace CSETWebCore.Business.Question
                 };
 
                 // O(1) dictionary lookup instead of O(N) linear search
-                _answersByQuestionId.TryGetValue(qa.QuestionId, out var answer);
+                var k = $"{qa.QuestionId}{qa.ComponentGuid}";
+                _answersByQuestionIdAndGuid.TryGetValue(k, out var answer);
                 if (answer != null)
                 {
                     TinyMapper.Bind<VIEW_QUESTIONS_STATUS, QuestionAnswer>();

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionInformationTabData.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionInformationTabData.cs
@@ -490,11 +490,16 @@ namespace CSETWebCore.Business.Question
 
                 List<ComponentOverrideLinkInfo> tmpList = new List<ComponentOverrideLinkInfo>();
 
-
                 foreach (COMPONENT_QUESTIONS componentType in _context.COMPONENT_QUESTIONS.Where(x => x.Question_Id == info.QuestionID))
                 {
                     bool enabled = info.HasComponentsForTypeAtSal(componentType.Component_Symbol_Id, salLevel);
-                    COMPONENT_SYMBOLS componentTypeData = info.DictionaryComponentInfo[componentType.Component_Symbol_Id];
+
+                    var found = info.DictionaryComponentInfo.TryGetValue(componentType.Component_Symbol_Id, out COMPONENT_SYMBOLS componentTypeData);
+                    if (!found)
+                    {
+                        continue;
+                    }
+
                     tmpList.Add(new ComponentOverrideLinkInfo()
                     {
                         Component_Symbol_Id = componentTypeData.Component_Symbol_Id,

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
@@ -82,6 +82,13 @@
               </div>
             </td>
           </tr>
+          <tr *ngIf="questions.length == 0">
+            <td colspan="2">
+              <div class="spinner-container" style="margin: 2em auto 0 auto">
+                <div style="max-width: 50px; max-height: 50px;"></div>
+              </div>
+            </td>
+          </tr>
         </table>
       </div>
     </div>

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
@@ -85,7 +85,7 @@
           </tr>
           }
           @empty {
-          <tr *ngIf="!questions">
+          <tr>
             <td colspan="2">
               <div class="spinner-container" style="margin: 2em auto 0 auto">
                 <div style="max-width: 50px; max-height: 50px;"></div>

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.html
@@ -50,7 +50,8 @@
           <tr>
             <th colspan="2">Specific Component Name</th>
           </tr>
-          <tr *ngFor="let q of questions; let i = index">
+          @for(q of questions; track i) {
+          <tr>
             <td>{{ utilitiesSvc.removeHtmlTags(q.componentName) }}</td>
             <td>
               <div class="btn-group btn-group-toggle answer-group" data-toggle="buttons" style="float:right;">
@@ -82,13 +83,16 @@
               </div>
             </td>
           </tr>
-          <tr *ngIf="questions.length == 0">
+          }
+          @empty {
+          <tr *ngIf="!questions">
             <td colspan="2">
               <div class="spinner-container" style="margin: 2em auto 0 auto">
                 <div style="max-width: 50px; max-height: 50px;"></div>
               </div>
             </td>
           </tr>
+          }
         </table>
       </div>
     </div>

--- a/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
+++ b/CSETWebNg/src/app/dialogs/component-override/component-override.component.ts
@@ -52,6 +52,7 @@ export class ComponentOverrideComponent {
     @Inject(MAT_DIALOG_DATA) public data: any) {
     dialog.beforeClosed().subscribe(() => this.broadcastQuestionOverride());
 
+    this.questions = null;
     this.questionsSvc.getOverrideQuestions(data.myQuestion.questionId,
       data.component_Symbol_Id).subscribe((x: any) => {
         this.questions = x;


### PR DESCRIPTION
This pull request improves the handling and display of component override questions in both the backend and frontend. The main changes include better null safety in backend data access, refactoring Angular template syntax for more efficient rendering, and enhanced loading state management in the UI.

**Backend improvements:**

* Added a null safety check when accessing `DictionaryComponentInfo` in `BuildComponentInfoTab` to prevent errors if a component type is missing, by using `TryGetValue` and continuing the loop if not found.

**Frontend (Angular) template and UI enhancements:**

* Refactored the `component-override.component.html` template to use Angular's new `@for` loop syntax for rendering questions, improving performance and readability.
* Added an `@empty` block to the template to show a loading spinner when questions are not yet loaded, providing better user feedback during data fetches.
* Set `this.questions` to `null` before fetching override questions in `component-override.component.ts` to trigger the loading state in the UI.


## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
