### PR TITLE
feat(docker): expose API_HOST and API_PROTOCOL env vars and cleanup Dockerfile

### DIFF
--- a/CSETWebApi/Dockerfile
+++ b/CSETWebApi/Dockerfile
@@ -24,9 +24,6 @@ WORKDIR /app
 # Copy published output from build stage
 COPY --from=build /app/out /app/
 
-# Create a file to indicate local installation
-RUN touch LOCAL-INSTALLATION
-
 # Set environment variable (optional if already configured in appsettings/code)
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV HTTP_PORTS=5000

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,8 @@ services:
     tty: true
     environment:
       - API_PORT=${API_PORT:-5000}
+      - API_HOST=${API_HOST:-}
+      - API_PROTOCOL=${API_PROTOCOL:-}
     ports:
       # Override host ports via WEB_PORT / WEB_TLS_PORT without editing this file.
       - ${WEB_PORT:-4200}:80


### PR DESCRIPTION
## Summary
Extends Docker Compose configuration to pass `API_HOST` and `API_PROTOCOL` environment variables through to the frontend service, enabling dynamic API targeting. Also removes an unused `LOCAL-INSTALLATION` marker file from the API Dockerfile.

## Commits
- `a670f17` chore(docker): remove LOCAL-INSTALLATION file creation
- `e814b59` feat(docker): expose API_HOST and API_PROTOCOL env vars in compose.yml

## Changes
- Removed `RUN touch LOCAL-INSTALLATION` from `CSETWebApi/Dockerfile` — the file was created but never needed in the containerized image
- Added `API_HOST` and `API_PROTOCOL` env vars to the frontend service in `compose.yml`, forwarded from the host environment with empty-string defaults (preserving existing behavior when unset)

## Breaking Changes
None

## Test Plan
- [ ] Run `task up` and verify the application starts correctly
- [ ] Set `API_HOST=myhost` and `API_PROTOCOL=https` in `.env` and confirm they are passed into the frontend container (`docker compose exec web env | grep API`)
- [ ] Verify the API container still starts without the LOCAL-INSTALLATION file and functions normally

## Related Issues
Continues work from #5473 (feat/docker-api-proxy-config)

## Release Notes
Docker Compose now forwards `API_HOST` and `API_PROTOCOL` environment variables to the frontend service, allowing operators to configure the API target host and protocol without modifying the compose file. The unused `LOCAL-INSTALLATION` marker file has been removed from the API Docker image.

## Checklist
- [x] Conventional commit format followed
- [x] No breaking changes
- [x] Defaults preserve existing behavior