### PR TITLE
fixed org name syncing across workflows

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentBusiness.cs
@@ -663,6 +663,8 @@ namespace CSETWebCore.Business.Assessment
         {
             string app_code = _tokenManager.Payload(Constants.Constants.Token_Scope);
 
+            var extBiz = new DemographicExtBusiness(_context);
+
             // Add or update the ASSESSMENTS record
             var dbAssessment = _context.ASSESSMENTS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
 
@@ -725,7 +727,11 @@ namespace CSETWebCore.Business.Assessment
 
             // add or update the INFORMATION record
             dbInformation.Assessment_Name = assessment.AssessmentName;
+
+            // keep ORG-NAME in sync with FacilityName
             dbInformation.Facility_Name = assessment.FacilityName;
+            extBiz.SaveX(assessmentId, "ORG-NAME", dbInformation.Facility_Name);
+
             dbInformation.City_Or_Site_Name = assessment.CityOrSiteName;
             dbInformation.State_Province_Or_Region = assessment.StateProvRegion;
             dbInformation.Postal_Code = assessment.PostalCode;
@@ -741,6 +747,7 @@ namespace CSETWebCore.Business.Assessment
             _context.SaveChanges();
 
 
+
             // persist maturity data
             if (assessment.UseMaturity)
             {
@@ -754,14 +761,12 @@ namespace CSETWebCore.Business.Assessment
             // No user is null here if accesskey login is used
             if (user != null)
             {
-                AssessmentNaming.ProcessName(_context, user.UserId, assessmentId);
+                AssessmentNaming.ProcessName(_context, assessmentId);
             }
             _assessmentUtil.TouchAssessment(assessmentId);
 
             return assessmentId;
         }
-
-
 
 
         /// <summary>
@@ -788,6 +793,7 @@ namespace CSETWebCore.Business.Assessment
             return (orgTypes.OrderBy(a => a.Sequence).Select(a => new DetailsDemographicsOptionsDTO() { Text = a.OptionText, Id = a.OptionValue })).ToList();
         }
 
+
         /// <summary>
         /// Returns a boolean indicating if the current User is attached to the specified Assessment.
         /// The authentication token is automatically read and the user is determined from it.
@@ -803,6 +809,7 @@ namespace CSETWebCore.Business.Assessment
 
             return (countAC > 0);
         }
+
 
         /// <summary>
         /// Sets the assessment type title and description.
@@ -909,11 +916,13 @@ namespace CSETWebCore.Business.Assessment
             return processedSets;
         }
 
+
         public class SetInfo
         {
             public string FullName { get; set; }
             public string ShortName { get; set; }
         }
+
 
         public IList<string> GetNames(int id1, int id2, int? id3, int? id4, int? id5, int? id6, int? id7, int? id8, int? id9, int? id10)
         {
@@ -955,6 +964,7 @@ namespace CSETWebCore.Business.Assessment
             return "";
         }
 
+
         /// <summary>
         /// Gets the userID that created the current assessment  
         /// </summary>
@@ -964,7 +974,6 @@ namespace CSETWebCore.Business.Assessment
             var assessment = _context.ASSESSMENTS.FirstOrDefault(x => x.Assessment_Id == assessmentId);
             return assessment?.AssessmentCreatorId;
         }
-
 
 
         /// <summary>
@@ -990,6 +999,7 @@ namespace CSETWebCore.Business.Assessment
             _context.SaveChanges();
         }
 
+
         public void clearFirstTime(int userid, int assessment_id)
         {
             var us = _context.USERS.Where(x => x.UserId == userid).FirstOrDefault();
@@ -999,6 +1009,7 @@ namespace CSETWebCore.Business.Assessment
                 _context.SaveChanges();
             }
         }
+
 
         public IEnumerable<MergeObservation> GetAssessmentObservations(int id1, int id2, int? id3, int? id4, int? id5, int? id6, int? id7, int? id8, int? id9, int? id10)
         {
@@ -1048,6 +1059,7 @@ namespace CSETWebCore.Business.Assessment
 
             return observationsPerAssessment;
         }
