### PR TITLE
Fixed cisaRegion and Observation persistence issues

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicExtBusinessTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/DemographicExtBusinessTests.cs
@@ -489,7 +489,8 @@ namespace CSETWebCore.Business.Tests.Demographic
                 new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 1, IndustryName = "Banking", Is_Other = false },
                 new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 2, IndustryName = "Other", Is_Other = true },
                 new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 3, IndustryName = "Insurance", Is_Other = false },
-                new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 4, IndustryName = "Other Services", Is_Other = true }
+                new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 4, IndustryName = "Other Services", Is_Other = true },
+                new SECTOR_INDUSTRY { SectorId = sectorId, IndustryId = 5, IndustryName = "Legacy NIPP", Is_NIPP = true }
             };
 
             var mockSubsectorSet = CreateMockDbSet(subsectors);
@@ -506,6 +507,7 @@ namespace CSETWebCore.Business.Tests.Demographic
             Assert.Equal("Insurance", result[1].OptionText);
             Assert.Contains("Other", result[2].OptionText);
             Assert.Contains("Other", result[3].OptionText);
+            Assert.DoesNotContain(result, x => x.OptionText == "Legacy NIPP");
         }
 
         [Fact]

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/SectorManagementTests.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business.Tests/Demographic/SectorManagementTests.cs
@@ -1,0 +1,193 @@
+////////////////////////////////
+//
+//   Copyright 2026 Battelle Energy Alliance, LLC
+//
+//
+////////////////////////////////
+using CSETWebCore.Business.Demographic;
+using CSETWebCore.DataLayer.Model;
+using CSETWebCore.Model.Demographic;
+using Microsoft.EntityFrameworkCore;
+
+namespace CSETWebCore.Business.Tests.Demographic
+{
+    public class SectorManagementTests
+    {
+        [Fact]
+        public void Save_WithNullSector_RemovesExistingSelection()
+        {
+            using var context = CreateContext();
+            context.ASSESSMENT_SECTOR_SUBSECTOR.Add(new ASSESSMENT_SECTOR_SUBSECTOR
+            {
+                Assessment_Id = 1,
+                SectorId = 1,
+                Sequence = 1
+            });
+            context.SaveChanges();
+
+            var manager = new SectorMultiManager(context);
+
+            manager.Save(1, new SectorSubsector { SectorId = null, Sequence = 1 });
+
+            Assert.Empty(context.ASSESSMENT_SECTOR_SUBSECTOR);
+        }
+
+        [Fact]
+        public void Get_UpgradesLegacyDetailsSectorBeforeConvertingStorage()
+        {
+            using var context = CreateContext();
+            context.SECTOR.AddRange(
+                new SECTOR { SectorId = 10, SectorName = "Food and Agriculture", Is_NIPP = false },
+                new SECTOR { SectorId = 17, SectorName = "Agriculture and Food", Is_NIPP = true });
+            context.DETAILS_DEMOGRAPHICS.Add(new DETAILS_DEMOGRAPHICS
+            {
+                Assessment_Id = 1,
+                DataItemName = "SECTOR",
+                IntValue = 17
+            });
+            context.SaveChanges();
+
+            var result = new SectorMultiManager(context).Get(1);
+
+            var selection = Assert.Single(result);
+            Assert.Equal(10, selection.SectorId);
+            Assert.Null(selection.SubsectorId);
+            Assert.Equal(10, Assert.Single(context.ASSESSMENT_SECTOR_SUBSECTOR).SectorId);
+            Assert.DoesNotContain(context.DETAILS_DEMOGRAPHICS, x => x.DataItemName == "SECTOR");
+            Assert.Contains(context.DETAILS_DEMOGRAPHICS,
+                x => x.DataItemName == Constants.Constants.ACK_SECTOR_UPDATED_PPD21
+                    && x.BoolValue == true);
+        }
+
+        [Fact]
+        public void Save_WithLegacySector_ThrowsArgumentException()
+        {
+            using var context = CreateContext();
+            context.SECTOR.Add(new SECTOR
+            {
+                SectorId = 17,
+                SectorName = "Agriculture and Food",
+                Is_NIPP = true
+            });
+            context.SaveChanges();
+
+            var manager = new SectorMultiManager(context);
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+                manager.Save(1, new SectorSubsector { SectorId = 17, Sequence = 1 }));
+
+            Assert.Contains("sector is not supported", exception.Message);
+            Assert.Empty(context.ASSESSMENT_SECTOR_SUBSECTOR);
+        }
+
+        [Fact]
+        public void Save_WhenSectorChanges_IgnoresStaleSubsectorAndClearsIt()
+        {
+            using var context = CreateContext();
+            context.SECTOR.AddRange(
+                new SECTOR { SectorId = 1, SectorName = "Chemical", Is_NIPP = false },
+                new SECTOR { SectorId = 2, SectorName = "Commercial Facilities", Is_NIPP = false });
+            context.SECTOR_INDUSTRY.Add(new SECTOR_INDUSTRY
+            {
+                SectorId = 1,
+                IndustryId = 100,
+                IndustryName = "Old subsector",
+                Is_NIPP = false
+            });
+            context.ASSESSMENT_SECTOR_SUBSECTOR.Add(new ASSESSMENT_SECTOR_SUBSECTOR
+            {
+                Assessment_Id = 1,
+                SectorId = 1,
+                IndustryId = 100,
+                Sequence = 1
+            });
+            context.SaveChanges();
+
+            var manager = new SectorMultiManager(context);
+
+            manager.Save(1, new SectorSubsector
+            {
+                SectorId = 2,
+                SubsectorId = 100,
+                Sequence = 1
+            });
+
+            var selection = Assert.Single(context.ASSESSMENT_SECTOR_SUBSECTOR);
+            Assert.Equal(2, selection.SectorId);
+            Assert.Null(selection.IndustryId);
+        }
+
+        [Fact]
+        public void Upgrade_TableSectorOnly_PreservesDetailsSubsector()
+        {
+            using var context = CreateContext();
+            context.DETAILS_DEMOGRAPHICS.AddRange(
+                new DETAILS_DEMOGRAPHICS
+                {
+                    Assessment_Id = 1,
+                    DataItemName = "SECTOR",
+                    IntValue = 1
+                },
+                new DETAILS_DEMOGRAPHICS
+                {
+                    Assessment_Id = 1,
+                    DataItemName = "SUBSECTOR",
+                    IntValue = 5
+                });
+            context.ASSESSMENT_SECTOR_SUBSECTOR.Add(new ASSESSMENT_SECTOR_SUBSECTOR
+            {
+                Assessment_Id = 1,
+                SectorId = 17,
+                IndustryId = 121,
+                Sequence = 1
+            });
+            context.SaveChanges();
+
+            var result = new SectorUpgradePpd21(context).UpgradeSector(1);
+
+            Assert.True(result.Changed);
+            Assert.Equal(10, Assert.Single(context.ASSESSMENT_SECTOR_SUBSECTOR).SectorId);
+            Assert.Contains(context.DETAILS_DEMOGRAPHICS,
+                x => x.DataItemName == "SUBSECTOR" && x.IntValue == 5);
+        }
+
+        [Fact]
+        public void Upgrade_DetailsSector_ClearsItsLegacySubsector()
+        {
+            using var context = CreateContext();
+            context.DETAILS_DEMOGRAPHICS.AddRange(
+                new DETAILS_DEMOGRAPHICS
+                {
+                    Assessment_Id = 1,
+                    DataItemName = "SECTOR",
+                    IntValue = 17
+                },
+                new DETAILS_DEMOGRAPHICS
+                {
+                    Assessment_Id = 1,
+                    DataItemName = "SUBSECTOR",
+                    IntValue = 121
+                });
+            context.SaveChanges();
+
+            var result = new SectorUpgradePpd21(context).UpgradeSector(1);
+
+            Assert.True(result.Changed);
+            Assert.Equal(10, context.DETAILS_DEMOGRAPHICS
+                .Single(x => x.DataItemName == "SECTOR").IntValue);
+            Assert.DoesNotContain(context.DETAILS_DEMOGRAPHICS,
+                x => x.DataItemName == "SUBSECTOR");
+        }
+
+        private static CSETContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<CsetwebContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            var context = new CSETContext(options);
+            context.Database.EnsureCreated();
+            return context;
+        }
+    }
+}

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/AnalyticsBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Analytics/AnalyticsBusiness.cs
@@ -224,7 +224,15 @@ namespace CSETWebCore.Business.Analytics
         /// <returns></returns>
         public List<SectorsAndSamples> GetSectorsAndSampleSizes(int assessmentId, string lang)
         {
-            var sectors = _context.SECTOR.ToList();
+            new SectorUpgradePpd21(_context).UpgradeSector(assessmentId);
+
+            var sectors = _context.SECTOR
+                .Where(x => !x.Is_NIPP)
+                .ToList();
+
+            var currentSectorIds = sectors
+                .Select(x => x.SectorId)
+                .ToHashSet();
 
             TranslationOverlay _overlay = new TranslationOverlay();
 
@@ -236,10 +244,15 @@ namespace CSETWebCore.Business.Analytics
             List<int> mySectorIds = [];
 
             var ass = _context.ASSESSMENT_SECTOR_SUBSECTOR.Where(x => x.Assessment_Id == assessmentId).OrderBy(x => x.Sequence);
-            mySectorIds.AddRange(ass.Select(x => x.SectorId));
+            mySectorIds.AddRange(
+            ass.Select(x => x.SectorId)
+                .Where(currentSectorIds.Contains));
 
             var ass2 = _context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "SECTOR");
-            mySectorIds.AddRange(ass2.Select(x => (int)x.IntValue));
+            mySectorIds.AddRange(
+            ass2.Where(x => x.IntValue.HasValue)
+                .Select(x => x.IntValue.Value)
+                .Where(currentSectorIds.Contains));
 
 
             // Get assessment counts for the target assessments' sectors

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/DemographicExtBusiness.cs
@@ -51,16 +51,16 @@ namespace CSETWebCore.Business.Demographic
             d.FacilityName = info.Facility_Name;
 
 
-            // update sector if the assessment was built with the old HSPD-7 list
-            var sectorUp = new SectorUpgradePpd21(_context);
-            var newSectorInfo = sectorUp.UpgradeSector(assessmentId);
-
-            // get sectors
+            // Get sectors.  SectorMultiManager normalizes any legacy HSPD-7 values.
             var smm = new SectorMultiManager(_context);
             d.SectorSubsectors = smm.Get(assessmentId);
 
             // see if the sector list had been upgraded to notify the user
-            d.Acknowledgement = myDD.Find(z => z.DataItemName == Constants.Constants.ACK_SECTOR_UPDATED_PPD21)?.BoolValue;
+            d.Acknowledgement = _context.DETAILS_DEMOGRAPHICS
+                .FirstOrDefault(z =>
+                    z.Assessment_Id == assessmentId
+                    && z.DataItemName == Constants.Constants.ACK_SECTOR_UPDATED_PPD21)
+                ?.BoolValue;
 
 
             d.CisaRegion = myDD.Find(z => z.DataItemName == "CISA-REGION")?.IntValue;
