### PR TITLE
Fix Sticky Landing Page Tabs

### DIFF
--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.html
@@ -23,7 +23,7 @@
 <div *transloco="let t" class="assess-component landing-page d-flex flex-column justify-content-start flex-11a w-100">
 
   <!-- Tabs -->
-  <div #tabs class="mt-0 ps-0 d-flex flex-column justify-content-start flex-00a">
+  <div #tabs class="sticky-tabs mt-0 ps-0 d-flex flex-column justify-content-start flex-00a">
     <div class="d-flex justify-content-start flex-11a">
       <ul class="nav nav-tabs d-flex flex-11a questions-tab-border">
         <li style="margin-left:45px;" class="d-flex align-items-center flex-00a"

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.scss
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.scss
@@ -61,5 +61,5 @@ li button span {
 .sticky-tabs {
     position: sticky;
     z-index: 999;
-    top: 62px;
+    top: 62.5px;
 }

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.scss
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.scss
@@ -1,24 +1,24 @@
-/* 
+/*
 
-  Copyright 2025 Battelle Energy Alliance, LLC  
+  Copyright 2025 Battelle Energy Alliance, LLC
 
-Permission is hereby granted, free of charge, to any person obtaining a copy 
-of this software and associated documentation files (the "Software"), to deal 
-in the Software without restriction, including without limitation the rights 
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is 
-furnished to do so, subject to the following conditions: 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
-copies or substantial portions of the Software. 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
-SOFTWARE. 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 */
 li.active {
@@ -61,4 +61,5 @@ li button span {
 .sticky-tabs {
     position: sticky;
     z-index: 999;
+    top: 62px;
 }

--- a/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
+++ b/CSETWebNg/src/app/initial/landing-page-tabs/landing-page-tabs.component.ts
@@ -21,7 +21,7 @@
 //  SOFTWARE.
 //
 ////////////////////////////////
-import { Component, ElementRef, OnInit, ViewChild, AfterViewInit, isDevMode } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
@@ -42,17 +42,6 @@ export class LandingPageTabsComponent implements OnInit {
   currentTab: string;
   isSearch: boolean = false;
   searchString: string = '';
-  devMode: boolean = isDevMode();
-  private _tabsElementRef: ElementRef;
-
-  @ViewChild('tabs') set tabsElementRef(element: ElementRef) {
-    this._tabsElementRef = element;
-
-    if (this._tabsElementRef) {
-      const tabsEl = this._tabsElementRef.nativeElement;
-      tabsEl.classList.add('sticky-tabs');
-    }
-  }
 
   constructor(
     private route: ActivatedRoute,

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.ts
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.ts
@@ -21,7 +21,7 @@
 //  SOFTWARE.
 //
 ////////////////////////////////
-import { Component, ViewEncapsulation, isDevMode } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { AggregationService } from '../../services/aggregation.service';
@@ -48,7 +48,6 @@ export class IodLayoutComponent {
   dialogRef: MatDialogRef<any>;
   isFooterVisible: boolean = false;
   footerClosed: boolean = true;
-  devMode: boolean = isDevMode();
 
   constructor(
     public auth: AuthenticationService,

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.ts
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.ts
@@ -21,7 +21,7 @@
 //  SOFTWARE.
 //
 ////////////////////////////////
-import { Component, ViewEncapsulation, OnInit, isDevMode, inject } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { AggregationService } from '../../services/aggregation.service';
@@ -50,7 +50,6 @@ export class LayoutMainComponent implements OnInit {
   dialogRef: MatDialogRef<any>;
   isFooterVisible: boolean = false;
   footerClosed: boolean = true;
-  devMode: boolean = isDevMode();
 
   display = "none";
   displayNotifications = "none";
@@ -122,7 +121,7 @@ export class LayoutMainComponent implements OnInit {
     var navigator = window.navigator as any;
     if(localStorage.getItem("mobileDismissed") != "true"){
       if (window.matchMedia("(max-width: 767px)").matches == false)
-      { 
+      {
         hasTouchScreen = false;
       } else if ("maxTouchPoints" in navigator) {
           hasTouchScreen = navigator.maxTouchPoints > 0;
@@ -145,7 +144,7 @@ export class LayoutMainComponent implements OnInit {
       }
 
       if (hasTouchScreen) {
-          this.isMobile = true; 
+          this.isMobile = true;
       } else {
         this.isMobile = false;
       }
@@ -159,6 +158,6 @@ export class LayoutMainComponent implements OnInit {
         });
       }
     }
-    
+
   }
 }

--- a/CSETWebNg/src/app/resource-library/resource-library.component.html
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.html
@@ -23,7 +23,7 @@
 <div class="rl d-flex flex-column flex-11a" *transloco="let t">
 
   <!-- Tabs -->
-  <ul #tabs class="nav nav-tabs d-flex flex-00a">
+  <ul #tabs class="sticky-tabs nav nav-tabs d-flex flex-00a">
     <li style="width: 45px"></li>
     <li [ngClass]="(selectedPane === 'search') ? ['active', 'landing-page'] : []" class="d-flex align-items-center flex-00a"
       (click)="selectedPane = 'search'">

--- a/CSETWebNg/src/app/resource-library/resource-library.component.scss
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.scss
@@ -84,4 +84,5 @@ li button span {
 .sticky-tabs {
   position: sticky;
   z-index: 999;
+  top: 62px;
 }

--- a/CSETWebNg/src/app/resource-library/resource-library.component.scss
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.scss
@@ -84,5 +84,5 @@ li button span {
 .sticky-tabs {
   position: sticky;
   z-index: 999;
-  top: 62px;
+  top: 62.5px;
 }

--- a/CSETWebNg/src/app/resource-library/resource-library.component.ts
+++ b/CSETWebNg/src/app/resource-library/resource-library.component.ts
@@ -21,7 +21,7 @@
 //
 ////////////////////////////////
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
-import { AfterViewInit, Component, ElementRef, OnInit, ViewChild, isDevMode } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Title } from "@angular/platform-browser";
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -31,7 +31,7 @@ import { OkayComponent } from '../dialogs/okay/okay.component';
 import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { NavigationService } from '../services/navigation/navigation.service';
 import { NavTreeService } from '../services/navigation/nav-tree.service';
-import { AuthenticationService } from '../services/authentication.service';
+
 const headers = {
   headers: new HttpHeaders().set('Content-Type', 'application/json'),
   params: new HttpParams()
@@ -78,29 +78,12 @@ export class ResourceLibraryComponent implements OnInit {
   children?: LibrarySearchResponse[];
   filter: string = '';
   setFilterDebounced = new Subject<string>();
-  devMode: boolean = isDevMode();
-  private _tabsElementRef: ElementRef;
-
-  @ViewChild('tabs') set tabsElementRef(element: ElementRef) {
-    this._tabsElementRef = element;
-
-    if (this._tabsElementRef) {
-      const tabsEl = this._tabsElementRef.nativeElement;
-      tabsEl.classList.add('sticky-tabs');
-      if (this.authSvc.isLocal && this.devMode) {
-        tabsEl.style.top = '81px';
-      } else {
-        tabsEl.style.top = '62px';
-      }
-    }
-  }
 
   constructor(private configSvc: ConfigService,
     private http: HttpClient,
     public navSvc: NavigationService,
     public navTreeSvc: NavTreeService,
     public dialog: MatDialog,
-    private authSvc: AuthenticationService,
     public titleSvc: Title) {
   }
 


### PR DESCRIPTION
This pull request simplifies how sticky tab behavior is applied to the landing page and resource library components and removes unnecessary development mode checks and logic. The main improvements are a shift from dynamically adding the `sticky-tabs` class in TypeScript to statically applying it in the HTML, and moving all sticky positioning logic into CSS for consistency and maintainability. Additionally, unused imports and code related to `isDevMode` have been removed from several components.

**Sticky Tabs Refactoring:**
- The `sticky-tabs` class is now applied directly in the HTML templates for both `landing-page-tabs.component.html` and `resource-library.component.html`, eliminating the need for dynamic class manipulation in TypeScript. [[1]](diffhunk://#diff-278faf038e69995fd85f273093f175ab18b800394403b7a18b7c57e61a1dc65dL26-R26) [[2]](diffhunk://#diff-2b1c0fcb0fc71872d40b9211dedfb02a406bc3c6fdfcdbf188fc89cdc7807b95L26-R26)
- Sticky positioning logic is consolidated in the respective SCSS files, with the `top` property set to `62.5px` for consistent tab placement. [[1]](diffhunk://#diff-17f51274dacca4756b6acd2b2cfdc75c108aecdc3e2843da99a83afaf22c149bR64) [[2]](diffhunk://#diff-cc58b107e0b7440c7bc49326cbb6329c1ab5ada901ee1816d48be51b5ed6a08eR87)

**Code Cleanup and Simplification:**
- Removed dynamic sticky tab logic and related `ViewChild`/`ElementRef` code from `landing-page-tabs.component.ts` and `resource-library.component.ts`, simplifying the components. [[1]](diffhunk://#diff-d67035523e2ca33c9ac108d34a8dcf22dbc0ee7bed7fe5d6af87be0478c86eafL45-L55) [[2]](diffhunk://#diff-c9a96e2734a1820252376efc9fd7eea404a5183e1cc25895a9bb55bc8eb5dc85L81-L103)
- Cleaned up unused imports, including `isDevMode`, from `landing-page-tabs.component.ts`, `resource-library.component.ts`, `iod-layout.component.ts`, and `layout-main.component.ts`. [[1]](diffhunk://#diff-d67035523e2ca33c9ac108d34a8dcf22dbc0ee7bed7fe5d6af87be0478c86eafL24-R24) [[2]](diffhunk://#diff-c9a96e2734a1820252376efc9fd7eea404a5183e1cc25895a9bb55bc8eb5dc85L24-R24) [[3]](diffhunk://#diff-1b3cddf4ffd1c82d04263f410a90c3f728db6d061d7d800e005c996a11251d5dL24-R24) [[4]](diffhunk://#diff-ff85693c84a1d2e921c1f024930a538de729c23f55dedc5ccd5291f417d7d46aL24-R24)
- Removed all `devMode` related variables and logic from the affected components, as they are no longer necessary. [[1]](diffhunk://#diff-d67035523e2ca33c9ac108d34a8dcf22dbc0ee7bed7fe5d6af87be0478c86eafL45-L55) [[2]](diffhunk://#diff-c9a96e2734a1820252376efc9fd7eea404a5183e1cc25895a9bb55bc8eb5dc85L81-L103) [[3]](diffhunk://#diff-1b3cddf4ffd1c82d04263f410a90c3f728db6d061d7d800e005c996a11251d5dL51) [[4]](diffhunk://#diff-ff85693c84a1d2e921c1f024930a538de729c23f55dedc5ccd5291f417d7d46aL53)
- Removed unused `AuthenticationService` injection from `resource-library.component.ts`. [[1]](diffhunk://#diff-c9a96e2734a1820252376efc9fd7eea404a5183e1cc25895a9bb55bc8eb5dc85L34-R34) [[2]](diffhunk://#diff-c9a96e2734a1820252376efc9fd7eea404a5183e1cc25895a9bb55bc8eb5dc85L81-L103)