### PR TITLE
Fixed bug where no gaps above 1M

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
@@ -278,8 +278,15 @@ namespace CSETWebCore.Helpers
             var gaps = FindGaps(tableName, identityColumnName, 1000000)
                     .Where(x => x.GapSize >= recordsNeeded).OrderBy(x => x.GapSize).ToList();
 
-            var newSeed = 1000000;
-            if (gaps.Count > 0)
+            int newSeed = 1000000;
+
+            if (gaps.Count == 0)
+            {
+                // using SqlQueryRaw() here - make sure no user-supplied values are in the string-formatted query
+                string sql = $"SELECT ISNULL(MAX({identityColumnName}), 1000000) as [Value] FROM {tableName} WHERE {identityColumnName} >= 1000000";
+                newSeed = _context.Database.SqlQueryRaw<int>(sql).First();
+            }
+            else 
             {
                 newSeed = gaps.FirstOrDefault().GapStart;
             }
@@ -367,7 +374,6 @@ namespace CSETWebCore.Helpers
                         }
                     }
                 }
-
             }
             catch
             {


### PR DESCRIPTION
If the keys used are all contiguous, gap detection fails.  When this happens, we simply use the max available key above 1M.

This pull request refines the logic for determining the seed value when cloning modules, specifically improving how gaps are handled and how the maximum identity value is calculated. The changes focus on making the seed selection more robust and ensuring that the SQL query used is safe from user input.

Improvements to seed selection logic:

* Changed the logic in `FindSeed` to check for gaps differently: if no suitable gap is found, the seed is now determined by querying the maximum value of the identity column, ensuring no user-supplied values are used in the SQL query.

General code cleanup:

* Minor formatting adjustment in `FindGaps` by removing an unnecessary blank line, improving code readability.

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
