### PR TITLE
ci(workflow): update Docker build workflow with official actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,64 +7,84 @@ on:
       - release/*
   push:
     branches:
+      - develop
       - release/*
-
-env:
-  IMAGE: ${{ secrets.IMAGE }}
-  PAT: ${{ secrets.PAT }}
 
 jobs:
   build-api:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
-    defaults:
-      run:
-        working-directory: ./CSETWebApi
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Registry login
-        run: echo $PAT | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Pull Docker Image
-        run: docker pull $IMAGE/api:latest || true
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PAT }}
 
-      - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/api:latest --cache-from $IMAGE/api:latest
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ secrets.IMAGE }}/api
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
 
-      - name: Push Docker Image
-        run: docker push $IMAGE/api:latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./CSETWebApi
+          file: ./CSETWebApi/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-web:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
-    defaults:
-      run:
-        working-directory: ./CSETWebNg
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Registry login
-        run: echo $PAT | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Pull Docker Image
-        run: docker pull $IMAGE/web:latest || true
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PAT }}
 
-      - name: Tag Docker Image
-        run: docker build -f Dockerfile . --tag $IMAGE/web:latest --cache-from $IMAGE/web:latest
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ secrets.IMAGE }}/web
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
 
-      - name: Push Docker Image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        run: docker push $IMAGE/web:latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./CSETWebNg
+          file: ./CSETWebNg/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   dependabot-build:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
-      
+      - uses: actions/checkout@v4
+
       - name: Basic build test (API)
         working-directory: ./CSETWebApi
         run: docker build -f Dockerfile . --tag test-api:latest
-        
+
       - name: Basic build test (Web)
         working-directory: ./CSETWebNg
         run: docker build -f Dockerfile . --tag test-web:latest


### PR DESCRIPTION
## Summary

Replaces manual `docker` CLI commands in the GitHub Actions build workflow with official Docker actions for better caching, image tagging, and reliability.

## Changes

- **Trigger**: Added `develop` branch to the `push` trigger so images are published when PRs merge to `develop`
- **BuildKit**: Added `docker/setup-buildx-action@v3` to enable BuildKit for all jobs
- **Auth**: Replaced `echo $PAT | docker login ...` with `docker/login-action@v3`
- **Tagging**: Added `docker/metadata-action@v5` to generate both `latest` and `sha-<short-sha>` tags for better image traceability
- **Build & Push**: Replaced manual `docker build` + `docker push` with `docker/build-push-action@v6`
- **Caching**: Added GitHub Actions layer cache (`type=gha, mode=max`) to speed up builds
- **Push control**: Images only pushed on `push` events — PR builds still compile/build without pushing
- **Checkout fix**: Corrected `actions/checkout@v6` (non-existent) to `@v4`

## Breaking Changes

None

## Test Plan

- [ ] Open a PR to `develop` — both `build-api` and `build-web` jobs should build successfully without pushing images
- [ ] Merge a PR to `develop` — both jobs should build and push images tagged as `latest` and `sha-<short-sha>` to ghcr.io
- [ ] Confirm Dependabot PRs still trigger `dependabot-build` job (build-only, no push)
- [ ] Verify image tags appear in the GitHub Container Registry for the repo

## Release Notes

Upgraded the CI Docker build workflow to use official Docker GitHub Actions, enabling GHA layer caching for faster builds and SHA-based image tagging for improved traceability. No user-facing changes.

## Checklist

- [x] Single atomic commit with conventional commit format
- [x] No secrets or credentials in workflow file
- [x] Push gated on event type to prevent unintended publishes