### PR TITLE
Seeds were off by one in some cases

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Helpers/ModuleCloner.cs
@@ -282,13 +282,15 @@ namespace CSETWebCore.Helpers
 
             if (gaps.Count == 0)
             {
+                // get the max used ID and seed to it
                 // using SqlQueryRaw() here - make sure no user-supplied values are in the string-formatted query
                 string sql = $"SELECT ISNULL(MAX({identityColumnName}), 1000000) as [Value] FROM {tableName} WHERE {identityColumnName} >= 1000000";
                 newSeed = _context.Database.SqlQueryRaw<int>(sql).First();
             }
-            else 
+            else
             {
-                newSeed = gaps.FirstOrDefault().GapStart;
+                // We want to reseed before the next available
+                newSeed = gaps.FirstOrDefault().GapStart - 1; 
             }
 
             NLog.LogManager.GetCurrentClassLogger().Info($"Calculated new seed value of {newSeed} for table {tableName}");


### PR DESCRIPTION
By setting the seed too high, trying to retrofit a set of records in a gap caused an error because we skipped the lowest potential ID and then ran out of room at the top end of the gap by one.

This pull request makes a targeted adjustment to the logic for reseeding identity columns in the `ModuleCloner` class. The change ensures that the reseeding happens just before the next available gap in the sequence, rather than at the gap itself.

Improvements to identity column reseeding logic:

* Modified the calculation in `FindSeed` so that when reseeding based on a gap, the new seed is set to one less than the gap start (`gaps.FirstOrDefault().GapStart - 1`), ensuring that the next available value is not immediately used for reseeding.

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
