### PR TITLE
Refactor Contacts to use BehaviorSubject eliminating race condition

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Contact/ContactBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Contact/ContactBusiness.cs
@@ -443,9 +443,10 @@ namespace CSETWebCore.Business.Contact
             var ac = (from cc in _context.ASSESSMENT_CONTACTS
                       where cc.Assessment_Contact_Id == assessmentContactId
                       select cc).FirstOrDefault();
-            if (ac == null)
-                throw new Exception("User does not exist");
-            _context.ASSESSMENT_CONTACTS.Remove(ac);
+            if (ac != null)
+            {
+                _context.ASSESSMENT_CONTACTS.Remove(ac);
+            }
 
 
             // Remove any related FINDING_CONTACT records

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -127,7 +127,7 @@
     </div>
 
     <div class="mt-4">
-      <app-assessment-contacts (triggerChange)="refreshContacts()"></app-assessment-contacts>
+      <app-assessment-contacts></app-assessment-contacts>
     </div>
 
     <hr class="w-100 hr-sal my-4" />

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -22,7 +22,7 @@
 //
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
-import { AssessmentContactsResponse, AssessmentDetail } from '../../../../models/assessment-info.model';
+import { AssessmentDetail } from '../../../../models/assessment-info.model';
 import { DemographicsIod } from '../../../../models/demographics-iod.model';
 import { User } from '../../../../models/user.model';
 import { AssessmentService } from '../../../../services/assessment.service';
@@ -31,6 +31,7 @@ import { DemographicIodService } from '../../../../services/demographic-iod.serv
 import { DemographicService } from '../../../../services/demographic.service';
 import { Upgrades } from '../../../../models/assessment-info.model';
 import { NavigationService } from '../../../../services/navigation/navigation.service';
+import { ContactsService } from '../../../../services/contacts.service';
 
 @Component({
   selector: 'app-assessment-config-iod',
@@ -52,6 +53,7 @@ export class AssessmentConfigIodComponent implements OnInit {
     private assessSvc: AssessmentService,
     private demoSvc: DemographicService,
     private iodDemoSvc: DemographicIodService,
+    private contactsSvc: ContactsService,
     private configSvc: ConfigService,
     private navSvc: NavigationService
   ) { }
@@ -64,7 +66,6 @@ export class AssessmentConfigIodComponent implements OnInit {
 
     this.iodDemoSvc.getDemographics().subscribe((data: any) => {
       this.iodDemographics = data;
-      this.refreshContacts();
     });
 
     this.getAssessmentDetail();
@@ -78,6 +79,11 @@ export class AssessmentConfigIodComponent implements OnInit {
         }
       })
     }
