### PR TITLE
Fixed Observation refresh and filtering

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/observations/observation-detail.component.ts
@@ -111,14 +111,10 @@ export class ObservationDetailComponent implements OnInit {
     this.impliedSave = true;
     this.observation.answer_Id = this.answerId;
     this.observation.question_Id = this.questionId;
-    //this.refreshIndividualsResponsible();
-
-    this.observation.answer_Id = this.answerId;
-    this.observation.question_Id = this.questionId;
 
     const resp: any = await firstValueFrom(this.observationsSvc.saveObservation(this.observation));
 
-    this.dialog.close(true);
+    this.dialog.close(resp);
   }
 
   /**

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
@@ -413,7 +413,7 @@ export class QuestionExtrasComponent implements OnInit {
       maxWidth: this.layoutSvc.hp ? '90%' : '750px',
     })
       .afterClosed().subscribe(result => {
-        this.populateList(obs.answer_Id);
+        this.populateList(result.answerId);
       });
   }
 
@@ -428,6 +428,7 @@ export class QuestionExtrasComponent implements OnInit {
     this.obsSvc.getObservationsForAnswer(answerId).subscribe(
       (response: Observation[]) => {
         this.extras.observations = response;
+        this.myQuestion.hasObservation = (this.extras.observations.length > 0);
       },
       error => {
         console.error('Error updating observations | ' + (<Error>error).message);


### PR DESCRIPTION
Return better data from dialog so that the list can refresh itself correctly using the answerId.  Also set the question's .hasObservation property after returning from the dialog so that filtering will work correctly.

This pull request introduces improvements to how observation data is handled and displayed in the assessment questions module. The main changes focus on ensuring updated observation information is properly reflected in the UI and that dialog interactions return more detailed data.

Observation data handling and UI updates:

* Updated the `save()` method in `ObservationDetailComponent` to return the full response from the save operation when closing the dialog, allowing downstream components to access updated observation details.
* Modified the dialog result handling in `QuestionExtrasComponent` to use `result.answerId` instead of `obs.answer_Id` when repopulating the observation list, ensuring the correct answer ID is used after dialog closure.
* Enhanced the observation list update logic in `QuestionExtrasComponent` by setting `myQuestion.hasObservation` to true if observations exist, improving UI feedback for users.





## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