@@ -178,7 +178,7 @@ namespace CSETWebCore.Business.Demographic
             }).ToList();
 
 
-            // No more HSPD-7 list support (Is_NIPP = true) - only the PPD-21 list of 18 sectors supported now
+            // No more HSPD-7 list support (Is_NIPP = true) - only the PPD-21 list of 16 sectors supported now
             var availableSectors = _context.SECTOR.Where(x => !x.Is_NIPP).ToList().OrderBy(y => y.SectorName);
 
             d.ListSectors = new List<ListItem2>();
@@ -201,7 +201,8 @@ namespace CSETWebCore.Business.Demographic
         /// <returns></returns>
         public List<ListItem2> GetSubsectors(int sectorId)
         {
-            var list = _context.SECTOR_INDUSTRY.Where(x => x.SectorId == sectorId)
+            var list = _context.SECTOR_INDUSTRY.Where(x =>
+                x.SectorId == sectorId && !x.Is_NIPP)
                .OrderBy(a => a.IndustryName).ToList();
 
             var otherItems = list.Where(x => x.Is_Other).ToList();

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorMultiManager.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorMultiManager.cs
@@ -6,6 +6,7 @@
 //////////////////////////////// 
 using CSETWebCore.DataLayer.Model;
 using CSETWebCore.Model.Demographic;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -33,7 +34,21 @@ namespace CSETWebCore.Business.Demographic
         {
             var resp = new List<SectorSubsector>();
 
-            var ss = _context.ASSESSMENT_SECTOR_SUBSECTOR.Where(x => x.Assessment_Id == assessmentId).ToList();
+            // Normalize legacy HSPD-7 values before reading either storage format.
+            // This keeps every caller consistent, regardless of which endpoint is
+            // the first one used to load the assessment.
+            new SectorUpgradePpd21(_context).UpgradeSector(assessmentId);
+
+            var currentSectorIds = _context.SECTOR
+                .Where(x => !x.Is_NIPP)
+                .Select(x => x.SectorId)
+                .ToHashSet();
+
+            var ss = _context.ASSESSMENT_SECTOR_SUBSECTOR
+                .Where(x => x.Assessment_Id == assessmentId)
+                .ToList()
+                .Where(x => currentSectorIds.Contains(x.SectorId));
+
             foreach (var sectorSubsector in ss)
             {
                 var x = new SectorSubsector() { SectorId = sectorSubsector.SectorId, SubsectorId = sectorSubsector.IndustryId, Sequence = sectorSubsector.Sequence };
@@ -69,15 +84,14 @@ namespace CSETWebCore.Business.Demographic
         /// <returns></returns>
         private List<ListItem2> GetSubsectorList(int sectorId)
         {
-            var resp = new List<ListItem2>();
-            var gg = _context.SECTOR_INDUSTRY.Where(x => x.SectorId == sectorId).ToList();
-            foreach (var g in gg)
+            return _context.SECTOR_INDUSTRY
+            .Where(x => x.SectorId == sectorId && !x.Is_NIPP)
+            .Select(x => new ListItem2
             {
-                var li = new ListItem2() { OptionValue = g.IndustryId, OptionText = g.IndustryName };
-                resp.Add(li);
-            }
-
-            return resp;
+                OptionValue = x.IndustryId,
+                OptionText = x.IndustryName
+            })
+            .ToList();
         }
 
 
@@ -92,13 +106,20 @@ namespace CSETWebCore.Business.Demographic
             var ddSector = _context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "SECTOR").FirstOrDefault();
             var ddSubsector = _context.DETAILS_DEMOGRAPHICS.Where(x => x.Assessment_Id == assessmentId && x.DataItemName == "SUBSECTOR").FirstOrDefault();
 
-            if (ddSector != null && ddSector.IntValue != null)
+            if (ddSector?.IntValue != null
+                && _context.SECTOR.Any(x =>
+                    x.SectorId == ddSector.IntValue.Value
+                    && !x.Is_NIPP))
             {
                 SectorSubsector resp;
                 resp = new SectorSubsector() { SectorId = ddSector.IntValue, Sequence = 1 };
                 resp.SubsectorList = GetSubsectorList((int)resp.SectorId);
 
-                if (ddSubsector != null)
+                if (ddSubsector?.IntValue != null
+                    && _context.SECTOR_INDUSTRY.Any(x =>
+                        x.IndustryId == ddSubsector.IntValue.Value
+                        && x.SectorId == ddSector.IntValue.Value
+                        && !x.Is_NIPP))
                 {
                     resp.SubsectorId = ddSubsector.IntValue;
                 }
@@ -141,39 +162,67 @@ namespace CSETWebCore.Business.Demographic
         public void Save(int assessmentId, SectorSubsector requestSector)
         {
             var dbTarget = _context.ASSESSMENT_SECTOR_SUBSECTOR
-                .Where(x => x.Assessment_Id == assessmentId && x.Sequence == requestSector.Sequence).FirstOrDefault();
+                .FirstOrDefault(x =>
+                    x.Assessment_Id == assessmentId
+                    && x.Sequence == requestSector.Sequence);
 
-
-            if (requestSector.SectorId == null)
+            if (!requestSector.SectorId.HasValue)
             {
-                _context.ASSESSMENT_SECTOR_SUBSECTOR.Remove(dbTarget);
+                if (dbTarget != null)
+                {
+                    _context.ASSESSMENT_SECTOR_SUBSECTOR.Remove(dbTarget);
+                    _context.SaveChanges();
+                }
+
+                return;
             }
 
-            if (requestSector.SectorId.HasValue)
+            var sectorId = requestSector.SectorId.Value;
+
+            if (!_context.SECTOR.Any(x =>
+                x.SectorId == sectorId && !x.Is_NIPP))
             {
-                if (dbTarget == null)
+                throw new ArgumentException(
+                    "The selected sector is not supported.",
+                    nameof(requestSector));
+            }
+
+            var sectorChanged = dbTarget != null && dbTarget.SectorId != sectorId;
+
+            if (!sectorChanged
+                && requestSector.SubsectorId.HasValue
+                && !_context.SECTOR_INDUSTRY.Any(x =>
+                    x.IndustryId == requestSector.SubsectorId.Value
+                    && x.SectorId == sectorId
+                    && !x.Is_NIPP))
+            {
+                throw new ArgumentException(
+                    "The selected subsector is not supported for this sector.",
+                    nameof(requestSector));
+            }
+
+            if (dbTarget == null)
+            {
+                dbTarget = new ASSESSMENT_SECTOR_SUBSECTOR()
                 {
-                    dbTarget = new ASSESSMENT_SECTOR_SUBSECTOR()
-                    {
-                        Assessment_Id = assessmentId,
-                        SectorId = (int)requestSector.SectorId,
-                        IndustryId = requestSector.SubsectorId,
-                        Sequence = requestSector.Sequence
-                    };
-                    _context.ASSESSMENT_SECTOR_SUBSECTOR.Add(dbTarget);
+                    Assessment_Id = assessmentId,
+                    SectorId = sectorId,
+                    IndustryId = requestSector.SubsectorId,
+                    Sequence = requestSector.Sequence
+                };
+                _context.ASSESSMENT_SECTOR_SUBSECTOR.Add(dbTarget);
+            }
+            else
+            {
+                // if they changed the sector, null the subsector
+                if (sectorChanged)
+                {
+                    dbTarget.SectorId = sectorId;
+                    dbTarget.IndustryId = null;
                 }
                 else
                 {
-                    // if they changed the sector, null the subsector
-                    if (dbTarget.SectorId != requestSector.SectorId)
-                    {
-                        dbTarget.SectorId = (int)requestSector.SectorId;
-                        dbTarget.IndustryId = null;
-                    }
-                    else
-                    {
-                        dbTarget.IndustryId = requestSector.SubsectorId;
-                    }
+                    dbTarget.IndustryId = requestSector.SubsectorId;
                 }
             }
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Demographic/SectorUpgrade.cs
@@ -61,57 +61,88 @@ namespace CSETWebCore.Business.Demographic
         /// <param name="assessmentId"></param>
         public SectorUpdateResult UpgradeSector(int assessmentId)
         {
-            var dbSector = _context.DETAILS_DEMOGRAPHICS.FirstOrDefault(x => x.Assessment_Id == assessmentId && x.DataItemName == "SECTOR");
+            var result = new SectorUpdateResult();
+            var demographicSectorChanged = false;
 
-            // do nothing if the sector is not a candidate for upgrading
-            if (dbSector == null || dbSector.IntValue == null || !HSPD7ToPPD21SectorIds.ContainsKey((int)dbSector.IntValue))
+            // Upgrade legacy sector data stored in DETAILS_DEMOGRAPHICS.
+            var demographicSector = _context.DETAILS_DEMOGRAPHICS
+                .FirstOrDefault(x =>
+                    x.Assessment_Id == assessmentId
+                    && x.DataItemName == "SECTOR");
+
+            if (demographicSector?.IntValue != null
+                && HSPD7ToPPD21SectorIds.TryGetValue(
+                    demographicSector.IntValue.Value,
+                    out var mappedDemographicSectorId))
+            {
+                demographicSector.IntValue = mappedDemographicSectorId;
+
+                result.SectorId = mappedDemographicSectorId;
+                result.Changed = true;
+                demographicSectorChanged = true;
+            }
+
+            // Upgrade legacy sector data stored in the current sector table.
+            // Legacy subsectors are cleared because there is no reliable
+            // one-to-one mapping to the current taxonomy.
+            var persistedSectors = _context.ASSESSMENT_SECTOR_SUBSECTOR
+                .Where(x => x.Assessment_Id == assessmentId)
+                .ToList();
+
+            foreach (var persistedSector in persistedSectors)
+            {
+                if (HSPD7ToPPD21SectorIds.TryGetValue(
+                    persistedSector.SectorId,
+                    out var mappedSectorId))
+                {
+                    persistedSector.SectorId = mappedSectorId;
+                    persistedSector.IndustryId = null;
+
+                    result.SectorId = mappedSectorId;
+                    result.Changed = true;
+                }
+            }
+
+            if (!result.Changed)
             {
                 return null;
             }
 
-            var resp = new SectorUpdateResult();
-
-            // update and persist sector/subsector records
-            var oldSectorId = dbSector.IntValue;
-
-            var newSectorId = GetPpd21SectorId((int)dbSector.IntValue);
-            if (newSectorId != null)
+            // Only clear the DETAILS_DEMOGRAPHICS subsector when its associated
+            // DETAILS_DEMOGRAPHICS sector was converted.  A conversion in the
+            // multi-sector table must not delete an unrelated current selection.
+            if (demographicSectorChanged)
             {
-                dbSector.IntValue = newSectorId;
-                resp.SectorId = (int)newSectorId;
-            }
+                var demographicSubsector = _context.DETAILS_DEMOGRAPHICS
+                    .FirstOrDefault(x =>
+                        x.Assessment_Id == assessmentId
+                        && x.DataItemName == "SUBSECTOR");
 
-
-            // save an ACKNOWLEDGMENT flag; let the caller know that the sector was changed
-            if (newSectorId != oldSectorId)
-            {
-                var ack = new DETAILS_DEMOGRAPHICS()
+                if (demographicSubsector != null)
                 {
-                    Assessment_Id = assessmentId,
-                    DataItemName = Constants.Constants.ACK_SECTOR_UPDATED_PPD21,
-                    BoolValue = true
-                };
-
-                if (!_context.DETAILS_DEMOGRAPHICS.Any(d =>
-                    d.Assessment_Id == assessmentId &&
-                    d.DataItemName == Constants.Constants.ACK_SECTOR_UPDATED_PPD21))
-                {
-                    _context.DETAILS_DEMOGRAPHICS.Add(ack);
+                    _context.DETAILS_DEMOGRAPHICS.Remove(demographicSubsector);
                 }
-
-                resp.Changed = true;
             }
 
+            // Notify the user that one or more sector selections were converted.
+            var acknowledgementExists = _context.DETAILS_DEMOGRAPHICS.Any(x =>
+                x.Assessment_Id == assessmentId
+                && x.DataItemName == Constants.Constants.ACK_SECTOR_UPDATED_PPD21);
 
-            var dbSubsector = _context.DETAILS_DEMOGRAPHICS.FirstOrDefault(x => x.Assessment_Id == assessmentId && x.DataItemName == "SUBSECTOR");
-            if (dbSubsector != null)
+            if (!acknowledgementExists)
             {
-                _context.Remove(dbSubsector);
+                _context.DETAILS_DEMOGRAPHICS.Add(
+                    new DETAILS_DEMOGRAPHICS
+                    {
+                        Assessment_Id = assessmentId,
+                        DataItemName = Constants.Constants.ACK_SECTOR_UPDATED_PPD21,
+                        BoolValue = true
+                    });
             }
 
             _context.SaveChanges();
 
-            return resp;
+            return result;
         }
 
 

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Question/QuestionBusiness.cs
@@ -485,8 +485,8 @@ namespace CSETWebCore.Business.Question
 
 
         /// <summary>
-        /// Persists a single answer to the SUB_CATEGORY_ANSWERS table for the 'block answer',
-        /// and flips all of the constituent questions' answers.
+        /// Persists the subcategory answer and all constituent question answers
+        /// as a single atomic operation.
         /// </summary>
         public void StoreSubcategoryAnswers(SubCategoryAnswers subCatAnswerBlock)
         {
@@ -495,45 +495,81 @@ namespace CSETWebCore.Business.Question
                 return;
             }
 
-            // SUB_CATEGORY_ANSWERS
+            using var transaction =
+                _context.Database.BeginTransaction();
 
-            // Get the USCH so that we will know the Heading_Pair_Id
-            var usch = _context.UNIVERSAL_SUB_CATEGORY_HEADINGS.FirstOrDefault(u => u.Question_Group_Heading_Id == subCatAnswerBlock.GroupHeadingId
-                                                                           && u.Universal_Sub_Category_Id == subCatAnswerBlock.SubCategoryId);
-
-            var subCatAnswer = _context.SUB_CATEGORY_ANSWERS.FirstOrDefault(sca => sca.Assessment_Id == _questionRequirement.AssessmentId
-                                                                          && sca.Heading_Pair_Id == usch.Heading_Pair_Id);
-
-            if (subCatAnswer == null)
+            try
             {
-                subCatAnswer = new SUB_CATEGORY_ANSWERS();
-                subCatAnswer.Assessment_Id = _questionRequirement.AssessmentId;
-                subCatAnswer.Heading_Pair_Id = usch.Heading_Pair_Id;
-                subCatAnswer.Answer_Text = subCatAnswerBlock.SubCategoryAnswer;
-                subCatAnswer.Component_Guid = new Guid().ToString();
-                _context.SUB_CATEGORY_ANSWERS.Add(subCatAnswer);
-            }
-            else
-            {
-                subCatAnswer.Assessment_Id = _questionRequirement.AssessmentId;
-                subCatAnswer.Heading_Pair_Id = usch.Heading_Pair_Id;
-                subCatAnswer.Answer_Text = subCatAnswerBlock.SubCategoryAnswer;
-                _context.SUB_CATEGORY_ANSWERS.Update(subCatAnswer);
-            }
+                var assessmentId =
+                    _questionRequirement.AssessmentId;
 
-            _context.SaveChanges();
+                var heading = _context.UNIVERSAL_SUB_CATEGORY_HEADINGS
+                    .FirstOrDefault(x =>
+                        x.Question_Group_Heading_Id
+                            == subCatAnswerBlock.GroupHeadingId
+                        && x.Universal_Sub_Category_Id
+                            == subCatAnswerBlock.SubCategoryId);
 
-            _assessmentUtil.TouchAssessment(_questionRequirement.AssessmentId);
-
-            // loop and store all of the subcategory's answers
-            foreach (Answer ans in subCatAnswerBlock.Answers)
-            {
-
-                if (String.IsNullOrWhiteSpace(ans.QuestionType))
+                if (heading == null)
                 {
-                    ans.QuestionType = _questionRequirement.DetermineQuestionType(ans.Is_Requirement, ans.Is_Component, false, ans.Is_Maturity);
+                    throw new InvalidOperationException(
+                        "The requested subcategory heading does not exist.");
                 }
-                _questionRequirement.StoreAnswer(ans);
+
+                var subCategoryAnswer = _context.SUB_CATEGORY_ANSWERS
+                    .FirstOrDefault(x =>
+                        x.Assessment_Id == assessmentId
+                        && x.Heading_Pair_Id == heading.Heading_Pair_Id);
+
+                if (subCategoryAnswer == null)
+                {
+                    subCategoryAnswer = new SUB_CATEGORY_ANSWERS
+                    {
+                        Assessment_Id = assessmentId,
+                        Heading_Pair_Id = heading.Heading_Pair_Id,
+                        Answer_Text = subCatAnswerBlock.SubCategoryAnswer,
+                        Component_Guid = Guid.Empty.ToString()
+                    };
+
+                    _context.SUB_CATEGORY_ANSWERS.Add(
+                        subCategoryAnswer);
+                }
+                else
+                {
+                    subCategoryAnswer.Answer_Text =
+                        subCatAnswerBlock.SubCategoryAnswer;
+
+                    _context.SUB_CATEGORY_ANSWERS.Update(
+                        subCategoryAnswer);
+                }
+
+                _context.SaveChanges();
+
+                foreach (var answer in subCatAnswerBlock.Answers)
+                {
+                    if (string.IsNullOrWhiteSpace(answer.QuestionType))
+                    {
+                        answer.QuestionType =
+                            _questionRequirement.DetermineQuestionType(
+                                answer.Is_Requirement,
+                                answer.Is_Component,
+                                false,
+                                answer.Is_Maturity);
+                    }
+
+                    // StoreAnswer() can call SaveChanges(). Those calls still
+                    // participate in the transaction opened above.
+                    _questionRequirement.StoreAnswer(answer);
+                }
+
+                _assessmentUtil.TouchAssessment(assessmentId);
+
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
             }
         }
 

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/DemographicsController.cs
@@ -15,6 +15,7 @@ using CSETWebCore.Interfaces.Helpers;
 using CSETWebCore.Model.Assessment;
 using CSETWebCore.Model.Demographic;
 using CSETWebCore.Model.Question;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -231,9 +232,15 @@ namespace CSETWebCore.Api.Controllers
                     response.TotalStandardQuestionsCount = stats.TotalStandardQuestionsCount ?? 0;
                 }
             }
