### PR TITLE
Fixed bootstrap margin and padding classes

### DIFF
--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -149,7 +149,7 @@
                 <mat-icon style="position: relative; top: -0.1rem">
                   {{ navTreeSvc?.tocControl?.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
                 </mat-icon>
-                <div class="text-wrap text-start u-hover tw:ml-2">
+                <div class="text-wrap text-start u-hover tw:ms-2">
                   {{ node?.label }}
                 </div>
               </div>
@@ -157,7 +157,7 @@
 
             <ul
               role="tree"
-              class="mat-tree-node tw:ml-4 tw:pl-2 tw:border-l tw:border-[#6b7280]"
+              class="mat-tree-node tw:ms-4 tw:ps-2 tw:border-l tw:border-[#6b7280]"
               *ngIf="navTreeSvc?.tocControl?.isExpanded(node)"
             >
               <ng-container matTreeNodeOutlet></ng-container>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -119,7 +119,7 @@
       </div>
 
       <div class="mb-4">
-        <label for="self-assessment" class="form-label tw:mr-3">{{ t('self assessment') }}</label>
+        <label for="self-assessment" class="form-label tw:me-3">{{ t('self assessment') }}</label>
         <input type="checkbox" name="self-assessment" id="self-assessment" [(ngModel)]="demographics.selfAssessment"
           [checked]="demographics.selfAssessment" (change)="updateDemographics()" class="tw:toggle">
       </div>

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.html
@@ -97,7 +97,7 @@
         </div>
 
         <div class="mb-4">
-            <label for="self-assessment" class="form-label tw:mr-3">{{ t('self assessment') }}</label>
+            <label for="self-assessment" class="form-label tw:me-3">{{ t('self assessment') }}</label>
             <input type="checkbox" name="self-assessment" id="self-assessment"
                 [(ngModel)]="demographics.selfAssessment" (change)="updateDemographics()" class="tw:toggle">
         </div>

--- a/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.html
@@ -80,7 +80,7 @@
 
                     <div class="w-100 flex-column">
 
-                        <div *ngIf="titlePlacement == 'top'" class="mb-2 mr-3 text-nowrap fw-bold">
+                        <div *ngIf="titlePlacement == 'top'" class="mb-2 me-3 text-nowrap fw-bold">
                             {{ q.displayNumber }}</div>
 
                         <div *ngIf="!!q.shortName" class="mb-1 fst-italic fw-bold"

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
@@ -110,7 +110,7 @@
             <div class="w-100 d-flex flex-row" *ngIf="!layoutSvc.hp">
               <div class="flex-column">
 
-                <div *ngIf="titlePlacement == 'top'" class="mb-2 mr-3 text-nowrap fw-bold">
+                <div *ngIf="titlePlacement == 'top'" class="mb-2 me-3 text-nowrap fw-bold">
                   {{ q.displayNumber }}</div>
 
                 <div style="width: 100%; list-style-type: none;">

--- a/CSETWebNg/src/app/assessment/results/reports/reports.component.html
+++ b/CSETWebNg/src/app/assessment/results/reports/reports.component.html
@@ -78,7 +78,7 @@
         (click)="clickExport()" matTooltip="{{'tooltip.export assessment' | transloco }}({{
               exportExtension
             }}).">
-        <span class="cset-icons-export-up fs-base-2 mr-2"></span>
+        <span class="cset-icons-export-up fs-base-2 me-2"></span>
         <span>Export</span>
       </button>
     </div>

