### PR TITLE
feat(docker): add API_PROTOCOL support and fix API_PORT empty-string handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,15 +6,6 @@ WEB_PORT=4200
 WEB_TLS_PORT=443
 API_PORT=5000
 
-# Frontend API URL injection (Optional — required when deploying behind a reverse proxy / on a named host)
-# Set these so the browser resolves API calls to the correct host instead of http://localhost:5000.
-# Example for a TLS-terminated server at https://csetdev1.inl.gov:
-#   API_HOST=csetdev1.inl.gov
-#   API_PROTOCOL=https
-#   API_PORT=          ← empty removes the port (uses standard HTTPS 443)
-#API_HOST=
-#API_PROTOCOL=
-
 # MSSQL Server
 MSSQL_SA_PASSWORD=Password123
 ACCEPT_EULA=Y

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@ WEB_PORT=4200
 WEB_TLS_PORT=443
 API_PORT=5000
 
+# Frontend API URL injection (Optional — required when deploying behind a reverse proxy / on a named host)
+# Set these so the browser resolves API calls to the correct host instead of http://localhost:5000.
+# Example for a TLS-terminated server at https://csetdev1.inl.gov:
+#   API_HOST=csetdev1.inl.gov
+#   API_PROTOCOL=https
+#   API_PORT=          ← empty removes the port (uses standard HTTPS 443)
+#API_HOST=
+#API_PROTOCOL=
+
 # MSSQL Server
 MSSQL_SA_PASSWORD=Password123
 ACCEPT_EULA=Y

--- a/CSETWebNg/etc/docker-entrypoint.sh
+++ b/CSETWebNg/etc/docker-entrypoint.sh
@@ -3,8 +3,9 @@ set -e
 
 CONFIG_FILE="/usr/share/nginx/html/assets/settings/config.json"
 
-# Replace API port if API_PORT env var is set (default: 5000)
-if [ -n "$API_PORT" ]; then
+# Replace API port if API_PORT env var is set (default: 5000).
+# Set API_PORT to empty string to remove the port (e.g., for standard HTTPS on port 443).
+if [ "${API_PORT+x}" = "x" ]; then
   sed -i 's/"port": "5000"/"port": "'"$API_PORT"'"/' "$CONFIG_FILE"
 fi
 
@@ -12,6 +13,12 @@ fi
 if [ -n "$API_HOST" ]; then
   # Replace only the api.host, not app.host - target the line after "api": {
   sed -i '/"api":/,/"library":/ s/"host": "localhost"/"host": "'"$API_HOST"'"/' "$CONFIG_FILE"
+fi
+
+# Replace API protocol if API_PROTOCOL env var is set (default: http).
+# Set to "https" when serving behind a TLS-terminating reverse proxy.
+if [ -n "$API_PROTOCOL" ]; then
+  sed -i '/"api":/,/"library":/ s/"protocol": "http"/"protocol": "'"$API_PROTOCOL"'"/' "$CONFIG_FILE"
 fi
 
 # Start nginx


### PR DESCRIPTION
## Summary
Improves the frontend Docker container's runtime configuration so it can be deployed behind a TLS-terminating reverse proxy on a named host without port numbers. Fixes a subtle bug where setting `API_PORT` to an empty string had no effect.

## Changes
- Add `API_PROTOCOL` env var injection in `docker-entrypoint.sh` to set `http`/`https` in the Angular config at container start
- Fix `API_PORT` guard from `-n` (non-empty) to `${API_PORT+x}` (set at all), so `API_PORT=""` correctly removes the port from the config (needed for standard HTTPS on 443)

## Breaking Changes
None

## Test Plan
- [ ] Start the Docker stack with `API_PROTOCOL=https API_HOST=myhost.example.com API_PORT=` and verify `config.json` inside the container reflects `protocol: https`, `host: myhost.example.com`, and `port: ""`
- [ ] Verify the default case (no env vars set) still produces `http://localhost:5000` in config
- [ ] Verify setting only `API_PORT=8080` still overrides just the port as before

## Related Issues
None

## Release Notes
The frontend Docker container now supports `API_PROTOCOL` (e.g. `https`) and correctly handles an empty `API_PORT` for deployments behind TLS-terminating reverse proxies on standard ports.

## Checklist
- [x] Conventional commit format followed
- [ ] Tested against a reverse-proxy deployment