### PR TITLE
feat(docker): add optional CA_CERT_URL build arg for corporate proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # CSET Web API
 ConnectionStrings__CSET_DB="data source=mssql,1433;initial catalog=CSET;User Id=sa;Password=Password123;Encrypt=False;TrustServerCertificate=True;"
 
+# Optional: URL to a custom CA certificate (for corporate proxies/VPNs)
+# CA_CERT_URL=https://your-internal-cert-store/root_ca.crt
+
 # Host port overrides for Docker Compose (Optional)
 WEB_PORT=4200
 WEB_TLS_PORT=443

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ WARP.md
 /CSETWebApi/CSETWeb_Api/.idea/.idea.CSETWeb_Api/.idea/copilot.data.migration.ask2agent.xml
 /CSETWebApi/CSETWeb_Api/.idea/.idea.CSETWeb_Api/.idea/copilot.data.migration.edit.xml
 
+## Local CA certs (corporate VPN/proxy — never commit) ##
+CSETWebNg/certs/
+CSETWebApi/certs/
+
 ## Mac OS ##
 .DS_Store
 

--- a/CSETWebApi/Dockerfile
+++ b/CSETWebApi/Dockerfile
@@ -4,14 +4,15 @@ WORKDIR /app
 
 COPY . .
 
-# Configure INL certs and environment variables
-# ADD http://certstore.inl.gov/pki/CAINLROOT_B64.crt /usr/local/share/ca-certificates/
-# RUN /usr/sbin/update-ca-certificates
-# ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
-#     REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-#     CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
-#     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
-#     SSL_CERT_DIR=/etc/ssl/certs/
+# Optional: install a custom CA cert for corporate proxies/VPNs.
+# Set CA_CERT_URL in .env (gitignored) to enable — e.g.:
+#   CA_CERT_URL=https://your-internal-cert-store/root_ca.crt
+ARG CA_CERT_URL=""
+RUN if [ -n "$CA_CERT_URL" ]; then \
+  apt-get update && apt-get install -y --no-install-recommends wget && \
+  wget -q --no-check-certificate -P /usr/local/share/ca-certificates/ "$CA_CERT_URL" && \
+  update-ca-certificates; \
+  fi
 
 # Use Release configuration for published output
 RUN dotnet publish CSETWeb_Api/CSETWeb_ApiCore -c Release -o out

--- a/CSETWebNg/Dockerfile
+++ b/CSETWebNg/Dockerfile
@@ -5,6 +5,18 @@ WORKDIR /var/www
 COPY . /var/www/
 
 RUN apt-get update
+
+# Optional: install a custom CA cert for corporate proxies/VPNs.
+# Set CA_CERT_URL in .env (gitignored) to enable — e.g.:
+#   CA_CERT_URL=https://your-internal-cert-store/root_ca.crt
+ARG CA_CERT_URL=""
+RUN if [ -n "$CA_CERT_URL" ]; then \
+    apt-get install -y --no-install-recommends wget && \
+    wget -q --no-check-certificate -P /usr/local/share/ca-certificates/ "$CA_CERT_URL" && \
+    update-ca-certificates; \
+    fi
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 RUN npm i -g @angular/cli \
     && npm i
 

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,8 @@ services:
     image: ghcr.io/cisagov/cset/web:latest
     build:
       context: CSETWebNg
+      args:
+        - CA_CERT_URL=${CA_CERT_URL:-}
     restart: unless-stopped
     stdin_open: true
     tty: true
@@ -23,6 +25,8 @@ services:
     image: ghcr.io/cisagov/cset/api:latest
     build:
       context: CSETWebApi
+      args:
+        - CA_CERT_URL=${CA_CERT_URL:-}
     restart: unless-stopped
     ports:
       # Override host port via API_PORT without editing this file.


### PR DESCRIPTION
## Summary
Replaces the hardcoded INL-specific CA certificate installation in both Dockerfiles with a generic, opt-in mechanism. Users behind corporate proxies or VPNs can now inject a custom CA cert at build time by setting `CA_CERT_URL` in their `.env` file — no changes to committed files required.

## Changes
- Add `CA_CERT_URL` build `ARG` to `CSETWebApi/Dockerfile` and `CSETWebNg/Dockerfile`; conditionally downloads and trusts the cert only when the arg is non-empty
- Set `NODE_EXTRA_CA_CERTS` in the web image so Node.js respects the system trust store after cert installation
- Pass `CA_CERT_URL` as a build arg through `compose.yml` for both `web` and `api` services
- Document the new variable in `.env.example` (commented out by default)
- Add `CSETWebNg/certs/` and `CSETWebApi/certs/` to `.gitignore` to prevent accidental commit of local cert files

## Breaking Changes
None — `CA_CERT_URL` defaults to an empty string, so existing builds are unaffected.

## Test Plan
- [ ] Build without `CA_CERT_URL` set: `docker compose build` — should succeed exactly as before
- [ ] Build with `CA_CERT_URL` set to a reachable cert URL: verify the cert is installed and `update-ca-certificates` runs
- [ ] Verify `NODE_EXTRA_CA_CERTS` is set in the web container: `docker compose run --rm web printenv NODE_EXTRA_CA_CERTS`
- [ ] Confirm no regressions in the standard `task up` / `task build` flows

## Related Issues
N/A

## Release Notes
Docker builds now support an optional `CA_CERT_URL` environment variable. Organizations behind corporate proxies or internal VPNs can set this in their `.env` file to automatically trust a custom CA certificate during image builds, without modifying any committed files.

## Checklist
- [x] Conventional commit format followed
- [x] `.env.example` updated with documentation
- [x] `.gitignore` updated to protect local cert files
- [x] No breaking changes to existing builds