--- a/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
+++ b/CSETWebNg/src/app/builder/custom-set-list/custom-set-list.component.ts
@@ -131,7 +131,7 @@ export class SetListComponent implements OnInit {
 
     if (this.setsInUseList.find(x => x.setName === s.setName)) {
       dialogRef.componentInstance.confirmMessage +=
-        "<div class=\"d-flex justify-content-center mt-2\"><span class=\"mr-3 fs-base-6 cset-icons-exclamation-triangle\" style=\"color: #856404\"></span>This module is currently in use in one or more assessments.<br/> All assessment data pertaining to the module will be lost.</div>";
+        "<div class=\"d-flex justify-content-center mt-2\"><span class=\"me-3 fs-base-6 cset-icons-exclamation-triangle\" style=\"color: #856404\"></span>This module is currently in use in one or more assessments.<br/> All assessment data pertaining to the module will be lost.</div>";
     }
 
     dialogRef.afterClosed().subscribe(result => {

--- a/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.html
+++ b/CSETWebNg/src/app/dialogs/select-assessments/select-assessments.component.html
@@ -33,7 +33,7 @@
 
   <mat-dialog-content class="p-3 pe-0 d-flex flex-column flex-11a">
     <form name="form" #userForm="ngForm">
-      <div class="mt-0 me-3 ml-3 mb-3">
+      <div class="mt-0 me-3 ms-3 mb-3">
         <table>
           <tr *ngFor="let a of assessments">
             <td class="align-top">

--- a/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
+++ b/CSETWebNg/src/app/dialogs/user-settings/user-settings.component.html
@@ -25,7 +25,7 @@
   class="edit-user-dialog d-flex flex-column justify-content-center flex-11a tw:rounded-xl tw:shadow-xl">
   <div class="mat-dialog-header p-3 d-flex justify-content-start align-items-center flex-00a">
     <span class="fa-solid fa-gear fs-base me-2 align-middle"></span>
-    <div class="pl-2">
+    <div class="ps-2">
       <span>
         {{t('menu.user.settings')}}
       </span>
@@ -35,16 +35,16 @@
   <mat-dialog-content class="p-4 d-flex flex-column flex-11a">
     <div class="tw:m-1">
 
-      <div class="d-flex align-items-center pl-3 m-2 mb-4">
+      <div class="d-flex align-items-center ps-3 m-2 mb-4">
         <span class="fa-solid fa-lock fs-base-4 me-1"></span>
         <span class="fw-300 form-label me-2">{{t('menu.user.encrypt')}}</span>
         <input type="checkbox" name="encryption" id="encryption" [checked]="encryption"
           (change)="updateEncryptPreference()" class="tw:toggle">
-        <!--        <span class="tw:ml-3">{{ encryption ? t('menu.user.on') : t('menu.user.off') }}</span>-->
+        <!--        <span class="tw:ms-3">{{ encryption ? t('menu.user.on') : t('menu.user.off') }}</span>-->
       </div>
 
 
-      <div class="pl-3 m-2 mb-4">
+      <div class="ps-3 m-2 mb-4">
         <form name="form" #userForm="ngForm">
           <div class="d-flex align-items-center">
             <span class="fas fa-language fs-base-4 me-1"></span>
@@ -58,7 +58,7 @@
         </form>
       </div>
 
-      <div *ngIf="showCisaAssessorWorkflowSwitch()" class="pl-3 m-2 mb-4">
+      <div *ngIf="showCisaAssessorWorkflowSwitch()" class="ps-3 m-2 mb-4">
         <div class="d-flex align-items-center">
           <span class="fa fa-globe fs-base-4 me-1"></span>
           <span class="fw-300 form-label me-2">{{ t('assessor workflow.user is cisa assessor')}}</span>

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
@@ -50,7 +50,7 @@
   <div *ngIf="checkActive('newAssessment')" class="pt-3">
     <div class="input-bar m-6">
       <div class="input-bar-item" style="width:300px;">
-        <div class="input-group tw:w-85 tw:pt-5 tw:pr-2.5 tw:pb-0 tw:pl-10">
+        <div class="input-group tw:w-85 tw:pt-5 tw:pr-2.5 tw:pb-0 tw:ps-10">
           <input #searchGallery type="text" class="form-control" [placeholder]="t('tooltip.search')"
             (keyup.enter)="changeToSearch(searchGallery.value)" aria-label="search gallery"
             aria-describedby="search-gallery">

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
@@ -51,11 +51,6 @@ export class LandingPageTabsComponent implements OnInit {
     if (this._tabsElementRef) {
       const tabsEl = this._tabsElementRef.nativeElement;
       tabsEl.classList.add('sticky-tabs');
-      if (this.authSvc.isLocal && this.devMode) {
-        tabsEl.style.top = '81px';
-      } else {
-        tabsEl.style.top = '62px';
-      }
     }
   }
 

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
@@ -36,145 +36,104 @@
         <div class="mt-1 mb-1 d-flex flex-column justify-content-between flex-00a">
           <div class="d-flex justify-content-between flex-00a">
             <div class="d-flex flex-row">
-              <button
-                *ngIf="configSvc.showExportAllButton()"
-                tabindex="0"
-                class="m-0 btn btn-secondary d-flex align-items-center flex-00a"
-                (click)="exportAllAssessments()"
-                matTooltip="{{ t('tooltip.export all') }}"
-                [disabled]="exportAllInProgress"
-              >
+              <button *ngIf="configSvc.showExportAllButton()" tabindex="0"
+                class="m-0 btn btn-secondary d-flex align-items-center flex-00a" (click)="exportAllAssessments()"
+                matTooltip="{{ t('tooltip.export all') }}" [disabled]="exportAllInProgress">
                 <span class="cset-icons-export-up fs-base-2 me-2"></span>
                 <span class="icon-link-button-text-dark">{{ t('export all') }}</span>
               </button>
             </div>
           </div>
-          <div
-            *ngIf="unsupportedImportFile"
-            class="alert-danger mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-00a"
-          >
+          <div *ngIf="unsupportedImportFile"
+            class="alert-danger mt-4 mb-4 d-flex flex-row justify-content-center align-items-center flex-00a">
             <span class="p-2 fs-large cset-icons-exclamation-triangle"></span>
             <div class="p-2 d-flex flex-column justify-content-center flex-01a">
               <span class="fs-base-3">{{ t('errors.import unsuported file 1') }}</span>
-              <span class="fs-base-1"
-                ><a
-                  href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
-                  target="_blank"
-                  tabindex="0"
-                  rel="noopener noreferrer"
-                >
-                  {{ t('errors.import unsuported file 2') }}</a
-                ></span
-              >
+              <span class="fs-base-1"><a href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
+                  target="_blank" tabindex="0" rel="noopener noreferrer">
+                  {{ t('errors.import unsuported file 2') }}</a></span>
             </div>
           </div>
         </div>
       </ng-container>
-      <div
-        *ngIf="sortedAssessments != null"
-        class="tw:justify-between tw:items-center tw:mb-2 tw:grid tw:grid-cols-1 tw:lg:grid-cols-2 tw:lg:gap-36 px-4"
-      >
-        <div class="tw:flex tw:w-full sm:tw:w-auto">
+
+      <div *ngIf="sortedAssessments != null"
+        class="tw:justify-between tw:items-center tw:mb-2 tw:grid tw:grid-cols-1 tw:lg:grid-cols-2 tw:lg:gap-36 px-4">
+        <div class="tw:flex tw:w-full sm:tw:w-auto mt-3">
           <div
-            class="tw:flex tw:w-full sm:tw:w-auto tw:bg-transparent tw:rounded-lg tw:p-1 tw:border tw:border-gray-200 tw:shadow-sm"
-          >
-            <button
-              type="button"
+            class="tw:flex tw:w-full sm:tw:w-auto tw:bg-transparent tw:rounded-lg tw:p-1 tw:border tw:border-gray-200 tw:shadow-sm">
+            <button type="button"
               class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
               [class]="
                 currentFilter === 'all'
                   ? 'tw:bg-blue-100 tw:text-cset-primary'
                   : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
-              "
-              (click)="setFilter('all')"
-            >
+              " (click)="setFilter('all')">
               {{ t('filters.view all') || 'View all' }}
             </button>
-            <button
-              type="button"
+            <button type="button"
               class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
               [class]="
                 currentFilter === 'done'
                   ? 'tw:bg-blue-100 tw:text-cset-primary'
                   : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
-              "
-              (click)="setFilter('done')"
-            >
+              " (click)="setFilter('done')">
               {{ t('filters.done') || 'Done' }}
             </button>
-            <button
-              type="button"
+            <button type="button"
               class="tw:px-4 tw:py-2 tw:rounded-md tw:text-sm tw:font-medium tw:transition-colors tw:flex-1 sm:tw:flex-none"
               [class]="
                 currentFilter === 'favorite'
                   ? 'tw:bg-blue-100 tw:text-cset-primary'
                   : 'tw:text-gray-600 tw:hover:text-gray-800 tw:dark:text-gray-200 tw:dark:hover:text-gray-400'
-              "
-              (click)="setFilter('favorite')"
-            >
+              " (click)="setFilter('favorite')">
               {{ t('filters.favorites') || 'Favorites' }}
             </button>
           </div>
         </div>
-        <div class="tw:flex tw:flex-col tw:sm:flex-row tw:gap-3 flex-wrap mt-2">
+
+        @if(sortedAssessments?.count > 0) {
+        <div class="tw:flex tw:flex-col tw:sm:flex-row tw:gap-3 flex-wrap mt-3">
           <!-- Import Button (Local) -->
-          <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-                 tabindex="0"
-                 class="btn btn-outline btn-neutral tw:h-12 tw:flex tw:justify-center tw:items-center px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit cursor-pointer tw:border tw:border-border"
-                 matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
-            <span class="tw:mr-3 tw:text-lg cset-icons-import"></span>
+          <label *ngIf="authSvc.isLocal && configSvc.showImportButton()" tabindex="0"
+            class="btn btn-outline btn-neutral tw:h-12 tw:flex tw:justify-center tw:items-center px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit cursor-pointer tw:border tw:border-border"
+            matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+            <span class="tw:me-3 tw:text-lg cset-icons-import"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('buttons.import') }}</span>
-            <input type="file"
-                   tabindex="0"
-                   class="tw:hidden"
-                   id="importFile"
-                   multiple
-                   accept="{{ importExtensions }},.cset"
-                   (change)="importAssessmentFile($event)">
+            <input type="file" tabindex="0" class="tw:hidden d-none" id="importFile" multiple
+              accept="{{ importExtensions }},.cset" (change)="importAssessmentFile($event)">
           </label>
 
           <!-- Import Button (Non-Local) -->
-          <label
-            *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+          <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
             class="btn btn-outline btn-neutral tw:h-12 tw:flex tw:justify-center tw:items-center px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit cursor-pointer tw:border tw:border-border"
-            matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
-          >
-            <span class="tw:mr-3 tw:text-lg cset-icons-import"></span>
+            matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
+            <span class="tw:me-3 tw:text-lg cset-icons-import"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('buttons.import') }}</span>
-            <input
-              type="file"
-              tabindex="-1"
-              class="tw:hidden"
-              id="importFile"
-              multiple
-              accept="{{ importExtensions }}"
-              (change)="importAssessmentFile($event)"
-            />
+            <input type="file" tabindex="-1" class="tw:hidden d-none" id="importFile" multiple accept="{{ importExtensions }}"
+              (change)="importAssessmentFile($event)" />
           </label>
 
           <!-- New Assessment Button -->
           <button
             class="btn btn-primary tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-            (click)="clickNewAssessmentButton()"