+
+    // when the contacts list changes, update the local list
+    this.contactsSvc.contactsUpdated$.subscribe((contacts: User[]) => {
+      this.contacts = structuredClone(contacts);
+    });
   }
 
   /**
@@ -138,14 +144,6 @@ export class AssessmentConfigIodComponent implements OnInit {
     this.iodDemoSvc.updateDemographic(this.iodDemographics);
   }
 
-  refreshContacts() {
-    if (this.assessSvc.id()) {
-      this.assessSvc.getAssessmentContacts().then((data: AssessmentContactsResponse) => {
-        this.contacts = data.contactList;
-      });
-    }
-  }
-
   showCityName() {
     return this.configSvc.behaviors.showCityName;
   }
@@ -167,8 +165,8 @@ export class AssessmentConfigIodComponent implements OnInit {
 
 
   }
-  setAssessmentDone(){
-    this.assessment.done =!this.assessment.done;
+  setAssessmentDone() {
+    this.assessment.done = !this.assessment.done;
     this.assessSvc.setAssesmentDone(this.assessment.done).subscribe();
   }
 }

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.html
@@ -24,22 +24,31 @@
   <div *ngIf="contacts">
     <h4>{{ t('contacts') }}</h4>
     <div class="list-group">
-      <app-contact-item [contact]="contact" [contactsList]="contacts" [impliedSave]="impliedSave" *ngFor="let contact of contacts; let i = index"
+      @for(contact of contacts; track $index; let i = $index) {
+      <app-contact-item [contact]="contact" [contactsList]="contacts" [impliedSave]="impliedSave"
         (startEditEvent)="startEdit()" (abandonEditEvent)="abandonEdit()" (edit)="editContact(contact)"
         (create)="saveNewContact(contact)" (remove)="removeContact(contact, i)" (rolesChangedEvent)="refreshContacts()">
       </app-contact-item>
-      <span class="mt-2 btn-group" *ngIf="showControls()">
+      }
+      
+      @if(showControls()) {
+      <span class="mt-2 btn-group">
         <button class="btn btn-group d-flex align-items-center flex-00a" (click)="newContact()" [disabled]="adding==1">
           <span class="cset-icons-plus fs-base me-2"></span>
           <span>{{ t('add contact') }}</span>
         </button>
-        <button *ngIf="false" class="btn btn-group cset-icons-envelope" (click)="openEmailDialog()">{{ t('email
+        @if(false) {
+        <button class="btn btn-group cset-icons-envelope" (click)="openEmailDialog()">{{ t('email
           contacts') }}</button>
+        }
       </span>
-      <div *ngIf="!showControls()" class="text-info small">
+      }
+      @else {
+      <div class="text-info small">
         <p>{{ t('not authorized message') }}</p>
         <p>{{ t('contact an administrator message') }}</p>
       </div>
+      }
     </div>
   </div>
 </div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-contacts/assessment-contacts.component.ts
@@ -36,6 +36,7 @@ import { ConfigService } from "../../../../services/config.service";
 import { EmailService } from "../../../../services/email.service";
 import { LayoutService } from "../../../../services/layout.service";
 import { ContactItemComponent } from "./contact-item/contact-item.component";
+import { ContactsService } from "../../../../services/contacts.service";
 
 @Component({
   selector: "app-assessment-contacts",
@@ -45,7 +46,6 @@ import { ContactItemComponent } from "./contact-item/contact-item.component";
   standalone: false
 })
 export class AssessmentContactsComponent implements OnInit {
-  @Output() triggerChange = new EventEmitter();
   @Input() impliedSave: boolean = false;
 
   contacts: EditableUser[] = [];
@@ -61,6 +61,7 @@ export class AssessmentContactsComponent implements OnInit {
 
 
   constructor(
+    private contactsSvc: ContactsService,
     private configSvc: ConfigService,
     private assessSvc: AssessmentService,
     private emailSvc: EmailService,
@@ -79,9 +80,14 @@ export class AssessmentContactsComponent implements OnInit {
         // Then fetch contacts
         return this.assessSvc.getAssessmentContacts();
       }).then((data: AssessmentContactsResponse) => {
+        this.contacts = [];
         for (const c of data.contactList) {
           this.contacts.push(new EditableUser(c));
         }
+
+        // broadcast the up-to-date list of contacts
+        this.contactsSvc.contactsUpdated(this.contacts);
+
         this.userRole = data.currentUserRole;
         this.userEmail = this.auth.email();
 
@@ -90,14 +96,6 @@ export class AssessmentContactsComponent implements OnInit {
       }).catch(error => {
         console.error('Error loading contacts:', error);
       });
-    }
-  }
-
-  changeOccurred() {
-    // emitting this when impliedSave is true will cause 
-    // the observation to save twice and make a duplicate
-    if (!this.impliedSave) {
-      this.triggerChange.next("Initialized");
     }
   }
 
@@ -187,7 +185,7 @@ export class AssessmentContactsComponent implements OnInit {
         contact.contactId = returnContact.contactId;
 
         this.sortContactsWithCreatorFirst();
-        this.changeOccurred();
+        this.refreshContacts();
       },
       error => {
         this.dialog
@@ -217,33 +215,28 @@ export class AssessmentContactsComponent implements OnInit {
     if (this.adding && contact.isNew) {
       this.contacts.splice(indx, 1);
       this.adding = false;
-      this.changeOccurred();
+      this.refreshContacts();
       return;
     }
+
     this.adding = false;
     if (contact.firstName === undefined
       || contact.lastName === undefined
       || contact.primaryEmail === undefined
     ) {
       this.dropContact(contact);
-      this.changeOccurred();
+      this.refreshContacts();
       return;
     }
 
     const dialogRef = this.dialog.open(ConfirmComponent);
     dialogRef.componentInstance.confirmMessage =
-      // "Are you sure you want to remove " +
-      // contact.firstName +
-      // " " +
-      // contact.lastName +
-      // " from this assessment?";
-
       this.tSvc.translate('dialogs.remove contact', { firstName: contact.firstName, lastName: contact.lastName });
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         this.dropContact(contact);
-        this.changeOccurred();
+        this.refreshContacts();
       }
     });
   }
@@ -284,7 +277,7 @@ export class AssessmentContactsComponent implements OnInit {
             }
             this.contactItems.forEach(x => x.enableMyControls = true);
             this.sortContactsWithCreatorFirst();
-            this.changeOccurred();
+            this.refreshContacts();
           },
           error: (error) => {
             console.error(error);
@@ -293,8 +286,10 @@ export class AssessmentContactsComponent implements OnInit {
       });
   }
 
+  /**
+   * Calls ngOnInit to rebuild and broadcast the new list.
+   */
   refreshContacts() {
-    this.contacts = [] as EditableUser[];
     this.ngOnInit();
   }
 