+
 
         public IEnumerable<MergeDocuments> GetAssessmentDocuments(int id1, int id2, int? id3, int? id4, int? id5, int? id6, int? id7, int? id8, int? id9, int? id10)
         {
@@ -1289,7 +1301,13 @@ namespace CSETWebCore.Business.Assessment
             var assessment = _context.ASSESSMENTS.Where(x => x.Assessment_Id == assessmentId).FirstOrDefault();
             assessment.AssessorMode = Convert.ToBoolean(mode);
             _context.SaveChanges();
+
+            if (assessment.AssessorMode)
+            {
+                AssessmentNaming.ProcessName(_context, assessment.Assessment_Id);
+            }
         }
+
 
         public void SetAssessmentDone(int assessmentId, bool isDone)
         {
@@ -1297,6 +1315,8 @@ namespace CSETWebCore.Business.Assessment
             assessment.Done = isDone;
             _context.SaveChanges();
         }
+
+
         public void SetAssessmentFavorite(int assessmentId, bool isFavorite)
         {
             int currentUserId = _tokenManager.GetUserId() ?? throw new UnauthorizedAccessException("User ID not found in token");

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentNaming.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Assessment/AssessmentNaming.cs
@@ -5,6 +5,7 @@
 //
 ////////////////////////////////
 using CSETWebCore.DataLayer.Model;
+using DocumentFormat.OpenXml.Office2010.Excel;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq;
@@ -15,16 +16,23 @@ namespace CSETWebCore.Business.Assessment
     {
         /// <summary>
         /// determines the assessment Name;
-        /// HAS the side effect of changing the assessment name in CISA Assessor Mode
+        /// Has the side effect of changing the assessment name in CISA Assessor Mode
         /// 
         /// Note that the "shortName" will be blank for diagram-based assessments (no model or standard to list)
         /// </summary>
         /// <returns>Nothing</returns>
-        static public void ProcessName(CsetwebContext context, int userid, int assessmentid)
+        static public void ProcessName(CsetwebContext context, int assessmentid)
         {
-            var user = context.USERS.Where(user => user.UserId == userid).FirstOrDefault();
             var assessment = context.ASSESSMENTS.Where(am => am.Assessment_Id == assessmentid).FirstOrDefault();
+
+            // don't change the assessment name for non-CISA assessments; leave as the user set it
+            if (!assessment.AssessorMode)
+            {
+                return;
+            }
+
             var info = context.INFORMATION.Where(info => info.Id == assessmentid).FirstOrDefault();
+            var ddOrgName = context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == assessmentid && x.DataItemName == "ORG-NAME").FirstOrDefault();
             var maturityModels = context.AVAILABLE_MATURITY_MODELS
                                 .Include(x => x.model)
                                 .Where(mats => mats.Assessment_Id == assessmentid && mats.Selected == true)
@@ -35,6 +43,7 @@ namespace CSETWebCore.Business.Assessment
                         .Where(stds => stds.Assessment_Id == assessmentid)
                         .Select(x => x.Set_NameNavigation.Short_Name)
                         .ToList();
+
 
             /* Update File naming convention
                [client-assessment type-report type].pcii.[PCII Number].[extension]
@@ -47,22 +56,19 @@ namespace CSETWebCore.Business.Assessment
             [client-assessment type-report type].pcii.[PCII Number].[extension]
             [client-assessment type - report type].non-pcii.[Date of Assessment].[extension]
              */
-            if (assessment.AssessorMode)
-            {
-                var date = assessment.Assessment_Date.ToString("yyyy-MM-dd");
-                var OrgName = info.Facility_Name;
 
-                var shortName = String.Join(',', maturityModels) + String.Join(',', stnds).Trim(',');
-                var orgAndType = $"{OrgName} {shortName}".Trim();
+            var date = assessment.Assessment_Date.ToString("yyyy-MM-dd");
+            var OrgName = assessment.AssessorMode ? ddOrgName?.StringValue ?? "" : info.Facility_Name;
 
-                var pcii = assessment.Is_PCII ? "pcii" : "non-pcii";
+            var shortName = String.Join(',', maturityModels) + String.Join(',', stnds).Trim(',');
+            var orgAndType = $"{OrgName} {shortName}".Trim();
 
-                date = assessment.Is_PCII ? assessment.PCII_Number : date;
-                var assessmentName = $"{orgAndType}.{pcii}.{date}".Trim();
-                info.Assessment_Name = assessmentName;
-                context.SaveChanges();
-            }
+            var pcii = assessment.Is_PCII ? "pcii" : "non-pcii";
 
+            date = assessment.Is_PCII ? assessment.PCII_Number : date;
+            var assessmentName = $"{orgAndType}.{pcii}.{date}".Trim();
+            info.Assessment_Name = assessmentName;
+            context.SaveChanges();
         }
     }
 }

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisDemographicBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/CisDemographicBusiness.cs
@@ -112,7 +112,7 @@ namespace CSETWebCore.Business.Demographic
             _context.CIS_CSI_SERVICE_DEMOGRAPHICS.Update(dbServiceDemographics);
             _context.SaveChanges();
             serviceDemographics.AssessmentId = dbServiceDemographics.Assessment_Id;