-            matTooltip="{{ t('welcome page.new assessment tooltip') }}"
-          >
-            <span class="tw:mr-3 tw:text-lg cset-icons-cset-lock"></span>
+            (click)="clickNewAssessmentButton()" matTooltip="{{ t('welcome page.new assessment tooltip') }}">
+            <span class="tw:me-3 tw:text-lg cset-icons-cset-lock"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('welcome page.new assessment') }}</span>
           </button>
 
           <!-- Export All Button -->
-          <button
-            *ngIf="configSvc.showExportAllButton()"
-            tabindex="0"
+          <button *ngIf="configSvc.showExportAllButton()" tabindex="0"
             class="btn btn-secondary flex tw:justify-center tw:items-center h-12 px-6 tw:shadow-sm w-50"
-            (click)="exportAllAssessments()"
-            matTooltip="{{ t('tooltip.export all') }}"
-            [disabled]="exportAllInProgress"
-          >
-            <span class="cset-icons-export-up tw:text-lg tw:mr-3"></span>
+            (click)="exportAllAssessments()" matTooltip="{{ t('tooltip.export all') }}"
+            [disabled]="exportAllInProgress">
+            <span class="cset-icons-export-up tw:text-lg tw:me-3"></span>
             <span class="tw:text-sm tw:font-medium">{{ t('export all') }}</span>
           </button>
         </div>