@@ -310,9 +305,9 @@ export class AssessmentContactsComponent implements OnInit {
 
     // update the API
     this.assessSvc.removeContact(contact.assessmentContactId).subscribe(
-      (response: { ContactList: User[] }) => {
+      (response: { contactList: User[] }) => {
         this.sortContactsWithCreatorFirst();
-        this.changeOccurred();
+        this.refreshContacts();
       },
       error => {
         this.dialog

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demographics/assessment-demographics.component.ts
@@ -34,6 +34,7 @@ import { UploadDemographicsComponent } from "../../../../dialogs/import demograp
 import { ConstantsService } from '../../../../services/constants.service';
 import { TranslocoService } from '@jsverse/transloco';
 import { OkayComponent } from '../../../../dialogs/okay/okay.component';
+import { ContactsService } from '../../../../services/contacts.service';
 
 
 
@@ -79,6 +80,7 @@ export class AssessmentDemographicsComponent implements OnInit {
     constructor(
         private demoSvc: DemographicService,
         public assessSvc: AssessmentService,
+        public contactsSvc: ContactsService,
         private c: ConstantsService,
         public configSvc: ConfigService,
         public dialog: MatDialog,
@@ -89,7 +91,6 @@ export class AssessmentDemographicsComponent implements OnInit {
         this.demoSvc.getAllAssetValues().subscribe(
             (data: DemographicsAssetValue[]) => {
                 this.assetValues = data;
-
             },
             error => {
                 console.error('Error Getting all asset values: ' + (<Error>error).name + (<Error>error).message);
@@ -110,6 +111,11 @@ export class AssessmentDemographicsComponent implements OnInit {
 
         this.refreshContacts();
         this.getOrganizationTypes();
+
+        // when the contacts list changes, update the local list
+        this.contactsSvc.contactsUpdated$.subscribe((contacts: User[]) => {
+            this.contacts = structuredClone(contacts);
+        });
     }
 
     /**

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.html
@@ -22,10 +22,12 @@
 -------------------------->
 <div *transloco="let t">
   <div class="white-panel d-flex justify-content-start flex-column flex-11a">
-    <app-assessment-contacts *ngIf="showContacts()" class="mb-5 d-flex justify-content-end flex-00a"
-      (triggerChange)="contactsUpdated()"></app-assessment-contacts>
+    @if(showContacts) {
+      <app-assessment-contacts class="mb-5 d-flex justify-content-end flex-00a"></app-assessment-contacts>
+    }
 
     <app-assessment-demographics #demographics class="mb-5 d-flex justify-content-end flex-00a"></app-assessment-demographics>
+    
   </div>
   <app-nav-back-next [page]="'info2'"></app-nav-back-next>
 </div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment2-info/assessment2-info.component.ts
@@ -27,17 +27,25 @@ import { NavigationService } from '../../../../services/navigation/navigation.se
 import { DemographicService } from '../../../../services/demographic.service';
 import { ConfigService } from '../../../../services/config.service';
 import { AssessmentDemographicsComponent } from '../assessment-demographics/assessment-demographics.component';
+import { TutorialEdmComponent } from '../../maturity/tutorial-edm/tutorial-edm.component';
+import { User } from '../../../../models/user.model';
+import { ContactsService } from '../../../../services/contacts.service';
 
 
 @Component({
-    selector: 'app-assessment2-info',
-    templateUrl: './assessment2-info.component.html',
-    standalone: false
+  selector: 'app-assessment2-info',
+  templateUrl: './assessment2-info.component.html',
+  standalone: false
 })
 export class Assessment2InfoComponent implements OnInit {
 
+  showContacts = true;
+
+  contacts: User[];
+
   constructor(
     public assessSvc: AssessmentService,
+    public contactsSvc: ContactsService,
     public navSvc: NavigationService,
     private demoSvc: DemographicService,
     public configSvc: ConfigService
@@ -47,6 +55,21 @@ export class Assessment2InfoComponent implements OnInit {
 
   ngOnInit() {
     this.demoSvc.id = (this.assessSvc.id());
+
+
+    // when the contacts list changes, update the local list
+    this.contactsSvc.contactsUpdated$.subscribe((contacts: User[]) => {
+      this.contacts = structuredClone(contacts);
+    });
+
+    // Anonymous access mode does not show contacts.  Otherwise
+    // defer to the skin's behavior.
+    if (this.configSvc.config.isRunningAnonymous ?? false) {
+      this.showContacts = false;
+    }
+    if (this.configSvc.behaviors?.showContacts ?? true) {
+      this.showContacts = true;
+    }
   }
 
   /**
@@ -54,17 +77,5 @@ export class Assessment2InfoComponent implements OnInit {
    */
   contactsUpdated() {
     this.demographics?.refreshContacts();
-  }
-
-  /**
-   * Anonymous access mode does not show contacts.  Otherwise
-   * defer to the skin's behavior.
-   */
-  showContacts() {
-    if (this.configSvc.config.isRunningAnonymous ?? false) {
-      return false;
-    }
-
-    return this.configSvc.behaviors?.showContacts ?? true;
   }
 }

--- a/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.html
+++ b/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.html
@@ -76,24 +76,28 @@
     </div>
 
 
-    <!-- interested parties -->
-    <div class="form-group" *ngIf="showContacts()">
+    <!-- individuals responsible -->
+    @if(showContacts) {
+    <div class="form-group">
       <div class="d-flex justify-content-between align-items-center flex-11a">
         <label for="contacts" class="form-label">{{ t('observation.individuals responsible') }}</label>
         <button class="btn-link fs-smaller" (click)="clearMulti()">{{ t('observation.clear selections') }}</button>
       </div>
 
       <div class="ps-3 pb-5">
-        <div *ngFor="let contact of observation.observation_Contacts; let i = index" class="py-1">
-          <input class="checkbox-custom d-none" type="checkbox" id="contact_{{i}}"
-            (change)="updateContact(contact, i)" [(ngModel)]="contact.selected">
+        @for(contact of observation.observation_Contacts; track $index; let i = $index) {
+        <div class="py-1">
+          <input class="checkbox-custom d-none" type="checkbox" id="contact_{{i}}" 
+            [(ngModel)]="contact.selected"
+            (change)="updateContact(contact, i)">
           <label for="contact_{{i}}" class="checkbox-custom-label">{{ contact.name }}</label>
         </div>
+        }
       </div>
 
-      <app-assessment-contacts (triggerChange)="refreshContacts()" [impliedSave]="impliedSave"
-        class="mb-4 d-flex justify-content-end flex-00a"></app-assessment-contacts>
+      <app-assessment-contacts [impliedSave]="impliedSave" class="mb-4 d-flex justify-content-end flex-00a"></app-assessment-contacts>
     </div>
+    }
   </mat-dialog-content>
 
   <mat-dialog-actions class="p-3 mb-0 mt-3 d-flex justify-content-between flex-00a">

--- a/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
@@ -25,10 +25,11 @@ import { Component, OnInit, Inject } from '@angular/core';
 import { ObservationsService } from '../../../services/observations.service';
 import { AssessmentService } from '../../../services/assessment.service';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { Observation, Importance } from './observations.model';
-import { map as lodash_map, filter as lodash_filter } from 'lodash';
+import { Observation, Importance, ObservationContact } from './observations.model';
 import { ConfigService } from '../../../services/config.service';
-import { firstValueFrom, Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
+import { ContactsService } from '../../../services/contacts.service';
+import { User } from '../../../models/user.model';
 
 @Component({
   selector: 'app-observations',
@@ -42,6 +43,7 @@ export class ObservationDetailComponent implements OnInit {
   observation: Observation;
   importances: Importance[];
   contactsModel: any[];
+  showContacts = true;
   answerId: number | null;
   questionId: number | null;
   impliedSave: boolean = false;
@@ -51,7 +53,8 @@ export class ObservationDetailComponent implements OnInit {
     private configSvc: ConfigService,
     private dialog: MatDialogRef<ObservationDetailComponent>,
     @Inject(MAT_DIALOG_DATA) public data: Observation,
-    public assessSvc: AssessmentService
+    public assessSvc: AssessmentService,
+    private contactsSvc: ContactsService
   ) {
     this.observation = data;
     this.answerId = data.answer_Id;
@@ -70,9 +73,19 @@ export class ObservationDetailComponent implements OnInit {
       await this.save();
     });
 
+    if (this.configSvc.config.isRunningAnonymous) {
+      this.showContacts = false;
+    }
+
     // makes 'Individuals Responsible' show up initially
-    if (this.observation.observation_Contacts.length == 0)
+    if (this.observation.observation_Contacts.length == 0) {
       this.observation.observation_Contacts = await this.observationsSvc.getContactsForEmptyObservation();
+    }
+
+    // when the contacts list changes, re-draw the Individuals Responsible list accordingly
+    this.contactsSvc.contactsUpdated$.subscribe((contacts: User[]) => {
+      this.refreshIndividualsResponsible(contacts);
+    });
   }
 
   /**
@@ -98,10 +111,12 @@ export class ObservationDetailComponent implements OnInit {
     this.impliedSave = true;
     this.observation.answer_Id = this.answerId;
     this.observation.question_Id = this.questionId;
-    await this.refreshContacts();
+    //this.refreshIndividualsResponsible();
 
     this.observation.answer_Id = this.answerId;
     this.observation.question_Id = this.questionId;
+
+    const resp: any = await firstValueFrom(this.observationsSvc.saveObservation(this.observation));
 
     this.dialog.close(true);
   }
@@ -114,54 +129,21 @@ export class ObservationDetailComponent implements OnInit {
   }
 
   /**
-   * 
+   * Build the checklist of Individuals Responsible 
+   * based on the latest contact list we have been given.
    */
-  showContacts(): boolean {
-    if (this.configSvc.config.isRunningAnonymous) {
-      return false;
-    }
+  refreshIndividualsResponsible(users: User[]) {
+    const oldList = this.observation.observation_Contacts;
 
-    return true;
-  }
-
-  /**
-   * 
-   */
-  async refreshContacts(): Promise<void> {
-    this.observation.answer_Id = this.answerId;
-    this.observation.question_Id = this.questionId;
-
-    const resp: any = await firstValueFrom(this.observationsSvc.saveObservation(this.observation));
-    if ((this.observation.observation_Id == null || this.observation.observation_Id == 0) && resp.observationId) {
-      this.observation.observation_Id = resp.observationId;
-    }
-    if ((this.observation.answer_Id == null ||this.observation.answer_Id == 0) && resp.answerId) {
-      this.observation.answer_Id = resp.answerId;
-    }
-    if ((this.observation.question_Id == null || this.observation.question_Id == 0) && resp.questionId) {
-      this.observation.question_Id = resp.questionId;
-    }
-
-    // the question type 
-    let tempQType = this.observation.question_Type;
-    
-    const response: Observation = await firstValueFrom(
-      this.observationsSvc.getObservation(
-        this.observation.answer_Id,
-        this.observation.observation_Id,
-        this.observation.question_Id,
-        this.observation.question_Type
-      )
-    );
-
-    this.observation = response;
-    this.contactsModel = lodash_map(lodash_filter(this.observation.observation_Contacts,
-      { 'selected': true }),
-      'Assessment_Contact_Id');
-
-    if (this.observation.question_Type == null) {
-      this.observation.question_Type = tempQType;
-    }
+    this.observation.observation_Contacts = [];
+    users.forEach(u => {
+      this.observation.observation_Contacts.push({
+        assessment_Contact_Id: u.assessmentContactId,
+        name: `${u.primaryEmail} -- ${u.firstName} ${u.lastName}`,
+        observation_Id: 0,
+        selected: oldList.find(x => x.assessment_Contact_Id === u.assessmentContactId)?.selected ?? false
+      } as ObservationContact);
+    });
   }
 
   /**

--- a/CSETWebNg/src/app/services/contacts.service.ts
+++ b/CSETWebNg/src/app/services/contacts.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { User } from '../models/user.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ContactsService {
+    private contactsUpdatedSubject = new BehaviorSubject<User[]>([]);
+    public contactsUpdated$ = this.contactsUpdatedSubject.asObservable();
+
+
+    /**
+     * Tell the world that the contacts have been updated
+     */
+    contactsUpdated(contacts: User[]) {
+      this.contactsUpdatedSubject.next(contacts);
+    }
+}


### PR DESCRIPTION
The assessment-contacts control now talks to other components more cleanly with a BehaviorSubject.  This eliminates wasted trips to the back-end that can result in race conditions.

This pull request refactors how assessment contacts are managed and synchronized across Angular components, replacing event-based updates with a shared service and observable pattern. The changes improve data consistency, simplify component interactions, and modernize template syntax.

Key changes include:

**Contact Synchronization and State Management:**
- Introduced `ContactsService` as a shared service with an observable to broadcast contact list changes across components, replacing manual event emitters and input/output bindings. Components like `AssessmentConfigIodComponent`, `AssessmentDemographicsComponent`, and `Assessment2InfoComponent` now subscribe to this observable to keep their local contact lists in sync. [[1]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6R34) [[2]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6R82-R86) [[3]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR37) [[4]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR83) [[5]](diffhunk://#diff-f940e2706b03057674476f00896b3ecc430636b276e06496dff185dfb4a8038cR114-R118) [[6]](diffhunk://#diff-2f126b04593cca48eb102077dab5e80b84dfb62d5be076cec9c6ecffab761fbbR30-R32) [[7]](diffhunk://#diff-2f126b04593cca48eb102077dab5e80b84dfb62d5be076cec9c6ecffab761fbbR42-R48) [[8]](diffhunk://#diff-2f126b04593cca48eb102077dab5e80b84dfb62d5be076cec9c6ecffab761fbbR58-R72)

- The `AssessmentContactsComponent` now broadcasts contact updates via the service instead of emitting events, and other components update their local state based on these broadcasts. [[1]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eR39) [[2]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL48) [[3]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eR64) [[4]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eR83-R90)

**Template and Component Cleanup:**
- Removed the `triggerChange` output and related event handling from `AssessmentContactsComponent` and its usage in parent components, simplifying the communication pattern. [[1]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL48) [[2]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L130-R130) [[3]](diffhunk://#diff-bc9d52715099a6bcfd1524ed6e9bff1e5c5b5cef1fc400e04d47a2d5c4a49a49L25-R30)
- Updated Angular templates to use the modern `@for` and `@if` syntax for cleaner, more readable code. [[1]](diffhunk://#diff-fb411aa4544c2da89fe20b2d3d3fa6f654054ffe5637d17ddf54415fa892c3dfL27-R51) [[2]](diffhunk://#diff-bc9d52715099a6bcfd1524ed6e9bff1e5c5b5cef1fc400e04d47a2d5c4a49a49L25-R30)

**Component Logic Improvements:**
- Removed redundant or now-unnecessary methods such as `refreshContacts()` in parent components, as contact updates are now handled reactively via the service. [[1]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6L67) [[2]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6L141-L148) [[3]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL96-L103)
- Updated the logic in `Assessment2InfoComponent` to determine when to show contacts based on configuration and anonymous mode, with state now managed via a property instead of a method. [[1]](diffhunk://#diff-2f126b04593cca48eb102077dab5e80b84dfb62d5be076cec9c6ecffab761fbbR58-R72) [[2]](diffhunk://#diff-2f126b04593cca48eb102077dab5e80b84dfb62d5be076cec9c6ecffab761fbbL58-L69)

**Consistency and Bug Fixes:**
- Ensured that all contact-related actions (add, remove, edit) trigger a full refresh and broadcast of the contact list, improving UI consistency and reducing the chance of stale data. [[1]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL190-R188) [[2]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL220-R239) [[3]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL287-R280) [[4]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eR289-L297) [[5]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eL313-R310) [[6]](diffhunk://#diff-3f96b84529483d1367a22b93925271e612c2b5f0700de950522f2be845345b2eR83-R90)

**Backend Robustness:**
- Improved robustness in the backend contact removal logic by only attempting to remove a contact if it exists, preventing exceptions for missing users.

These changes collectively modernize the contact management flow, making the codebase easier to maintain and less error-prone.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
