### PR TITLE
Bound (change) to alt text instead of every keystroke.  Fixed typo.

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
+++ b/CSETWebNg/src/app/assessment/questions/question-block/question-block.component.html
@@ -146,7 +146,7 @@
             <div *ngIf="q.showJustificationField">
               <textarea appAutoSize class="form-control" style="width: 100%; min-height: 80px;"
                 [placeholder]="t('answer-options.placeholders.alt justification')" [(ngModel)]="q.altAnswerText"
-                (ngModelChange)="storeAnswer(q, null)" tabindex="0"></textarea>
+                (change)="storeAnswer(q, null)" tabindex="0"></textarea>
             </div>
 
             <app-malcolm-answer-default *ngIf="configSvc.config.behaviors.showMalcolmAnswerComparison != null
@@ -197,7 +197,7 @@
             <div *ngIf="q.showJustificationField">
               <textarea appAutoSize class="form-control" style="width: 100%; min-height: 80px;"
                 [placeholder]="t('answer-options.placeholders.alt justification')" [(ngModel)]="q.altAnswerText"
-                (ngModelChange)="storeAnswert(q, null)" tabindex="0"></textarea>
+                (change)="storeAnswer(q, null)" tabindex="0"></textarea>
             </div>
           </div>
 


### PR DESCRIPTION
This pull request updates how answer changes are handled in the `question-block.component.html` file. Specifically, it switches from using the Angular `ngModelChange` event to the standard `change` event for storing answers in justification fields. This ensures that the answer is only stored when the user finishes editing the textarea, rather than on every keystroke.

**Event handling updates:**

* Replaced `(ngModelChange)="storeAnswer(q, null)"` with `(change)="storeAnswer(q, null)"` for the justification textarea to trigger storing the answer only when the field loses focus or the user commits their input.
* Fixed a typo in the event handler name from `storeAnswert` to `storeAnswer` and switched to the `(change)` event for consistency and correctness.


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