+        }
+
+
         <ng-template #noAssessmentsElseBlock>
           <h2 class="mt-0" *ngIf="sortedAssessments?.length == 0">
             <div>{{ t('welcome page.welcome to', { appTitle: appTitle }) }}</div>
@@ -185,66 +144,40 @@
               <div class="tw:flex tw:flex-wrap tw:justify-content-between tw:flex-11a">
                 <button
                   class="m-0 p-3 tw:me-sm-2 tw:me-md-3 tw:me-lg-4 btn btn-primary d-flex align-items-center flex-11a lp-btn-mw-lg"
-                  (click)="clickNewAssessmentButton()"
-                  matTooltip="{{ t('welcome page.new assessment tooltip') }}"
-                >
+                  (click)="clickNewAssessmentButton()" matTooltip="{{ t('welcome page.new assessment tooltip') }}">
                   <span class="tw:me-3 landing-icon landing-icon-sm cset-icons-cset-lock"></span>
                   <span class="landing-button-text landing-button-text-sm">{{ t('welcome page.new assessment') }}</span>
                 </button>
                 <!-- <hr class="landing my-4"> -->
-                <label
-                  *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+                <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
                   class="tw:mt-3 tw:mt-sm-3 tw:mt-md-0 tw:p-3 tw:c-gray-900 btn btn-secondary tw:d-flex tw:align-items-center tw:flex-11a tw:lp-btn-mw-lg"
