### PR TITLE
fix(reports): prevent typeahead from dropping first keystroke

### DIFF
--- a/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
+++ b/CSETWebNg/src/app/reports/module-content/module-content-launch/module-content-launch.component.ts
@@ -196,7 +196,7 @@ export class ModuleContentLaunchComponent implements OnInit {
         this.selectedOption === item.value
       );
 
-      if (!currentSelectedItem || value !== currentSelectedItem.displayName) {
+      if (this.isValidSelection && (!currentSelectedItem || value !== currentSelectedItem.displayName)) {
         // Text was modified, clear the selection
         this.clearSelection();
       }


### PR DESCRIPTION
## Summary
Fixes the module-content-launch typeahead input silently dropping the user's first keystroke.

## Changes
- Guard `clearSelection()` in `onInputChange()` with `this.isValidSelection` so it only fires when there is an active selection to clear — not on fresh input

## Root Cause
`onInputChange()` was called on every `ngModelChange`. When no prior selection existed (`selectedOption === ''`), the lookup for `currentSelectedItem` failed, causing `clearSelection()` to run and null out `selectedItem` via `[(ngModel)]`, erasing the just-typed character.

## Breaking Changes
None

## Test Plan
- [ ] Navigate to Module Content Report page
- [ ] Click into the typeahead input and type a character — it should appear immediately
- [ ] Select an item from the dropdown, then modify the text — selection should clear as before
- [ ] Clear the field and type again — first keystroke should register

## Release Notes
Fixed a bug where the first character typed into the Module Content Report search field was silently dropped.

## Checklist
- [x] Conventional commit format followed
- [ ] Tests pass locally