### PR TITLE
fix(docker): enable nginx API proxy and remove host gateway mapping

### DIFF
--- a/CSETWebNg/etc/nginx/default.conf
+++ b/CSETWebNg/etc/nginx/default.conf
@@ -7,19 +7,19 @@ server {
         index  index.html index.htm;
         try_files $uri /index.html;
     }
-    # location /api {
-    #     proxy_pass http://api:5000/api;
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     # Handle preflight requests
-    #     if ($request_method = OPTIONS) {
-    #         add_header 'Access-Control-Allow-Origin' '*';
-    #         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-    #         add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
-    #         return 204;
-    #     }
-    # }
+    location /api {
+        proxy_pass http://api:5000/api;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # Handle preflight requests
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization';
+            return 204;
+        }
+    }
     # Error pages
     error_page  500 502 503 504 /50x.html;
     location = /50x.html {

--- a/compose.yml
+++ b/compose.yml
@@ -9,8 +9,6 @@ services:
     restart: unless-stopped
     stdin_open: true
     tty: true
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     environment:
       - API_PORT=${API_PORT:-5000}
     ports:


### PR DESCRIPTION
## Summary

- Enable the nginx `/api` location block to proxy API calls from the frontend to the backend `api:5000` service
- Remove the `host.docker.internal:host-gateway` extra_hosts mapping from `compose.yml` since it's no longer needed with nginx handling API routing internally

## Changes

- **`CSETWebNg/etc/nginx/default.conf`**: Uncommented the `/api` proxy location block, routing frontend API requests to the backend via the Docker internal service name (`api:5000`). Also added missing newline at end of file.
- **`compose.yml`**: Removed `extra_hosts: - "host.docker.internal:host-gateway"` from the frontend service since API traffic now routes through nginx to the internal `api` service rather than through the host network.

## Breaking Changes

None — this restores intended nginx proxy behavior for containerized deployments.

## Test Plan

- [ ] Run `task up:dev` (or `docker compose up`) to start the development environment
- [ ] Confirm the frontend loads at `http://localhost`
- [ ] Confirm API calls (e.g., login, assessment list) succeed and are proxied through nginx
- [ ] Verify no CORS errors in the browser console
- [ ] Confirm OPTIONS preflight requests return 204 with appropriate headers

## Related Issues

None

## Release Notes

Fixed nginx configuration for Docker deployments: API requests from the frontend are now correctly proxied to the backend through nginx using Docker's internal service networking. This removes the requirement for the `host.docker.internal` host mapping.

## Checklist

- [x] No application code changed — configuration only
- [x] Conventional commit format followed
- [x] Changes are tightly coupled and committed together