-                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
-                >
+                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
                   <span class="tw:me-3 tw:landing-icon tw:landing-icon-sm cset-icons-import"></span>
                   <label for="importFile" class="tw:m-0 tw:landing-button-text tw:landing-button-text-sm">
                     {{ t('welcome page.import assessment') }}
                   </label>
-                  <input
-                    type="file"
-                    class="display-none"
-                    id="importFile"
-                    multiple
-                    accept="{{ importExtensions }},.cset"
-                    (change)="importAssessmentFile($event)"
-                  />
+                  <input type="file" class="d-none" id="importFile" multiple accept="{{ importExtensions }},.cset"
+                    (change)="importAssessmentFile($event)" />
                 </label>
-                <label
-                  *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+                <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
                   class="p-3 m-0 mt-3 mt-sm-0 c-gray-900 btn btn-secondary d-flex align-items-center flex-11a lp-btn-mw-lg"
-                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})"
-                >
+                  matTooltip="{{ t('tooltip.import', { appName: appName }) }} ({{ importExtensions }})">
                   <span class="me-3 landing-icon landing-icon-sm cset-icons-import"></span>
                   <label for="importFile" class="m-0 landing-button-text landing-button-text-sm">
                     {{ t('welcome page.import assessment') }}
                   </label>
-                  <input
-                    type="file"
-                    class="display-none"
-                    id="importFile"
-                    multiple
-                    accept="{{ importExtensions }}"
-                    (change)="importAssessmentFile($event)"
-                  />
+                  <input type="file" class="d-none" id="importFile" multiple accept="{{ importExtensions }}"
+                    (change)="importAssessmentFile($event)" />
                 </label>
               </div>
             </div>
-            <div
-              *ngIf="unsupportedImportFile"
-              class="alert-danger my-4 d-flex flex-row justify-content-center align-items-center flex-11a"
-            >
+            <div *ngIf="unsupportedImportFile"
+              class="alert-danger my-4 d-flex flex-row justify-content-center align-items-center flex-11a">
               <span class="p-md-3 p-2 fs-large cset-icons-exclamation-triangle"></span>
               <div class="p-md-3 p-2 d-flex flex-column justify-content-center flex-01a">
                 <span class="fs-base-3">{{ t('errors.import unsuported file 1') }}</span>
-                <span class="fs-base-1 mt-2"
-                  ><a
-                    href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >{{ t('errors.import unsuported file 2') }}</a
-                  ></span
-                >
+                <span class="fs-base-1 mt-2"><a href="{{ this.configSvc.docUrl }}htmlhelp/importing_a__cset_file.htm"
+                    target="_blank" rel="noopener noreferrer">{{ t('errors.import unsuported file 2') }}</a></span>
               </div>
             </div>
           </div>
@@ -261,15 +194,8 @@
 
       <div *ngIf="sortedAssessments?.length > 0" class="px-4 d-flex flex-column flex-11a oy-auto">
         <!-- table for handset portrait -->
-        <table
-          *ngIf="layoutSvc.hp"
-          role="presentation"
-          aria-label="assessments"
-          matSort
-          (matSortChange)="sortData($event)"
-          class="assessment-summary"
-          style="overflow-x: auto"
-        >
+        <table *ngIf="layoutSvc.hp" role="presentation" aria-label="assessments" matSort
+          (matSortChange)="sortData($event)" class="assessment-summary" style="overflow-x: auto">
           <th aria-label="assessment name" mat-sort-header="assessment" style="width: 25%">
             {{ t('assessment name') }}
           </th>
@@ -277,30 +203,21 @@
           <th [aria-label]="tSvc.translate('actions')" style="width: 5%" *ngIf="layoutSvc.hp"></th>
           <tr *ngFor="let assessment of filteredAssessments; let i = index">
             <td>
-              <button
-                tabindex="0"
+              <button tabindex="0"
                 class="btn btn-link btn-link-dark d-flex justify-content-start align-items-start flex-00a wrap-text text-start"
-                (click)="this.navSvc.beginAssessment(assessment.assessmentId)"
-              >
+                (click)="this.navSvc.beginAssessment(assessment.assessmentId)">
                 {{ assessment.assessmentName }}
               </button>
             </td>
             <td>{{ systemTimeTranslator(assessment.lastModifiedDate, 'med') }}</td>
             <td class="text-nowrap ps-1">
