### PR TITLE
Fixed available key calculation in module cloning

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/ModuleBuilder/ModuleBuilderBusiness.cs
@@ -766,16 +766,17 @@ namespace CSETWebCore.Business.ModuleBuilder
                 dbSet.Set_Category_Id = set.SetCategory == 0 ? null : set.SetCategory;
                 dbSet.Is_Custom = set.IsCustom;
                 dbSet.Is_Displayed = set.IsDisplayed;
-
-                var gallItem = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($"[\"{originalSet.Set_Name}\"]")).FirstOrDefault();
-
-                gallItem.Description = gallDescription;
-                gallItem.Title = dbSet.Full_Name;
-
                 _context.SETS.Update(dbSet);
                 _context.SaveChanges();
 
-                _context.GALLERY_ITEM.Update(gallItem);
+                var gallItem = _context.GALLERY_ITEM.Where(x => x.Configuration_Setup.Contains($"[\"{originalSet.Set_Name}\"]")).FirstOrDefault();
+
+                if (gallItem != null)
+                {
+                    gallItem.Description = gallDescription;
+                    gallItem.Title = dbSet.Full_Name;
+                    _context.GALLERY_ITEM.Update(gallItem);
+                }
             }
 
             _context.SaveChanges();

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
@@ -275,9 +275,14 @@ namespace CSETWebCore.Helpers
         /// <returns></returns>
         private int FindSeed(string tableName, string identityColumnName, int recordsNeeded)
         {
-            var gaps = FindGaps(tableName, identityColumnName)
-                    .Where(x => x.GapStart < 1000000 && x.GapSize >= recordsNeeded).OrderBy(x => x.GapSize).ToList();
-            var newSeed = gaps.FirstOrDefault().GapSize;
+            var gaps = FindGaps(tableName, identityColumnName, 1000000)
+                    .Where(x => x.GapSize >= recordsNeeded).OrderBy(x => x.GapSize).ToList();
+
+            var newSeed = 1000000;
+            if (gaps.Count > 0)
+            {
+                newSeed = gaps.FirstOrDefault().GapStart;
+            }
 
             NLog.LogManager.GetCurrentClassLogger().Info($"Calculated new seed value of {newSeed} for table {tableName}");
 
@@ -317,22 +322,26 @@ namespace CSETWebCore.Helpers
 
 
         /// <summary>
-        /// 
+        /// Find contiguous runs of unused identity values in a table.  
         /// </summary>
         /// <param name="tableName"></param>
         /// <param name="identityColumnName"></param>
         /// <returns></returns>
-        private List<GapResult> FindGaps(string tableName, string identityColumnName)
+        private List<GapResult> FindGaps(string tableName, string identityColumnName, int start = 0)
         {
             var sql = "SELECT " +
                 $"{identityColumnName} + 1 AS GapStart, " +
-                    "next_id - 1 AS GapEnd, " +
-                    $"next_id - {identityColumnName} - 1 AS GapSize " +
+                "next_id - 1 AS GapEnd, " +
+                $"next_id - {identityColumnName} - 1 AS GapSize " +
                 "FROM ( " +
                     "SELECT " +
                     $"{identityColumnName}, " +
                     $"LEAD({identityColumnName}) OVER (ORDER BY {identityColumnName}) AS next_id " +
-                    $"FROM {tableName} " +
+                    "FROM ( " +
+                        $"SELECT {identityColumnName} FROM {tableName} WHERE {identityColumnName} >= {start} " +
+                        "UNION ALL " +
+                        $"SELECT {start} - 1 " +
+                    ") anchored " +
                 ") subquery " +
                 $"WHERE next_id - {identityColumnName} > 1 " +
                 "ORDER BY GapStart;";


### PR DESCRIPTION
This pull request introduces improvements to the module cloning and set saving logic, focusing on more robust handling of identity value gaps and database updates. The most important changes are grouped by theme below.

**Identity Value Gap Handling Improvements:**

* Updated the `FindSeed` method in `ModuleCloner.cs` to use a new approach for finding gaps in identity values, setting a default seed of 1,000,000 and only adjusting it if suitable gaps are found, improving reliability when allocating new records.
* Modified the `FindGaps` method to accept a `start` parameter, allowing for more flexible and targeted gap searches, and updated the SQL query to anchor the gap search at the specified start value. [[1]](diffhunk://#diff-c67c68222a2802e351c6e4a470633abf6820981af53782f9ef26d649205f7a3fL320-R330) [[2]](diffhunk://#diff-c67c68222a2802e351c6e4a470633abf6820981af53782f9ef26d649205f7a3fL335-R344)

**Database Update Logic Enhancements:**

* Improved the `SaveSetDetail` method in `ModuleBuilderBusiness.cs` to ensure that set and gallery item updates are properly saved to the database, with changes to the order and conditions of `Update` and `SaveChanges` calls for better consistency and reliability.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