-            AssessmentNaming.ProcessName(_context, userid, serviceDemographics.AssessmentId);
+            AssessmentNaming.ProcessName(_context, serviceDemographics.AssessmentId);
             _assessmentUtil.TouchAssessment(dbServiceDemographics.Assessment_Id);
 
             return serviceDemographics.AssessmentId;

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
@@ -304,7 +304,7 @@ namespace CSETWebCore.Business.Demographic
         /// 
         /// </summary>
         /// <param name="demographic"></param>
-        public void SaveDemographics(DemographicExt demographic, int userid)
+        public void SaveDemographics(DemographicExt demographic)
         {
             var info = _context.INFORMATION.Where(x => x.Id == demographic.AssessmentId).FirstOrDefault();
             info.Facility_Name = demographic.OrganizationName;
@@ -350,7 +350,7 @@ namespace CSETWebCore.Business.Demographic
             _context.RemoveRange(ssg);
             _context.SaveChanges();
 
-            AssessmentNaming.ProcessName(_context, userid, demographic.AssessmentId);
+            AssessmentNaming.ProcessName(_context, demographic.AssessmentId);
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -187,7 +187,7 @@ namespace CSETWebCore.Api.Controllers
             var userid = _token.GetCurrentUserId();
 
             var mgr = new DemographicExtBusiness(_context);
-            mgr.SaveDemographics(demographics, userid ?? 0);
+            mgr.SaveDemographics(demographics);
 
             _hooks.HookDemographicsChanged(demographics.AssessmentId);
 

--- a/CSETWebNg/src/app/assessment/assessment.component.ts
+++ b/CSETWebNg/src/app/assessment/assessment.component.ts
@@ -168,6 +168,12 @@ export class AssessmentComponent implements OnInit {
          { passive: true }
       );
 
+      this.assessSvc.assessment$
+         .pipe(takeUntil(this.destroy$))
+         .subscribe(data => {
+            if (data) this.assessment = data;
+         });
+
       this.evaluateWindowSize();
 
       if (this.configSvc.behaviors.replaceAssessmentWithAnalysis) {
@@ -214,7 +220,7 @@ export class AssessmentComponent implements OnInit {
    getAssessmentDetail() {
       this.assessSvc.getAssessmentDetail().subscribe((data: AssessmentDetail) => {
          this.assessment = data;
-         this.assessSvc.assessment = data;
+         this.assessSvc.assessment = structuredClone(data);
       });
    }
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -167,11 +167,11 @@ export class AssessmentConfigIodComponent implements OnInit {
     this.assessment.assessorMode = !this.assessment.assessorMode;
     // Sets assessment level assessor mode and navigates to configuration page in non-assessor mode
     this.assessSvc.setAssessorSetting(this.assessment.assessorMode).subscribe(() => {
+      this.assessSvc.refreshAssessmentName();
       this.navSvc.navBack('info2');
     });
-
-
   }
+
   setAssessmentDone() {
     this.assessment.done = !this.assessment.done;
     this.assessSvc.setAssesmentDone(this.assessment.done).subscribe();

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-demog-iod/assessment-demog-iod.component.ts
@@ -27,7 +27,6 @@ import { DemographicService } from '../../../../services/demographic.service';
 import { MatDialog } from '@angular/material/dialog';
 import { UploadDemographicsComponent } from "../../../../dialogs/import demographics/import-demographics.component";
 import { AuthenticationService } from '../../../../services/authentication.service';
-import { UploadExportComponent } from "../../../../dialogs/import-assessment/import-assessment.component";
 import { AssessmentService } from '../../../../services/assessment.service';
 
 
@@ -46,7 +45,7 @@ interface ImportExportData {
 
 export class AssessmentDemogIodComponent {
   unsupportedImportFile: boolean = false;
-  @ViewChild('demoIOD') demoIOD;
+  @ViewChild('demoIOD') demoIOD: any;
   eventImportExport: Subject<ImportExportData> = new Subject<ImportExportData>();
 
   constructor(
@@ -56,7 +55,7 @@ export class AssessmentDemogIodComponent {
     public assessmentSvc: AssessmentService
   ) { }
 
-  importClick(event) {
+  importClick(event: any) {
     let dialogRef = null;
     this.unsupportedImportFile = false;
     if (event.target.files[0]?.name.endsWith(".json")) {
@@ -69,7 +68,7 @@ export class AssessmentDemogIodComponent {
     }
 
     if (!this.unsupportedImportFile) {
-      dialogRef.afterClosed().subscribe(result => {
+      dialogRef.afterClosed().subscribe(() => {
         this.demoIOD.populateDemographicsModel();
         this.assessmentSvc.refreshAssessment();
         this.demoSvc.demographicUpdateCompleted$.next();

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-detail/assessment-detail.component.ts
@@ -188,6 +188,7 @@ export class AssessmentDetailComponent implements OnInit {
     this.assessment.assessorMode = !this.assessment.assessorMode;
     // Sets assessment level assessor mode and navigates to configuration page in assessor mode
     this.assessSvc.setAssessorSetting(this.assessment.assessorMode).subscribe(() => {
+      this.assessSvc.refreshAssessmentName();
       this.navSvc.navBack('csi2');
     });
 

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/demographics-iod/demographics-iod.component.ts
@@ -162,7 +162,9 @@ export class DemographicsIodComponent implements OnInit {
     this.configSvc.userIsCisaAssessor = true;
     this.demographicData.sectorDirective = 'NIPP';
 
+    // keep facilityname/orgname synced up in its various locations
     this.demographicData.facilityName = this.demographicData.organizationName;
+    this.assessSvc.assessment.facilityName = this.demographicData.facilityName;
 
     this.demoSvc.updateDemographic(this.demographicData);
   }

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-practices/cpg-practices.component.ts
@@ -49,7 +49,6 @@ export class CpgPracticesComponent implements OnInit {
    */
   ngOnInit(): void {
     this.ssgBonusModels = this.assessSvc.assessment.ssgModelIds;
-    console.log('practices', this.assessSvc.assessment);
   }
 
   /**

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
@@ -111,7 +111,6 @@ export class CommentsMfrComponent implements OnInit {
     // get marked for review
     try {
       const respMfr: any = await firstValueFrom(this.maturitySvc.getMarkedForReview());
-      console.log('mfr response', respMfr);
       this.markedForReview = respMfr.markedForReviewList;
       this.loading = false;
     } catch (error) {

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -206,8 +206,6 @@ export class CpgReportComponent implements OnInit {
     hm.forEach(h => {
       this.ssgHeatmaps[h.modelId] = h.scores;
     });
-
-    console.log('ssg heatmaps', this.ssgHeatmaps);
   }
 
   /**

--- a/CSETWebNg/src/app/services/assessment.service.ts
+++ b/CSETWebNg/src/app/services/assessment.service.ts
@@ -23,7 +23,7 @@
 ////////////////////////////////
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, filter, first, firstValueFrom, Observable, Subject, take, timeout } from 'rxjs';
+import { BehaviorSubject, filter, firstValueFrom, Observable, Subject, take, timeout } from 'rxjs';
 import {
   AssessmentContactsResponse,
   AssessmentDetail,
@@ -32,7 +32,6 @@ import {
 import { User } from '../models/user.model';
 import { ConfigService } from './config.service';
 import { Router } from '@angular/router';
-import { Answer } from '../models/questions.model';
 import { ConversionService } from './conversion.service';
 import { ConstantsService } from './constants.service';
 import { parseReturnPath } from '../helpers/url-routing.helper';
@@ -80,6 +79,8 @@ export class AssessmentService {
    * when the assessment is loaded.
    */
   public assessment: AssessmentDetail;
+
+  assessment$ = new BehaviorSubject<AssessmentDetail>(null);
 
   /**
    * Stores the active assessment 'features' that the user wishes to use,
@@ -270,9 +271,7 @@ export class AssessmentService {
     // clean out properties that may contain HTML before posting.
     // The API WAF may reject to prevent XSS.
     // These properties are not user updatable.
-    const payload = JSON.parse(JSON.stringify(assessment));
-    payload.maturityModel = null;
-    payload.typeDescription = null;
+    const payload = { ...structuredClone(assessment), maturityModel: undefined, typeDescription: undefined };
 
     return this.http
       .post(
@@ -281,9 +280,7 @@ export class AssessmentService {
         headers
       )
       .subscribe(() => {
-        if (this.configSvc.userIsCisaAssessor) {
-          this.updateAssessmentName();
-        }
+        this.refreshAssessmentName();
       });
   }
 
@@ -515,9 +512,10 @@ export class AssessmentService {
   //Call this when the assessment name
   //was calculated in the backend and needs
   //to be updated here
-  updateAssessmentName() {
+  refreshAssessmentName() {
     this.getAssessmentDetail().subscribe((data: AssessmentDetail) => {
       this.assessment.assessmentName = data.assessmentName;
+      this.assessment$.next(this.assessment);
     });
   }
 
@@ -672,7 +670,7 @@ export class AssessmentService {
    * CISA Assessor Workflow's Assessment Configuration page.
    */
   isPcii() {
-    if (!!this.assessment) {
+    if (this.assessment) {
       return this.assessment.is_PCII ?? false;
     }
     return false;
@@ -697,11 +695,6 @@ export class AssessmentService {
     return this.http.get(this.apiUrl + 'hasGlobalDocuments');
   }
 
-
-  updateAnswer(answer: Answer) {
-
-  }
-
   //Assessment upgrade conversion
   convertAssesment(original_id: number) {
     let queryParams = new HttpParams()
@@ -722,10 +715,12 @@ export class AssessmentService {
     this.assessment.assessorMode = mode;
     return this.http.post(this.apiUrl + 'assessormode', mode, headers)
   }
+
   setAssesmentDone(done: boolean) {
     this.assessment.done = done;
     return this.http.post(this.apiUrl + 'setAssessmentDone', done, headers)
   }
+
   setAssessmentFavorite(isFavorite: boolean) {
     return this.http.post(this.apiUrl + 'setAssessmentFavorite', isFavorite, headers);
   }

--- a/CSETWebNg/src/app/services/demographic-iod.service.ts
+++ b/CSETWebNg/src/app/services/demographic-iod.service.ts
@@ -90,9 +90,7 @@ export class DemographicIodService {
   updateDemographic(demographic: DemographicsIod) {
     this.http.post(this.apiUrl, demographic, headers)
       .subscribe(() => {
-        if (this.configSvc.userIsCisaAssessor) {
-          this.assessSvc.updateAssessmentName();
-        }
+        this.assessSvc.refreshAssessmentName();
         this.demographicUpdateCompleted$.next();
       });
   }


### PR DESCRIPTION
This pull request focuses on improving the consistency and automation of assessment naming, especially in "Assessor Mode", and streamlining how demographic and assessment detail changes propagate through the system. It also includes minor refactoring and cleanup, as well as improvements to the Angular front-end for better data synchronization and type safety.

**Assessment Naming and Demographic Synchronization:**

* The `AssessmentNaming.ProcessName` method was refactored to only require `assessmentId` (removing the `userid` parameter), and now uses the organization name from the `DETAILS_DEMOGRAPHICS` table when in Assessor Mode, ensuring assessment names are automatically and consistently updated. [[1]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L18-R35) [[2]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L50-R61) [[3]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L65-L66) [[4]](diffhunk://#diff-b5cbae1bcd86dca77574be7c0b154a7dea30f66122b85b7d1f1fa2af8509c7e2L115-R115) [[5]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL353-R353)
* When saving assessment details, the code now explicitly keeps the `ORG-NAME` demographic in sync with `FacilityName` and updates the assessment name if Assessor Mode is enabled. [[1]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R730-R734) [[2]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1304-R1319)

**Back-End API and Business Logic Improvements:**

* The `SaveDemographics` method in `DemographicExtBusiness` was simplified to remove the `userid` parameter, aligning with the new `ProcessName` signature. [[1]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL307-R307) [[2]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523L190-R190)
* The `AssessmentNaming.ProcessName` call was updated throughout the codebase to match the new signature and logic, ensuring consistent behavior. [[1]](diffhunk://#diff-b5cbae1bcd86dca77574be7c0b154a7dea30f66122b85b7d1f1fa2af8509c7e2L115-R115) [[2]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283L757-L766)

**Front-End Data Handling and Synchronization:**

* The Angular assessment components now subscribe to assessment data changes, ensuring the UI stays in sync with the latest backend updates.
* After toggling Assessor Mode, the front-end explicitly refreshes the assessment name to reflect any automatic changes. [[1]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6R170-R174) [[2]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR191)
* Improved type safety and code clarity in demographic import/export component by specifying types and removing unused imports. [[1]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L49-R48) [[2]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L59-R58) [[3]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L72-R71) [[4]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L30)

**Minor Cleanups and Refactoring:**

* Removed unused parameters and cleaned up whitespace and comments in several business logic methods. [[1]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283L757-L766) [[2]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283L969)
* Added missing or improved documentation comments for better maintainability. [[1]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R796) [[2]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R813) [[3]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R919-R926) [[4]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R967) [[5]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1002) [[6]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1013) [[7]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1063)

These changes collectively improve the reliability and maintainability of assessment naming, demographic synchronization, and front-end/back-end data consistency.

**References:**  
[[1]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L18-R35) [[2]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L50-R61) [[3]](diffhunk://#diff-b608b9d6d7607594f980fdb008a03462d194d5e0fa13d3582c4ccaf63d088154L65-L66) [[4]](diffhunk://#diff-b5cbae1bcd86dca77574be7c0b154a7dea30f66122b85b7d1f1fa2af8509c7e2L115-R115) [[5]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL353-R353) [[6]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R730-R734) [[7]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1304-R1319) [[8]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL307-R307) [[9]](diffhunk://#diff-dc99c7b461b989e17e30bbb0aa48804d22d2c6e4f6ef7b6f5806703b58239523L190-R190) [[10]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283L757-L766) [[11]](diffhunk://#diff-22bba8ad48fc86e4beaa57772bf893cf0a9fca43f3836cbb5df82b0eef92823aR171-R176) [[12]](diffhunk://#diff-1aa6598f7ff02a2fd47cfd62e62f777b3fd33b18dce24285e621de0db84140a6R170-R174) [[13]](diffhunk://#diff-95a68442e2b7553bb12b8a6faba282aa9b97d7716fac3a11c2acb7ecd428c78aR191) [[14]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L49-R48) [[15]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L59-R58) [[16]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L72-R71) [[17]](diffhunk://#diff-cbe3df9d87fd0ae86f2a3df148ae27dea6f697b088e1d0525aa186127974f3e2L30) [[18]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283L969) [[19]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R796) [[20]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R813) [[21]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R919-R926) [[22]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R967) [[23]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1002) [[24]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1013) [[25]](diffhunk://#diff-acff946980b0afe406d0af2f5e6183ac13077a84f3732fb20688c5f03e597283R1063)


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