-              <button
-                tabindex="0"
-                class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
-                (click)="removeAssessment(assessment, i)"
-                matTooltip="{{ t('tooltip.remove assessment') }}"
-              >
+              <button tabindex="0" class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
+                (click)="removeAssessment(assessment, i)" matTooltip="{{ t('tooltip.remove assessment') }}">
                 <span class="cset-icons-trash-x fs-base-2"></span>
               </button>
-              <button
-                tabindex="0"
-                class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
+              <button tabindex="0" class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
                 (click)="clickDownloadLink(assessment.assessmentId)"
-                matTooltip="{{ t('tooltip.export assessment') }} ({{ exportExtension }})."
-              >
+                matTooltip="{{ t('tooltip.export assessment') }} ({{ exportExtension }}).">
                 <span class="cset-icons-export-up fs-base-2"></span>
               </button>
             </td>
@@ -310,21 +227,11 @@
           <div class="overflow-x-auto rounded-lg border border-gray-200" style="border-radius: 10px">
             <ag-grid-angular
               class="ag-theme-alpine tw:w-full tw:rounded-lg tw:[&_.ag-header-cell-label]:text-white tw:[&_.ag-icon-filter]:text-white tw:[&_.ag-root-wrapper]:rounded-lg tw:[&_.ag-header]:rounded-t-lg tw:[&_.ag-body-viewport]:rounded-b-lg tw:[&_.ag-icon-asc]:text-white tw:[&_.ag-icon-desc]:text-white tw:[&_.ag-sort-indicator-icon]:text-white"
-              theme="legacy"
-              [columnDefs]="columnDefs"
-              [defaultColDef]="defaultColDef"
-              [pagination]="true"
-              [paginationPageSize]="20"
-              [suppressCellFocus]="true"
-              [rowHeight]="50"
-              [headerHeight]="50"
-              (gridReady)="onGridReady($event)"
-              (paginationChanged)="onPaginationChanged()"
-              (firstDataRendered)="onFirstDataRendered()"
-              (cellClicked)="onCellClicked($event)"
-              [style.height.px]="dynamicGridHeight"
-              style="width: 100%"
-            >
+              theme="legacy" [columnDefs]="columnDefs" [defaultColDef]="defaultColDef" [pagination]="true"
+              [paginationPageSize]="20" [suppressCellFocus]="true" [rowHeight]="50" [headerHeight]="50"
+              (gridReady)="onGridReady($event)" (paginationChanged)="onPaginationChanged()"
+              (firstDataRendered)="onFirstDataRendered()" (cellClicked)="onCellClicked($event)"
+              [style.height.px]="dynamicGridHeight" style="width: 100%">
             </ag-grid-angular>
           </div>
         </div>
@@ -346,40 +253,27 @@
           <div class="tw:flex tw:gap-3">
             <button
               class="btn btn-primary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-              (click)="clickNewAssessmentButton()"
-            >
-              <span class="mr-2 cset-icons-cset-lock"></span>
+              (click)="clickNewAssessmentButton()">
+              <span class="me-2 cset-icons-cset-lock"></span>
               {{ t('welcome page.new assessment') }}
             </button>
 
             <!-- Local import button -->
-            <label
-              *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-              class="btn btn-secondary cursor-pointer tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-            >
-              <span class="mr-2 cset-icons-import"></span>
+            <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+              class="btn btn-secondary cursor-pointer tw:h-12 tw:flex px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center">
+              <span class="me-2 cset-icons-import"></span>
               {{ t('welcome page.import assessment') }}
-              <input
-                type="file"
-                class="hidden"
-                accept="{{ importExtensions }},.cset"
-                (change)="importAssessmentFile($event)"
-              />
+              <input type="file" class="hidden d-none" accept="{{ importExtensions }},.cset"
+                (change)="importAssessmentFile($event)" />
             </label>
 
             <!-- Non-local import button -->
-            <label
-              *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-              class="btn btn-secondary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center"
-            >
-              <span class="mr-2 cset-icons-import"></span>
+            <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+              class="btn btn-secondary tw:h-12 tw:flex tw:px-6 tw:shadow-sm tw:flex-1 tw:min-w-fit tw:justify-center tw:items-center">
+              <span class="me-2 cset-icons-import"></span>
               {{ t('welcome page.import assessment') }}
-              <input
-                type="file"
-                class="tw:hidden"
-                accept="{{ importExtensions }}"
-                (change)="importAssessmentFile($event)"
-              />
+              <input type="file" class="tw:hidden d-none" accept="{{ importExtensions }}"
+                (change)="importAssessmentFile($event)" />
             </label>
           </div>
         </div>