+            catch (ArgumentException exc)
+            {
+                NLog.LogManager.GetCurrentClassLogger().Warn($"Invalid sector selection: {exc}");
+                return BadRequest(exc.Message);
+            }
             catch (Exception exc)
             {
                 NLog.LogManager.GetCurrentClassLogger().Error($"... {exc}");
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
 
             return Ok(response);

--- a/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWeb_ApiCore/Controllers/QuestionsController.cs
@@ -229,97 +229,120 @@ namespace CSETWebCore.Api.Controllers
 
 
         /// <summary>
-        /// Persists an answer.  This includes Y/N/NA/A as well as comments and alt text.
+        /// Persists an answer. This includes Y/N/NA/A as well as
+        /// comments, feedback, justification and review state.
         /// </summary>
         [HttpPost]
         [Route("api/AnswerQuestion")]
         public IActionResult StoreAnswer([FromBody] Answer answer)
         {
-            int assessmentId = _token.AssessmentForUser();
+            if (answer == null)
+            {
+                return BadRequest("An answer is required.");
+            }
+
+            var assessmentId = _token.AssessmentForUser();
+            var questionType = answer.QuestionType?.Trim();
+
+            Answer savedAnswer;
+            var detailsChanged = false;
+
+            switch (questionType)
+            {
+                case "Component":
+                    {
+                        var business = new ComponentQuestionBusiness(
+                            _context,
+                            _assessmentUtil,
+                            _token,
+                            _questionRequirement);
+
+                        savedAnswer = business.StoreAnswer(answer);
+                        _hooks.HookQuestionAnswered(savedAnswer);
+                        break;
+                    }
+
+                case "Requirement":
+                    {
+                        var business = new RequirementBusiness(
+                            _assessmentUtil,
+                            _questionRequirement,
+                            _context,
+                            _token);
+
+                        savedAnswer = business.StoreAnswer(answer);
+                        _hooks.HookQuestionAnswered(savedAnswer);
+                        break;
+                    }
+
+                case "Maturity":
+                    {
+                        var business = new MaturityBusiness(
+                            _context,
+                            _assessmentUtil);
+
+                        savedAnswer = business.StoreAnswer(assessmentId, answer);
+                        detailsChanged = _hooks.HookQuestionAnswered(savedAnswer);
+                        break;
+                    }
+
+                case "Question":
+                    {
+                        var business = new QuestionBusiness(
+                            _token,
+                            _document,
+                            _htmlConverter,
+                            _questionRequirement,
+                            _assessmentUtil,
+                            _context);
+
+                        savedAnswer = business.StoreAnswer(answer);
+                        _hooks.HookQuestionAnswered(savedAnswer);
+                        break;
+                    }
+
+                default:
+                    return BadRequest(
+                        $"Unsupported question type '{answer.QuestionType}'.");
+            }
+
+            if (!savedAnswer.AnswerId.HasValue || savedAnswer.AnswerId.Value <= 0)
+            {
+                NLog.LogManager.GetCurrentClassLogger().Error(
+                    "Answer persistence returned no valid AnswerId. "
+                    + $"AssessmentId={assessmentId}, "
+                    + $"QuestionId={answer.QuestionId}, "
+                    + $"QuestionType={questionType}");
+
+                return StatusCode(
+                    Microsoft.AspNetCore.Http.StatusCodes.Status500InternalServerError,
+                    "The answer could not be persisted.");
+            }
+
+            // Update last-answered state only after persistence succeeds.
+            var lastAnswered = new LastAnsweredHelper(_context);
+            lastAnswered.Save(
+                assessmentId,
+                _token.GetCurrentUserId(),
+                savedAnswer);
 
             var response = new AnswerQuestionResponse
             {
-                AnswerId = 0,
-                DetailsChanged = false
+                AnswerId = savedAnswer.AnswerId.Value,
+                DetailsChanged = detailsChanged,
+                AssessmentId = assessmentId
             };
 
-
-            if (answer == null)
-            {
-                return Ok(0);
-            }
-
-            if (String.IsNullOrWhiteSpace(answer.QuestionType))
-            {
-                if (answer.Is_Component)
-                    answer.QuestionType = "Component";
-                if (answer.Is_Maturity)
-                    answer.QuestionType = "Maturity";
-                if (answer.Is_Requirement)
-                    answer.QuestionType = "Requirement";
-                if (answer.Is_Question)
-                    answer.QuestionType = "Question";
-            }
-
-
-            // Remember the last-answered question
-            var lah = new LastAnsweredHelper(_context);
-            lah.Save(assessmentId, _token.GetCurrentUserId(), answer);
-
-            if (answer.Is_Component)
-            {
-                var cb = new ComponentQuestionBusiness(_context, _assessmentUtil, _token, _questionRequirement);
-                var savedComponentAnswer = cb.StoreAnswer(answer);
-
-                _hooks.HookQuestionAnswered(savedComponentAnswer);
-
-                response.AnswerId = (int)savedComponentAnswer.AnswerId;
-            }
-
-
-            if (answer.Is_Requirement)
-            {
-                var rb = new RequirementBusiness(_assessmentUtil, _questionRequirement, _context, _token);
-                var savedRequirementAnswer = rb.StoreAnswer(answer);
-
-                _hooks.HookQuestionAnswered(savedRequirementAnswer);
-
-
-                response.AnswerId = (int)savedRequirementAnswer.AnswerId;
-            }
-
-
-            if (answer.Is_Maturity)
-            {
-                var mb = new MaturityBusiness(_context, _assessmentUtil);
-                var savedMaturityAnswer = mb.StoreAnswer(assessmentId, answer);
-
-                var detailsChanged = _hooks.HookQuestionAnswered(savedMaturityAnswer);
-
-
-                response.AnswerId = (int)savedMaturityAnswer.AnswerId;
-                response.DetailsChanged = detailsChanged;
-            }
-
-
-            if (answer.QuestionType == "Question")
-            {
-                var qb = new QuestionBusiness(_token, _document, _htmlConverter, _questionRequirement, _assessmentUtil, _context);
-                var savedQuestionAnswer = qb.StoreAnswer(answer);
-
-                _hooks.HookQuestionAnswered(savedQuestionAnswer);
-
-                response.AnswerId = (int)savedQuestionAnswer.AnswerId;
-            }
-
-
-            CompletionCounts stats = new CompletionCounter(_context).Count(assessmentId);
+            var stats = new CompletionCounter(_context).Count(assessmentId);
             if (stats != null)
             {
                 response.CompletedCount = stats.CompletedCount;
-                response.TotalMaturityQuestionsCount = stats.TotalMaturityQuestionsCount ?? 0;
-                response.TotalDiagramQuestionsCount = stats.TotalDiagramQuestionsCount ?? 0;
-                response.TotalStandardQuestionsCount = stats.TotalStandardQuestionsCount ?? 0;
+                response.TotalMaturityQuestionsCount =
+                    stats.TotalMaturityQuestionsCount ?? 0;
+                response.TotalDiagramQuestionsCount =
+                    stats.TotalDiagramQuestionsCount ?? 0;
+                response.TotalStandardQuestionsCount =
+                    stats.TotalStandardQuestionsCount ?? 0;
             }
 
             return Ok(response);

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.html
@@ -58,8 +58,8 @@
     <div class="row mb-3">
       <div class="col">
         <label for="name" class="form-label">{{t('cisa region')}}</label>
-        <select class="form-select" id="cisaRegion" tabindex="0" name="cisaRegion" (change)="updateDemographicsIod()"
-          [(ngModel)]="iodDemographics.cisaRegion">
+        <select class="form-select" id="cisaRegion" tabindex="0" name="cisaRegion" (change)="updateDemographics()"
+          [(ngModel)]="demographics.cisaRegion">
           <option [ngValue]="null">-- {{t('select')}} --</option>
           <option *ngFor="let region of iodDemographics.cisaRegions" [ngValue]="region.optionValue">
             {{region.optionText}}

--- a/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
+++ b/CSETWebNg/src/app/assessment/prepare/assessment-info/assessment-config-iod/assessment-config-iod.component.ts
@@ -22,7 +22,7 @@
 //
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
-import { AssessmentDetail } from '../../../../models/assessment-info.model';
+import { AssessmentDetail, Demographic } from '../../../../models/assessment-info.model';
 import { DemographicsIod } from '../../../../models/demographics-iod.model';
 import { User } from '../../../../models/user.model';
 import { AssessmentService } from '../../../../services/assessment.service';
@@ -41,7 +41,7 @@ import { ContactsService } from '../../../../services/contacts.service';
 })
 export class AssessmentConfigIodComponent implements OnInit {
   iodDemographics: DemographicsIod = {};
-  demographics: any = {};
+  demographics: Demographic = {};
   contacts: User[] = [];
   assessment: AssessmentDetail = {};
   IsPCII: boolean = false;
@@ -59,13 +59,13 @@ export class AssessmentConfigIodComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.demoSvc.getDemographic().subscribe((data: any) => {
+    this.demoSvc.getDemographic().subscribe((data: Demographic) => {
       this.demographics = data;
       this.assessSvc.assessment.ssgModelIds = data.ssgModelIds;
       this.demographics.techDomain ??= 'IT';
     });
 
-    this.iodDemoSvc.getDemographics().subscribe((data: any) => {
+    this.iodDemoSvc.getDemographics().subscribe((data: DemographicsIod) => {
       this.iodDemographics = data;
       this.iodDemographics.techDomain ??= 'IT';
     });
@@ -145,10 +145,6 @@ export class AssessmentConfigIodComponent implements OnInit {
 
   updateDemographics() {
     this.demoSvc.updateDemographic(this.demographics);
-  }
-
-  updateDemographicsIod() {
-    this.iodDemoSvc.updateDemographic(this.iodDemographics);
   }
 
   showCityName() {

--- a/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block-maturity/question-block-maturity.component.ts
@@ -32,6 +32,12 @@ import { CompletionService } from '../../../services/completion.service';
 import { TranslocoService } from '@jsverse/transloco';
 
 
+interface AnswerSaveState {
+  confirmedAnswer: string;
+  version: number;
+}
+
+
 /**
  * This was cloned from question-block to start a new version that is
  * not so "subcategory-centric", mainly for the new simplified
@@ -62,6 +68,9 @@ export class QuestionBlockMaturityComponent implements OnInit {
 
   moduleBehavior: any;
   titlePlacement: string;
+
+  private answerSaveStates =
+    new WeakMap<Question, AnswerSaveState>();
 
 
   /**
@@ -167,11 +176,36 @@ export class QuestionBlockMaturityComponent implements OnInit {
   }
 
   /**
+   * Gets the save state before applying an optimistic answer change.
+   */
+  private beginAnswerSave(q: Question): {
+    state: AnswerSaveState;
+    version: number;
+  } {
+    let state = this.answerSaveStates.get(q);
+
+    if (!state) {
+      state = {
+        confirmedAnswer: q.answer,
+        version: 0
+      };
+      this.answerSaveStates.set(q, state);
+    }
+
+    return {
+      state,
+      version: ++state.version
+    };
+  }
+
+  /**
    * Pushes an answer asynchronously to the API.
    * @param q
    * @param ans
    */
   storeAnswer(q: Question, newAnswerValue: string) {
+    const attempt = this.beginAnswerSave(q);
+
     // if they clicked on the same answer that was previously set, "un-set" it
     if (q.answer === newAnswerValue) {
       newAnswerValue = 'U';
@@ -180,6 +214,8 @@ export class QuestionBlockMaturityComponent implements OnInit {
     if (!!newAnswerValue) {
       q.answer = newAnswerValue;
     }
+
+    const submittedAnswer = q.answer;
 
     const answer: Answer = {
       answerId: q.answer_Id,
@@ -206,19 +242,34 @@ export class QuestionBlockMaturityComponent implements OnInit {
 
     this.refreshPercentAnswered();
 
-    this.questionsSvc.storeAnswer(answer).subscribe((response: AnswerQuestionResponse) => {
-      q.answer_Id = response.answerId;
-      if (response.detailsChanged) {
-        this.questionsSvc.emitRefreshQuestionDetails(answer.questionId);
-      }
-      if (response && response.completedCount !== undefined) {
-        this.assessSvc.completionRefreshRequested$.next({
-          completedCount: response.completedCount,
-          totalCount: (response.totalMaturityQuestionsCount || 0) +
-            (response.totalDiagramQuestionsCount || 0) +
-            (response.totalStandardQuestionsCount || 0)
+    this.questionsSvc.storeAnswer(answer).subscribe({
+      next: (response: AnswerQuestionResponse) => {
+        attempt.state.confirmedAnswer = submittedAnswer;
 
-        });
+        q.answer_Id = response.answerId;
+        if (response.detailsChanged) {
+          this.questionsSvc.emitRefreshQuestionDetails(answer.questionId);
+        }
+        if (response && response.completedCount !== undefined) {
+          this.assessSvc.completionRefreshRequested$.next({
+            completedCount: response.completedCount,
+            totalCount: (response.totalMaturityQuestionsCount || 0) +
+              (response.totalDiagramQuestionsCount || 0) +
+              (response.totalStandardQuestionsCount || 0)
+
+          });
+        }
+      },
+      error: error => {
+        if (attempt.state.version === attempt.version) {
+          q.answer = attempt.state.confirmedAnswer;
+          this.completionSvc.setAnswer(q.questionId, q.answer);
+          this.setJustificationVisibility(q);
+          this.refreshReviewIndicator();
+          this.refreshPercentAnswered();
+        }
+
+        console.error('Unable to save answer.', error);
       }
     });
   }

--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.ts
@@ -35,6 +35,19 @@ import { MalcolmService } from '../../../services/malcolm.service';
 import { LinebreakPipe } from '../../../helpers/linebreak.pipe';
 
 
+interface AnswerSaveState {
+  confirmedAnswer: string;
+  version: number;
+}
+
+interface AnswerSaveAttempt {
+  question: Question;
+  state: AnswerSaveState;
+  version: number;
+  submittedAnswer: string;
+}
+
+
 /**
  * Represents the display container of a single subcategory with its member questions.
  */
@@ -67,6 +80,11 @@ export class QuestionBlockComponent implements OnInit {
   titlePlacement = 'top';
 
   showQuestionIds = false;
+
+  private answerSaveStates =
+    new WeakMap<Question, AnswerSaveState>();
+
+  private subCategorySaveState?: AnswerSaveState;
 
 
   /**
@@ -232,12 +250,66 @@ export class QuestionBlockComponent implements OnInit {
   }
 
   /**
+   * Starts an optimistic save while retaining the last server-confirmed value.
+   */
+  private beginAnswerSave(q: Question): AnswerSaveAttempt {
+    let state = this.answerSaveStates.get(q);
+
+    if (!state) {
+      state = {
+        confirmedAnswer: q.answer,
+        version: 0
+      };
+      this.answerSaveStates.set(q, state);
+    }
+
+    return {
+      question: q,
+      state,
+      version: ++state.version,
+      submittedAnswer: q.answer
+    };
+  }
+
+  /**
+   * Restores the confirmed value only if no newer save has been submitted.
+   */
+  private rollbackAnswer(attempt: AnswerSaveAttempt): boolean {
+    if (attempt.state.version !== attempt.version) {
+      return false;
+    }
+
+    attempt.question.answer = attempt.state.confirmedAnswer;
+    this.completionSvc.setAnswer(
+      attempt.question.questionId,
+      attempt.question.answer
+    );
+    this.setJustificationVisibility(attempt.question);
+
+    return true;
+  }
+
+  private getSubCategorySaveState(): AnswerSaveState {
+    if (!this.subCategorySaveState) {
+      this.subCategorySaveState = {
+        confirmedAnswer: this.mySubCategory.subCategoryAnswer,
+        version: 0
+      };
+    }
+
+    return this.subCategorySaveState;
+  }
+
+  /**
    * Send a block of answers to the API for all my questions.
    * This is used when selecting "N" or "NA" at the subcategory
    * level.  All of the subcategory questions are answered en masse.
    * @param ans
    */
   setBlockAnswer(ans: string) {
+    const subCategoryState = this.getSubCategorySaveState();
+    const subCategoryVersion = ++subCategoryState.version;
+
     // if they clicked on the same answer that was previously set, "un-set" it
     if (this.mySubCategory.subCategoryAnswer === ans) {
       ans = "U";
@@ -252,13 +324,19 @@ export class QuestionBlockComponent implements OnInit {
       answers: []
     };
 
+    const answerAttempts: AnswerSaveAttempt[] = [];
+
     // Bundle all of the member questions for this subcategory into the request
     this.mySubCategory.questions.forEach(q => {
+      const attempt = this.beginAnswerSave(q);
 
       // set all questions' answers if N or NA or U
       if (ans === 'N' || ans === 'NA' || ans === 'U') {
         q.answer = ans;
       }
+
+      attempt.submittedAnswer = q.answer;
+      answerAttempts.push(attempt);
 
       const answer: Answer = {
         answerId: q.answer_Id,
@@ -278,6 +356,7 @@ export class QuestionBlockComponent implements OnInit {
       };
 
       this.completionSvc.setAnswer(q.questionId, q.answer);
+      this.setJustificationVisibility(q);
 
       subCatAnswers.answers.push(answer);
     });
@@ -287,7 +366,41 @@ export class QuestionBlockComponent implements OnInit {
     this.refreshPercentAnswered();
 
     this.questionsSvc.storeSubCategoryAnswers(subCatAnswers)
-      .subscribe();
+      .subscribe({
+        next: () => {
+          subCategoryState.confirmedAnswer =
+            subCatAnswers.subCategoryAnswer;
+
+          answerAttempts.forEach(attempt => {
+            attempt.state.confirmedAnswer =
+              attempt.submittedAnswer;
+          });
+        },
+        error: error => {
+          if (subCategoryState.version === subCategoryVersion) {
+            this.mySubCategory.subCategoryAnswer =
+              subCategoryState.confirmedAnswer;
+          }
+
+          let answerRolledBack = false;
+
+          answerAttempts.forEach(attempt => {
+            answerRolledBack =
+              this.rollbackAnswer(attempt)
+              || answerRolledBack;
+          });
+
+          if (answerRolledBack) {
+            this.refreshReviewIndicator();
+            this.refreshPercentAnswered();
+          }
+
+          console.error(
+            'Unable to save subcategory answers.',
+            error
+          );
+        }
+      });
   }
 
   /**
@@ -308,6 +421,8 @@ export class QuestionBlockComponent implements OnInit {
    * @param ans
    */
   storeAnswer(q: Question, newAnswerValue: string) {
+    const attempt = this.beginAnswerSave(q);
+
     // if they clicked on the same answer that was previously set, "un-set" it
     if (q.answer === newAnswerValue) {
       newAnswerValue = "U";
@@ -316,6 +431,8 @@ export class QuestionBlockComponent implements OnInit {
     if (!!newAnswerValue) {
       q.answer = newAnswerValue;
     }
+
+    attempt.submittedAnswer = q.answer;
 
     const answer: Answer = {
       answerId: q.answer_Id,
@@ -343,21 +460,33 @@ export class QuestionBlockComponent implements OnInit {
     this.refreshPercentAnswered();
 
     this.questionsSvc.storeAnswer(answer)
-      .subscribe((resp: AnswerQuestionResponse) => {
-        q.answer_Id = resp.answerId;
-        if (resp.detailsChanged) {
-          this.questionsSvc.emitRefreshQuestionDetails(answer.questionId);
-        }
-        if (resp && resp.completedCount !== undefined) {
-          this.assessSvc.completionRefreshRequested$.next({
-            completedCount: resp.completedCount,
-            totalCount: (resp.totalMaturityQuestionsCount || 0) +
-              (resp.totalDiagramQuestionsCount || 0) +
-              (resp.totalStandardQuestionsCount || 0)
-          });
+      .subscribe({
+        next: (resp: AnswerQuestionResponse) => {
+          attempt.state.confirmedAnswer =
+            attempt.submittedAnswer;
+
+          q.answer_Id = resp.answerId;
+          if (resp.detailsChanged) {
+            this.questionsSvc.emitRefreshQuestionDetails(answer.questionId);
+          }
+          if (resp && resp.completedCount !== undefined) {
+            this.assessSvc.completionRefreshRequested$.next({
+              completedCount: resp.completedCount,
+              totalCount: (resp.totalMaturityQuestionsCount || 0) +
+                (resp.totalDiagramQuestionsCount || 0) +
+                (resp.totalStandardQuestionsCount || 0)
+            });
+          }
+        },
+        error: error => {
+          if (this.rollbackAnswer(attempt)) {
+            this.refreshReviewIndicator();
+            this.refreshPercentAnswered();
+          }
+
+          console.error('Unable to save answer.', error);
         }
       });
-
   }
 
   /**

--- a/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
+++ b/CSETWebNg/src/app/assessment/questions/question-extras/question-extras.component.ts
@@ -27,7 +27,7 @@ import { OkayComponent } from '../../../dialogs/okay/okay.component';
 import { ConfirmComponent } from '../../../dialogs/confirm/confirm.component';
 // eslint-disable-next-line max-len
 import { ReferenceDocLink, QuestionDetailsContentViewModel, QuestionInformationTabData, QuestionDocument } from '../../../models/question-extras.model';
-import { Answer, Question } from '../../../models/questions.model';
+import { Answer, AnswerQuestionResponse, Question } from '../../../models/questions.model';
 import { ConfigService } from '../../../services/config.service';
 import { FileUploadClientService } from '../../../services/file-client.service';
 import { ObservationsService } from '../../../services/observations.service';
@@ -335,8 +335,11 @@ export class QuestionExtrasComponent implements OnInit {
     this.questionsSvc.broadcastExtras(this.extras);
 
     this.questionsSvc.storeAnswer(this.answer).subscribe(
-      (response: number) => {
-        this.myQuestion.answer_Id = response;
+      (response: AnswerQuestionResponse) => {
+        this.myQuestion.answer_Id = response.answerId;
+        if (this.answer != null) {
+          this.answer.answerId = response.answerId;
+        }
       },
       error => console.error('Error saving response: ' + (<Error>error).message)
     );

--- a/CSETWebNg/src/app/helpers/jwt.interceptor.ts
+++ b/CSETWebNg/src/app/helpers/jwt.interceptor.ts
@@ -23,7 +23,7 @@
 ////////////////////////////////
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Router } from '@angular/router';
 
@@ -36,17 +36,15 @@ export class JwtInterceptor implements HttpInterceptor {
     request: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    // add authorization header with jwt token if available 
+    // add authorization header with jwt token if available
     // and the requestor did not provide one
     if (!request.headers.has('authorization') && !request.headers.has('noauth')) {
-      if (
-        localStorage.getItem('userToken') &&
-        localStorage.getItem('userToken').length > 1
-      ) {
-        request.headers.append('Content-Type', 'application/json');
+      const userToken = localStorage.getItem('userToken');
+
+      if (userToken?.length > 1) {
         request = request.clone({
           setHeaders: {
-            Authorization: localStorage.getItem('userToken')
+            Authorization: userToken
           }
         });
       }
@@ -54,36 +52,34 @@ export class JwtInterceptor implements HttpInterceptor {
 
     return next.handle(request)
       .pipe(
-        catchError((event: any, caught: Observable<any>) => {
+        catchError((error: HttpErrorResponse) => {
+          const shouldEject =
+            error.status === 500
+            || error.status === 401
+            || error.error?.ExceptionMessage === 'JWT invalid';
 
-          if (event instanceof HttpErrorResponse) {
-            const e = <HttpErrorResponse>event;
+          if (shouldEject) {
+            console.error('HTTP authentication/server error. Logging out.');
 
-            // continue if this is a "business exception"
-            if (e.status !== 500 && e.status !== 401) {
-              throw event;
-            }
-
-
-            if (e.status === 401) {
-              console.error('Error 401! Ejecting to login page!');
-            }
-
-            if (e.status === 500 || (e.error && e.error.ExceptionMessage === 'JWT invalid')) {
-              console.error('JWT Invalid. logging out.');
-            }
-
-            const userToken = localStorage.getItem('userToken')
+            const userToken = localStorage.getItem('userToken');
             // Preserve theme preference
             const savedTheme = localStorage.getItem('cset-theme');
+
             localStorage.clear();
+
             if (savedTheme) {
               localStorage.setItem('cset-theme', savedTheme);
             }
-            this.router.navigate(['/home/login/eject'], { queryParams: { token: userToken } });
 
-            return of({});
+            this.router.navigate(
+              ['/home/login/eject'],
+              { queryParams: { token: userToken } }
+            );
           }
+
+          // Preserve the failure so callers can report, retry, or recover from
+          // an unsuccessful request instead of treating it as a success.
+          return throwError(() => error);
         })
       );
   }

--- a/CSETWebNg/src/app/models/assessment-info.model.ts
+++ b/CSETWebNg/src/app/models/assessment-info.model.ts
@@ -115,6 +115,8 @@ export interface AssessmentContactsResponse {
 export interface Demographic {
     assessment_Id?: number;
 
+    cisaRegion?: number;
+
     // PPD-21 or NIPP
     sectorDirective?: string;
 

--- a/CSETWebNg/src/app/models/demographics-iod.model.ts
+++ b/CSETWebNg/src/app/models/demographics-iod.model.ts
@@ -31,6 +31,7 @@ export interface DemographicsIod {
   organizationName?: string;
   facilityName?: string;
   businessUnit?: string;
+  cisaRegion?: number;
 
   // PPD-21 or NIPP
   sectorDirective?: string;
@@ -82,6 +83,7 @@ export interface DemographicsIod {
   listRegulationTypes?: any[];
   listShareOrgs?: any[];
   listBarriers?: any[];
+  cisaRegions?: any[];
 }
 
 export interface CisaWorkflowFieldValidationResponse {

--- a/CSETWebNg/src/app/services/questions.service.ts
+++ b/CSETWebNg/src/app/services/questions.service.ts
@@ -23,11 +23,25 @@
 ////////////////////////////////
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-// eslint-disable-next-line max-len
-import { Answer, DefaultParameter, ParameterForAnswer, Category, SubCategoryAnswers, QuestionResponse, SubCategory, Question } from '../models/questions.model';
+import {
+  Answer,
+  AnswerQuestionResponse,
+  Category,
+  DefaultParameter,
+  ParameterForAnswer,
+  Question,
+  QuestionResponse,
+  SubCategory,
+  SubCategoryAnswers
+} from '../models/questions.model';
 import { ConfigService } from './config.service';
 import { AssessmentService } from './assessment.service';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import {
+  BehaviorSubject,
+  firstValueFrom,
+  Observable,
+  Subject
+} from 'rxjs';
 import { TranslocoService } from '@jsverse/transloco';
 import { LinebreakPipe } from '../helpers/linebreak.pipe';
 import { tap } from 'rxjs/operators';
@@ -38,10 +52,18 @@ const headers = {
   params: new HttpParams()
 };
 
+interface CompletionCountResponse {
+  completedCount?: number;
+  totalMaturityQuestionsCount?: number;
+  totalDiagramQuestionsCount?: number;
+  totalStandardQuestionsCount?: number;
+}
+
 @Injectable()
 export class QuestionsService {
 
-  public questionOverrideSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  public questionOverrideSubject =
+    new BehaviorSubject<boolean>(false);
 
   /**
    * The TOC might make the API trip to get the questions.  If so,
@@ -67,12 +89,17 @@ export class QuestionsService {
    * Components override update subject
    */
   private componentOverrideEventSubject = new Subject<any>();
-  componentOverrideEvent$ = this.componentOverrideEventSubject.asObservable();
-
+  componentOverrideEvent$ =
+    this.componentOverrideEventSubject.asObservable();
 
   /**
+   * The tail of each answer's save queue.
    *
+   * Saves for different questions can run concurrently, while saves for the
+   * same answer identity are executed in the order they were submitted.
    */
+  private answerSaveQueues = new Map<string, Promise<void>>();
+
   constructor(
     private http: HttpClient,
     private configSvc: ConfigService,
@@ -91,71 +118,70 @@ export class QuestionsService {
    */
   questions: QuestionResponse = null;
 
-
   /**
    * Sets the application mode of the assessment.
    */
   setMode(mode: string) {
-    return this.http.post(this.configSvc.apiUrl + 'setmode?mode=' + mode, headers)
-      .pipe(
-        tap((response: any) => {
-          if (response?.completedCount !== undefined) {
-            const totalCount =
-              (response.totalMaturityQuestionsCount || 0) +
-              (response.totalDiagramQuestionsCount || 0) +
-              (response.totalStandardQuestionsCount || 0);
-            this.assessSvc.completionRefreshRequested$.next({
-              completedCount: response.completedCount,
-              totalCount: totalCount
-            });
-          }
-        })
-      );
+    return this.http.post(
+      this.configSvc.apiUrl + 'setmode?mode=' + mode,
+      headers
+    ).pipe(
+      tap((response: any) => {
+        this.publishCompletionCounts(response);
+      })
+    );
   }
+
   /**
    * Retrieves the list of questions.
    */
   getQuestionsList() {
-    return this.http.get(this.configSvc.apiUrl + 'questionlist', headers);
+    return this.http.get(
+      this.configSvc.apiUrl + 'questionlist',
+      headers
+    );
   }
 
-  /**
-   *
-   */
   getComponentQuestionsList(): Observable<QuestionResponse> {
-    return this.http.get<QuestionResponse>(this.configSvc.apiUrl + 'componentquestionlist', headers);
+    return this.http.get<QuestionResponse>(
+      this.configSvc.apiUrl + 'componentquestionlist',
+      headers
+    );
   }
 
-  /**
-   *
-   */
   getQuestionListOverridesOnly() {
-    return this.http.get(this.configSvc.apiUrl + 'QuestionListComponentOverridesOnly', headers);
+    return this.http.get(
+      this.configSvc.apiUrl + 'QuestionListComponentOverridesOnly',
+      headers
+    );
   }
 
   /**
-   * Grab all the child question's answers for a specific parent question.
-   * Currently set up for use in an ISE assessment.
-  */
+   * Gets all child-question answers for a parent question.
+   */
   getChildAnswers(parentId: number) {
-    headers.params = headers.params.set('parentId', parentId);
-    return this.http.get(this.configSvc.apiUrl + 'GetChildAnswers', headers);
+    const options = {
+      ...headers,
+      params: headers.params.set('parentId', parentId)
+    };
+
+    return this.http.get(
+      this.configSvc.apiUrl + 'GetChildAnswers',
+      options
+    );
   }
 
   /**
-   * Analyzes the current 'auto load supplemental' preference and the maturity model
+   * Determines whether supplemental content should load automatically.
    */
   autoLoadSupplemental(modelId?: any) {
-    // first see if it should be forced on by configuration
     if (this.configSvc.config.supplementalAutoloadInitialValue) {
       return true;
     }
 
-    // find the configuration for the model
-    const moduleBehavior = this.configSvc.getModuleBehavior(modelId);
+    const moduleBehavior =
+      this.configSvc.getModuleBehavior(modelId);
 
-
-    // standards (modelid is null) - check the checkbox state
     if (!moduleBehavior) {
       return this.autoLoadSuppCheckboxState;
     }
@@ -164,160 +190,360 @@ export class QuestionsService {
   }
 
   /**
-   * Posts an Answer to the API.
-   * @param answer
+   * Queues an answer for persistence.
+   *
+   * Calls for the same answer identity are serialized. This prevents an older
+   * extras request from completing after a newer answer-value request and
+   * overwriting the newer value.
    */
-  storeAnswer(answer: Answer) {
-    answer.questionType = localStorage.getItem('questionSet');
-    return this.http.post(this.configSvc.apiUrl + 'answerquestion', answer, headers).pipe(
-      tap((response: any) => {
-        if (response?.completedCount !== undefined) {
-          // Find whichever count has a value (only one will)
-          const totalCount =
-            (response.totalMaturityQuestionsCount || 0) +
-            (response.totalDiagramQuestionsCount || 0) +
-            (response.totalStandardQuestionsCount || 0);
-          this.assessSvc.completionRefreshRequested$.next({
-            completedCount: response.completedCount,
-            totalCount: totalCount
-          });
-        }
+  storeAnswer(
+    answer: Answer
+  ): Observable<AnswerQuestionResponse> {
+
+    // All Answer properties are primitives, so a shallow copy is sufficient.
+    // The snapshot prevents later UI mutations from changing a queued request.
+    const snapshot: Answer = { ...answer };
+    const queueKey = this.buildAnswerQueueKey(snapshot);
+
+    return new Observable<AnswerQuestionResponse>(subscriber => {
+      const previousTail =
+        this.answerSaveQueues.get(queueKey) ?? Promise.resolve();
+
+      let currentTail: Promise<void>;
+
+      currentTail = previousTail
+        // A failed save must not permanently block later saves.
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            const response = await firstValueFrom(
+              this.postAnswer(snapshot)
+            );
+
+            if (!subscriber.closed) {
+              subscriber.next(response);
+              subscriber.complete();
+            }
+          } catch (error) {
+            if (!subscriber.closed) {
+              subscriber.error(error);
+            }
+          }
+        })
+        .finally(() => {
+          // Only the current tail may remove this queue. A newer request may
+          // already have replaced it.
+          if (this.answerSaveQueues.get(queueKey) === currentTail) {
+            this.answerSaveQueues.delete(queueKey);
+          }
+        });
+
+      this.answerSaveQueues.set(queueKey, currentTail);
+    });
+  }
+
+  /**
+   * Performs the actual HTTP request after the queued request reaches the
+   * front of its answer-specific queue.
+   */
+  private postAnswer(
+    answer: Answer
+  ): Observable<AnswerQuestionResponse> {
+
+    return this.http.post<AnswerQuestionResponse>(
+      this.configSvc.apiUrl + 'answerquestion',
+      answer,
+      headers
+    ).pipe(
+      tap((response: AnswerQuestionResponse) => {
+        this.publishCompletionCounts(response);
       })
     );
   }
 
   /**
+   * Builds the natural identity used for client-side save ordering.
+   *
+   * Assessment ID is included because this service can remain alive while
+   * navigating between assessments.
+   */
+  private buildAnswerQueueKey(answer: Answer): string {
+    return [
+      this.assessSvc.id() ?? '',
+      answer.questionType?.trim() ?? '',
+      answer.questionId,
+      answer.componentGuid ?? '',
+      answer.optionId ?? ''
+    ].join('|');
+  }
+
+  /**
+   * Publishes completion-count changes returned by answer endpoints.
+   */
+  private publishCompletionCounts(response: CompletionCountResponse): void {
+    if (response?.completedCount === undefined) {
+      return;
+    }
+
+    const totalCount =
+      (response.totalMaturityQuestionsCount || 0) +
+      (response.totalDiagramQuestionsCount || 0) +
+      (response.totalStandardQuestionsCount || 0);
+
+    this.assessSvc.completionRefreshRequested$.next({
+      completedCount: response.completedCount,
+      totalCount
+    });
+  }
+
+  /**
    * Posts a block of answers to the API.
    */
-  storeSubCategoryAnswers(answers: SubCategoryAnswers) {
-    return this.http.post(this.configSvc.apiUrl + 'answersubcategory', answers, headers)
-      .pipe(
-        tap((response: any) => {
-          if (response?.completedCount !== undefined) {
-            // Find whichever count has a value (only one will)
-            const totalCount =
-              (response.totalMaturityQuestionsCount || 0) +
-              (response.totalDiagramQuestionsCount || 0) +
-              (response.totalStandardQuestionsCount || 0);
-            this.assessSvc.completionRefreshRequested$.next({
-              completedCount: response.completedCount,
-              totalCount: totalCount
-            });
+  storeSubCategoryAnswers(
+    answers: SubCategoryAnswers
+  ): Observable<CompletionCountResponse> {
+    // Snapshot the request because the same answer objects may continue to be
+    // edited while this save is waiting for earlier requests to finish.
+    const snapshot: SubCategoryAnswers = {
+      ...answers,
+      answers: (answers.answers ?? []).map(answer => ({ ...answer }))
+    };
+
+    const queueKeys = Array.from(new Set(
+      snapshot.answers.map(answer => this.buildAnswerQueueKey(answer))
+    )).sort();
+
+    // A subcategory with no answer rows still needs its own serialization key.
+    if (queueKeys.length === 0) {
+      queueKeys.push([
+        'subcategory',
+        this.assessSvc.id() ?? '',
+        snapshot.groupHeadingId,
+        snapshot.subCategoryId
+      ].join('|'));
+    }
+
+    return new Observable<CompletionCountResponse>(subscriber => {
+      // Capture every current tail before publishing this request as the next
+      // tail for all affected answers. Later individual saves will then wait
+      // until the complete subcategory save finishes.
+      const previousTails = queueKeys.map(queueKey =>
+        this.answerSaveQueues.get(queueKey) ?? Promise.resolve()
+      );
+
+      let currentTail: Promise<void>;
+
+      currentTail = Promise.all(
+        previousTails.map(previousTail =>
+          previousTail.catch(() => undefined)
+        )
+      )
+        .then(async () => {
+          try {
+            const response = await firstValueFrom(
+              this.postSubCategoryAnswers(snapshot)
+            );
+
+            if (!subscriber.closed) {
+              subscriber.next(response);
+              subscriber.complete();
+            }
+          } catch (error) {
+            if (!subscriber.closed) {
+              subscriber.error(error);
+            }
           }
         })
-      );
+        .finally(() => {
+          queueKeys.forEach(queueKey => {
+            if (this.answerSaveQueues.get(queueKey) === currentTail) {
+              this.answerSaveQueues.delete(queueKey);
+            }
+          });
+        });
+
+      queueKeys.forEach(queueKey => {
+        this.answerSaveQueues.set(queueKey, currentTail);
+      });
+    });
   }
+
   /**
-   * Retrieves the extra detail content for the question.
-   * @param questionId
+   * Performs the subcategory HTTP request after all affected answer queues
+   * have reached this request.
    */
-  getDetails(questionId: number, questionType: string): any {
-    return this.http.post(this.configSvc.apiUrl
+  private postSubCategoryAnswers(
+    answers: SubCategoryAnswers
+  ): Observable<CompletionCountResponse> {
+    return this.http.post(
+      this.configSvc.apiUrl + 'answersubcategory',
+      answers,
+      headers
+    ).pipe(
+      tap((response: CompletionCountResponse) => {
+        this.publishCompletionCounts(response);
+      })
+    );
+  }
+
+  /**
+   * Retrieves extra detail content for a question.
+   */
+  getDetails(
+    questionId: number,
+    questionType: string
+  ): any {
+    return this.http.post(
+      this.configSvc.apiUrl
       + 'details?questionid=' + questionId
-      + '&&questionType=' + questionType
-      , headers);
+      + '&&questionType=' + questionType,
+      headers
+    );
   }
 
   /**
    * Renames a document.
    */
   renameDocument(id: number, title: string) {
-    return this.http.post(this.configSvc.apiUrl + 'renamedocument?id=' + id + '&title=' + title, headers);
+    return this.http.post(
+      this.configSvc.apiUrl
+      + 'renamedocument?id=' + id
+      + '&title=' + title,
+      headers
+    );
   }
 
   toggleShared(id: number, isShared: boolean) {
-    return this.http.post(this.configSvc.apiUrl + 'doc/toggleshared?id=' + id + '&isShared=' + isShared, headers);
+    return this.http.post(
+      this.configSvc.apiUrl
+      + 'doc/toggleshared?id=' + id
+      + '&isShared=' + isShared,
+      headers
+    );
   }
 
   /**
    * Deletes a document.
    */
   deleteDocument(id: number, questionId: number) {
-    return this.http.post(this.configSvc.apiUrl + 'deletedocument?id=' + id + "&questionId=" + questionId, headers);
+    return this.http.post(
+      this.configSvc.apiUrl
+      + 'deletedocument?id=' + id
+      + '&questionId=' + questionId,
+      headers
+    );
   }
 
-  /**
-   *
-   */
   getQuestionsForDocument(id: number) {
-    return this.http.get(this.configSvc.apiUrl + 'questionsfordocument?id=' + id, headers);
+    return this.http.get(
+      this.configSvc.apiUrl
+      + 'questionsfordocument?id=' + id,
+      headers
+    );
   }
 
-  /**
-   *
-   */
   getDefaultParametersForAssessment() {
-    return this.http.get(this.configSvc.apiUrl + 'ParametersForAssessment', headers);
+    return this.http.get(
+      this.configSvc.apiUrl + 'ParametersForAssessment',
+      headers
+    );
   }
 
   /**
-   * Stores an assessment-specific (global) parameter value override.
+   * Stores an assessment-wide parameter override.
    */
   storeAssessmentParameter(p: DefaultParameter) {
-    return this.http.post(this.configSvc.apiUrl + 'SaveAssessmentParameter',
+    return this.http.post(
+      this.configSvc.apiUrl + 'SaveAssessmentParameter',
       {
         id: p.parameterId,
         token: p.parameterName,
         substitution: p.parameterValue
       },
-      headers);
+      headers
+    );
   }
 
   /**
-   * Stores an answer-specific (in-line) parameter value override.
-   * @param answerParm
+   * Stores an answer-specific parameter override.
    */
   storeAnswerParameter(answerParm: ParameterForAnswer) {
-    return this.http.post(this.configSvc.apiUrl + 'SaveAnswerParameter',
+    return this.http.post(
+      this.configSvc.apiUrl + 'SaveAnswerParameter',
       {
         requirementId: answerParm.requirementId,
         id: answerParm.parameterId,
         answerId: answerParm.answerId,
         substitution: answerParm.parameterValue
       },
-      headers);
+      headers
+    );
   }
 
-  /**
-   *
-   */
-  getSubGroupingQuestionCount(subGroups: string[], modelId: number) {
-    return this.http.get(this.configSvc.apiUrl + 'SubGroupingQuestionCount?subGroups=' +
-      subGroups + '&modelId=' + modelId, headers);
+  getSubGroupingQuestionCount(
+    subGroups: string[],
+    modelId: number
+  ) {
+    return this.http.get(
+      this.configSvc.apiUrl
+      + 'SubGroupingQuestionCount?subGroups='
+      + subGroups
+      + '&modelId='
+      + modelId,
+      headers
+    );
   }
 
-  /**
-   *
-   */
-  getOverrideQuestions(questionId, Component_Symbol_Id) {
+  getOverrideQuestions(
+    questionId: number,
+    componentSymbolId: number
+  ) {
     let params = new HttpParams();
-    params = params.append('question_id', questionId);
-    params = params.append('Component_Symbol_Id', Component_Symbol_Id);
-    return this.http.get(this.configSvc.apiUrl + 'GetOverrideQuestions', { params: params });
+
+    params = params.append(
+      'question_id',
+      questionId
+    );
+
+    params = params.append(
+      'Component_Symbol_Id',
+      componentSymbolId
+    );
+
+    return this.http.get(
+      this.configSvc.apiUrl + 'GetOverrideQuestions',
+      { params }
+    );
   }
 
   /**
-   * Finds the question in the master collection and updates its answer.
-   * This function was built specifically for Component Overrides,
-   * so it's currently limited to those.  But it could be expanded if there was
-   * a general need to update answers anywhre in the master structure.
+   * Updates an answer in the master Component Overrides structure.
    */
-  setAnswerInQuestionList(questionId: number, answerId: number, answerText: string) {
+  setAnswerInQuestionList(
+    questionId: number,
+    answerId: number,
+    answerText: string
+  ) {
     this.questions.categories.forEach((group: Category) => {
-      if (group.standardShortName === 'Component Overrides') {
-        group.subCategories.forEach((sc: SubCategory) => {
-          sc.questions.forEach((q: Question) => {
-            if (q.questionId === questionId && q.answer_Id === answerId) {
-              q.answer = answerText;
-            }
-          });
-        });
+      if (group.standardShortName !== 'Component Overrides') {
+        return;
       }
+
+      group.subCategories.forEach((sc: SubCategory) => {
+        sc.questions.forEach((q: Question) => {
+          if (
+            q.questionId === questionId
+            && q.answer_Id === answerId
+          ) {
+            q.answer = answerText;
+          }
+        });
+      });
     });
   }
 
   /**
-   * Save the answer with the Marked for Review flag flipped.
+   * Saves an answer with its Marked for Review flag flipped.
    */
   saveMFR(q: Question) {
     q.markForReview = !q.markForReview;
@@ -340,178 +566,228 @@ export class QuestionsService {
       componentGuid: q.componentGuid
     };
 
-    this.storeAnswer(newAnswer).subscribe();
+    /*
+     * This retains the existing fire-and-forget behavior. A stronger design
+     * would return this Observable and let the component display or recover
+     * from an error.
+     */
+    this.storeAnswer(newAnswer).subscribe({
+      error: error => {
+        q.markForReview = !q.markForReview;
+        console.error(
+          'Unable to save Marked for Review state.',
+          error
+        );
+      }
+    });
   }
 
-  /**
-   * The service can emit the question extras object that is given to it.
-   * This was originally built to broadcast changes to documents/artifacts
-   * but could be expanded for other changes as well.
-   */
-  extrasChanged$: BehaviorSubject<number> = new BehaviorSubject(0);
+  extrasChanged$: BehaviorSubject<number> =
+    new BehaviorSubject(0);
+
   broadcastExtras(qe: any) {
     this.extrasChanged$.next(qe);
   }
 
+  private detailsChangedSubject =
+    new BehaviorSubject<number>(0);
 
-  /**
-   * If you need to refresh extras from the API, use this subject
-   */
-  private detailsChangedSubject = new BehaviorSubject<number>(0);
-  detailsChanged$ = this.detailsChangedSubject.asObservable();
+  detailsChanged$ =
+    this.detailsChangedSubject.asObservable();
+
   emitRefreshQuestionDetails(questionId: number) {
     this.detailsChangedSubject.next(questionId);
   }
 
-
-  /**
-   *
-   */
   buildNavTargetID(target: any): string {
     if (!target) {
       return '';
     }
+
     if (target.hasOwnProperty('parent')) {
-      return target.parent.toLowerCase().replace(/ /g, '-') + '-' + target.categoryID;
+      return target.parent
+        .toLowerCase()
+        .replace(/ /g, '-')
+        + '-'
+        + target.categoryID;
     }
+
     return '';
   }
 
-  /**
-   * Finds the button definition and return its CSS
-   */
-  answerOptionCss(modelName: string, answerCode: string) {
-    return this.findAnsDefinition(modelName, answerCode).buttonCss;
+  answerOptionCss(
+    modelName: string,
+    answerCode: string
+  ) {
+    return this.findAnsDefinition(
+      modelName,
+      answerCode
+    ).buttonCss;
   }
 
-  /**
-   * Finds the button definition and returns its label
-   */
-  answerButtonLabel(modelName: string, answerCode: string): string {
-    const def = this.findAnsDefinition(modelName, answerCode);
-    return this.tSvc.translate('answer-options.button-labels.' + def.buttonLabelKey.toLowerCase());
+  answerButtonLabel(
+    modelName: string,
+    answerCode: string
+  ): string {
+    const definition = this.findAnsDefinition(
+      modelName,
+      answerCode
+    );
+
+    return this.tSvc.translate(
+      'answer-options.button-labels.'
+      + definition.buttonLabelKey.toLowerCase()
+    );
   }
 
-  /**
-   * Finds the button definition and returns its tooltip, if defined.
-   * If a tooltip is not defined, the button label is returned.
-   */
-  answerButtonTooltip(modelName: string, answerCode: string): string {
-    var def = this.findAnsDefinition(modelName, answerCode);
-    return this.tSvc.translate('answer-options.button-tooltips.' + def.buttonLabelKey.toLowerCase());
+  answerButtonTooltip(
+    modelName: string,
+    answerCode: string
+  ): string {
+    const definition = this.findAnsDefinition(
+      modelName,
+      answerCode
+    );
+
+    return this.tSvc.translate(
+      'answer-options.button-tooltips.'
+      + definition.buttonLabelKey.toLowerCase()
+    );
   }
 
-  /**
-   * Finds the button definition and returns its full label
-   */
-  answerDisplayLabel(modelName: string, answerCode: string) {
-    const def = this.findAnsDefinition(modelName, answerCode);
-    return this.tSvc.translate('answer-options.labels.' + def.buttonLabelKey.toLowerCase());
+  answerDisplayLabel(
+    modelName: string,
+    answerCode: string
+  ) {
+    const definition = this.findAnsDefinition(
+      modelName,
+      answerCode
+    );
+
+    return this.tSvc.translate(
+      'answer-options.labels.'
+      + definition.buttonLabelKey.toLowerCase()
+    );
   }
 
-  /**
-   * Finds the answer in the default object or the model-specific object.
-   * Standards questions screen pass '0' for the modelId.
-   */
-  findAnsDefinition(model: string, answerCode: string) {
-    let ansDef;
+  findAnsDefinition(
+    model: string,
+    answerCode: string
+  ) {
+    let answerDefinition;
 
-    // assume unanswered if null or undefined
     if (!answerCode) {
       answerCode = 'U';
     }
 
-    // look for model-specific answer options
-    if (!!model && String(model).trim().length > 0) {
+    if (model && String(model).trim().length > 0) {
+      const moduleBehavior =
+        this.configSvc.getModuleBehavior(model);
 
-      // first try to find the model configuration using its model name
-      let modelConfiguration = this.configSvc.getModuleBehavior(model);
+      if (moduleBehavior) {
+        answerDefinition =
+          moduleBehavior.answerOptions?.find(option =>
+            option.code === answerCode
+            && option.skin === this.configSvc.installationMode
+          );
 
-      if (!!modelConfiguration) {
-        // first look for a skin-specific answer option
-        ansDef = modelConfiguration.answerOptions?.find(o => o.code == answerCode && o.skin == this.configSvc.installationMode);
-        if (ansDef) {
-          return ansDef;
+        if (answerDefinition) {
+          return answerDefinition;
         }
 
-        // or the general version of the answer option for the model
-        ansDef = modelConfiguration.answerOptions?.find(o => o.code == answerCode && !o.skin);
-        if (ansDef) {
-          return ansDef;
+        answerDefinition =
+          moduleBehavior.answerOptions?.find(option =>
+            option.code === answerCode
+            && !option.skin
+          );
+
+        if (answerDefinition) {
+          return answerDefinition;
         }
       }
     }
 
-    // fallback to default options for standard-based or model-based
-    ansDef = this.configSvc.config.answerOptionsDefault.find(x => x.code == answerCode);
-    if (ansDef) {
-      return ansDef;
+    answerDefinition =
+      this.configSvc.config.answerOptionsDefault.find(
+        option => option.code === answerCode
+      );
+
+    if (answerDefinition) {
+      return answerDefinition;
     }
 
-    // return a dummy definition to help us spot holes in the lookup
     return {
-      buttonLabelKey: "X",
-      buttonCss: "btn-yes"
+      buttonLabelKey: 'X',
+      buttonCss: 'btn-yes'
     };
   }
 
-
-  /**
-   * If there are any parameters in the text defined by double curly braces
-   * format them to look like the published standard.  No substitution is
-   * performed by this function, just formatting.
-   */
   formatParameters(text: string) {
-    text = text.replace(/{{/g, '[<em>').replace(/}}/g, '</em>]');
-    return text;
+    return text
+      .replace(/{{/g, '[<em>')
+      .replace(/}}/g, '</em>]');
   }
 
-  /**
-   * Replace parameter placeholders in the question text template with any overridden values.
-   * @param q
-   */
   applyTokensToText(q: Question) {
     let text = q.questionText;
-
-    //text = this.linebreakPipe.transform(text);
 
     if (!q.parmSubs) {
       return text;
     }
 
-    // Substitute the longer tokens first, to avoid substituting a nested token
-    // and leave the outer token untouched.  We currently only support the outer tokens.
     q.parmSubs.sort((a, b) => {
-      if (a.token.length > b.token.length) return -1;
-      if (a.token.length < b.token.length) return 1;
+      if (a.token.length > b.token.length) {
+        return -1;
+      }
+
+      if (a.token.length < b.token.length) {
+        return 1;
+      }
+
       return 0;
     });
 
-    q.parmSubs.forEach(t => {
-      if (t.substitution == null) {
-        // uncustomized
-        text = this.replaceAll(text, `{{${t.token}}}`, "[<span class='sub-me fst-italic pid-" + t.id + "'>" + t.token + "</span>]");
+    q.parmSubs.forEach(token => {
+      if (token.substitution == null) {
+        text = this.replaceAll(
+          text,
+          `{{${token.token}}}`,
+          '[<span class=\'sub-me fst-italic pid-'
+          + token.id
+          + '\'>'
+          + token.token
+          + '</span>]'
+        );
       } else {
-        // customized
-        text = this.replaceAll(text, `{{${t.token}}}`, "<span class='sub-me pid-" + t.id + "'>" + t.substitution + "</span>");
+        text = this.replaceAll(
+          text,
+          `{{${token.token}}}`,
+          '<span class=\'sub-me pid-'
+          + token.id
+          + '\'>'
+          + token.substitution
+          + '</span>'
+        );
       }
     });
 
     return text;
   }
 
-  /**
-   *
-   * @param origString
-   * @param searchStr
-   * @param replaceStr
-   * @returns
-   */
-  replaceAll(origString: string, searchStr: string, replaceStr: string) {
-    // escape regexp special characters in search string
-    searchStr = searchStr.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  replaceAll(
+    original: string,
+    search: string,
+    replacement: string
+  ) {
+    search = search.replace(
+      /[-\/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    );
 
-    return origString.replace(new RegExp(searchStr, 'gi'), replaceStr);
+    return original.replace(
+      new RegExp(search, 'gi'),
+      replacement
+    );
   }
 
   emitComponentOverrideEvent(data: any) {


### PR DESCRIPTION
This pull request introduces significant updates to sector and subsector management, with a focus on removing support for legacy HSPD-7 (NIPP) sectors and enforcing the use of the current PPD-21 sector list. It ensures that only valid, current sectors and subsectors can be selected or returned, normalizes legacy data on access, and adds comprehensive tests for these scenarios.

**Sector and Subsector Validation and Normalization**
* All sector and subsector accesses now normalize legacy HSPD-7 (NIPP) values to the current PPD-21 list, ensuring consistent and valid data across all endpoints (`SectorMultiManager.cs`, `AnalyticsBusiness.cs`, `DemographicExtBusiness.cs`). [[1]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL36-R51) [[2]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL95-R122) [[3]](diffhunk://#diff-32890f3a48e08bb3bb49c39241bcb24fc3ec5a30c74e47f6a48dca4351562d7cL227-R235) [[4]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL54-R63)
* Save operations for sectors/subsectors now explicitly reject legacy (NIPP) sectors and mismatched subsectors, throwing clear exceptions for unsupported selections (`SectorMultiManager.cs`). [[1]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL144-R209) [[2]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL168-L178)

**Filtering and Query Improvements**
* All queries for sectors and subsectors now exclude legacy (NIPP) items, both when listing available options and when reading existing selections (`SectorMultiManager.cs`, `DemographicExtBusiness.cs`). [[1]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL36-R51) [[2]](diffhunk://#diff-f04eb4b925c2829d3bcb7e1eb3acf52586ae80646a4f06cebf425492df9e202cL204-R205) [[3]](diffhunk://#diff-dd3eaeb2b1ca0e2dbbb6c2c8af568532fee2d646bb452aa2668f72b59c2ccb5eL72-R94)

**Testing Enhancements**
* A new test suite (`SectorManagementTests.cs`) covers legacy upgrades, validation, and correct behavior when removing or changing sectors/subsectors, including error handling for unsupported selections.
* Unit tests for subsector sorting and filtering are updated to include and validate handling of legacy and special sector types (`DemographicExtBusinessTests.cs`). [[1]](diffhunk://#diff-7858ec3d9677a835581116507a8005b746b3ca48cc3e0e092d909b39db1ee12dL492-R493) [[2]](diffhunk://#diff-7858ec3d9677a835581116507a8005b746b3ca48cc3e0e092d909b39db1ee12dR510)

**Documentation and Code Comments**
* Code comments and documentation are updated to clarify that only the PPD-21 sector list (16 sectors) is now supported, and legacy support is removed (`DemographicExtBusiness.cs`).

These changes collectively enforce data integrity, improve maintainability, and ensure the application only works with the current, supported sector taxonomy.



Also audited and fixed other potential issues with saving answers and question extras.  It was reported that sometimes answers may not be getting properly saved.  This attempts to harden those write pathways.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