@@ -395,38 +289,26 @@
         <p class="tw:text-text-secondary mb-4">{{ t('welcome page.to get started') }}</p>
         <div class="flex flex-col gap-3">
           <button class="btn btn-primary w-full tw:justify-center tw:items-center" (click)="clickNewAssessmentButton()">
-            <span class="mr-2 cset-icons-cset-lock"></span>
+            <span class="me-2 cset-icons-cset-lock"></span>
             {{ t('welcome page.new assessment') }}
           </button>
 
           <!-- Local import button for mobile -->
-          <label
-            *ngIf="authSvc.isLocal && configSvc.showImportButton()"
-            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center"
-          >
-            <span class="mr-2 cset-icons-import"></span>
+          <label *ngIf="authSvc.isLocal && configSvc.showImportButton()"
+            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center">
+            <span class="me-2 cset-icons-import"></span>
             {{ t('welcome page.import assessment') }}
-            <input
-              type="file"
-              class="tw:hidden"
-              accept="{{ importExtensions }},.cset"
-              (change)="importAssessmentFile($event)"
-            />
+            <input type="file" class="tw:hidden d-none" accept="{{ importExtensions }},.cset"
+              (change)="importAssessmentFile($event)" />
           </label>
 
           <!-- Non-local import button for mobile -->
-          <label
-            *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
-            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center"
-          >
-            <span class="mr-2 cset-icons-import"></span>
+          <label *ngIf="!authSvc.isLocal && configSvc.showImportButton()"
+            class="btn btn-secondary tw:w-full cursor-pointer tw:justify-center tw:items-center">
+            <span class="me-2 cset-icons-import"></span>
             {{ t('welcome page.import assessment') }}
-            <input
-              type="file"
-              class="tw:hidden"
-              accept="{{ importExtensions }}"
-              (change)="importAssessmentFile($event)"
-            />
+            <input type="file" class="tw:hidden d-none" accept="{{ importExtensions }}"
+              (change)="importAssessmentFile($event)" />
           </label>
         </div>
       </div>

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -691,18 +691,18 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
             data-assessment-id="${assessmentId}"
             data-row-index="${rowIndex}"
             title="Remove assessment">
-      <span class="cset-icons-trash-x tw:text-sm mr-2"></span>
+      <span class="cset-icons-trash-x tw:text-sm me-2"></span>
       <span class="text-nowrap">${labelRemove}</span>
     </button>
   `;
 
     if (this.showColumn('export')) {
       buttons += `
-      <button class="btn btn-ghost btn-sm ml-1"
+      <button class="btn btn-ghost btn-sm ms-1"
               data-action="export"
               data-assessment-id="${assessmentId}"
               title="Export assessment">
-        <span class="cset-icons-export-up tw:text-sm mr-2"></span>
+        <span class="cset-icons-export-up tw:text-sm me-2"></span>
         <span class="text-nowrap">${labelExport}</span>
       </button>
     `;
@@ -710,11 +710,11 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
 
     if (this.showColumn('export json')) {
       buttons += `
-      <button class="btn btn-ghost btn-sm ml-1"
+      <button class="btn btn-ghost btn-sm ms-1"
               data-action="exportJson"
               data-assessment-id="${assessmentId}"
               title="Export assessment JSON">
-        <span class="cset-icons-export-up tw:text-sm mr-2"></span>
+        <span class="cset-icons-export-up tw:text-sm me-2"></span>
         <span class="text-nowrap">${labelExportJson}</span>
       </button>
     `;
@@ -724,7 +724,7 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
     if (this.showColumn('export json')) {
       const uploaded = !!assessment.jsonUploaded;
       jsonIndicator = `
-      <div class="tw:flex tw:items-center tw:border-l tw:border-base-300 tw:pl-2 tw:ml-1" title="Check to indicate that the JSON file has been submitted to CISA">
+      <div class="tw:flex tw:items-center tw:border-l tw:border-base-300 tw:ps-2 tw:ms-1" title="Check to indicate that the JSON file has been submitted to CISA">
         <input type="checkbox" id="json-uploaded-${assessmentId}" ${uploaded ? 'checked' : ''}
                class="checkbox-custom"
                data-action="toggleJsonUploaded"

--- a/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
+++ b/CSETWebNg/src/app/initial/new-assessment/new-assessment.component.html
@@ -30,7 +30,7 @@
             'tw:bg-cset-primary tw:text-white tw:dark:text-gray-200 tw:[&>i]:text-black': selectedCategory === 'favorites',
             'tw:text-text-primary': selectedCategory !== 'favorites'
           }" (click)="selectCategory('favorites')">
-        <i class="fa-solid fa-star tw:scale-125 tw:inline-block tw:text-[#15288] tw:mr-2"
+        <i class="fa-solid fa-star tw:scale-125 tw:inline-block tw:text-[#15288] tw:me-2"
           style="text-shadow: 0 0 3px currentColor"></i>
         {{ t('gallery.favorites') }}
 
@@ -51,7 +51,7 @@
           'tw:bg-cset-primary tw:text-white tw:dark:text-gray-200 tw:[&>i]:text-black':  selectedCategoryId === row.group_Id,
           'tw:text-text-primary': selectedCategoryId !== row.group_Id
         }" (click)="selectCategory(row.group_Title)">
-          <i [class]="getCategoryIcon(row.group_Title)" class="tw:mr-2"></i>
+          <i [class]="getCategoryIcon(row.group_Title)" class="tw:me-2"></i>
           {{row.group_Title}}
           <span class="tw:float-right tw:text-text-primary tw:px-2 tw:py-1 tw:rounded tw:text-xs" [ngClass]="{
           'tw:bg-badge-active': selectedCategoryId === row.group_Id,


### PR DESCRIPTION
We had a bunch of pl-, pr-, ml- and mr- classes still hanging around.  Bootstrap changed them to use 's' and 'e' instead of 'l' and 'r' awhile back.

This pull request updates the codebase to use the Bootstrap 5 margin and padding utility classes (`me`, `ms`, `ps`) instead of the deprecated Bootstrap 4 classes (`mr`, `ml`, `pl`). Additionally, it improves the layout and accessibility of the `my-assessments` page by refactoring button and filter group markup. These changes enhance consistency, maintainability, and future compatibility across the application.

**Migration to Bootstrap 5 utility classes:**

* Replaced all instances of `mr-` (margin-right), `ml-` (margin-left), and `pl-` (padding-left) with their Bootstrap 5 equivalents `me-` (margin-end), `ms-` (margin-start), and `ps-` (padding-start) in component templates and dialog markup. [[1]](diffhunk://#diff-ecefc1b419823d403593013d65426811215259b1ee135c134f2637c797f87858L152-R160) [[2]](diffhunk://#diff-aa6bd924628e3d34d639b783546e2d90ac3ecc6424c243275351a08246fff0c7L122-R122) [[3]](diffhunk://#diff-edbdc985d59f6702b912f824334f8da7b047fbb222e226fe311da2f6b0a0eaafL100-R100) [[4]](diffhunk://#diff-8989a3ef1aceb7a6e78a9e34eed1830a8aa113526f9390b38d672251f61e3e7eL83-R83) [[5]](diffhunk://#diff-b28b468c875e3e8204a3022eea5a6697ccea16a86ae89bd1d8f617e25e7c0434L113-R113) [[6]](diffhunk://#diff-34d2d62c5c70e2bc736cd19d971f1e860a40c2ef0f87457ed2e9523d0aea85c6L81-R81) [[7]](diffhunk://#diff-e5f8cf083b4c4e5c129d1f04bfccc8d75ac82e6ad7cae097a704217783668e57L134-R134) [[8]](diffhunk://#diff-fdd0e45f46d9a58e7559217c88d8e6b00182d1524954d9a00f416f15413482c3L36-R36) [[9]](diffhunk://#diff-8bdc23ecf0b0cf593319d495402dbf33895690f136e6f79cbc28bd5a8459f95aL28-R28) [[10]](diffhunk://#diff-8bdc23ecf0b0cf593319d495402dbf33895690f136e6f79cbc28bd5a8459f95aL38-R47) [[11]](diffhunk://#diff-8bdc23ecf0b0cf593319d495402dbf33895690f136e6f79cbc28bd5a8459f95aL61-R61) [[12]](diffhunk://#diff-278faf038e69995fd85f273093f175ab18b800394403b7a18b7c57e61a1dc65dL53-R53)

**UI and accessibility improvements:**

* Refactored the `my-assessments` page to streamline filter and button groups, improved markup for import/export buttons, and ensured proper usage of Bootstrap 5 classes for layout consistency and accessibility.

**Code cleanup:**

* Removed conditional logic for setting the sticky tabs' top offset in `landing-page-tabs.component.ts`, simplifying the code.



## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
