### PR TITLE
Fixed a few report issues.  Standardized popup report tab titles

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -373,10 +373,20 @@ namespace CSETWebCore.Business.Reports
         /// <returns></returns>
         private List<MatRelevantAnswers> ConvertParentsToChildren(int assessmentId, List<MatRelevantAnswers> parentQuestions)
         {
+            var techDomain = new DemographicExtBusiness(_context)
+                .GetX(assessmentId, "TECH-DOMAIN")?.ToString();
+
+            var outOfScopeIds = new QuestionScopeAnalyzer(
+                assessmentId, _context, techDomain)
+                .DetermineScopeForTechnologyDomain(techDomain);
+
             var parentIds = parentQuestions.Select(a => a.ANSWER.Question_Or_Requirement_Id).ToList();
 
             var allChildQuestions = _context.MATURITY_QUESTIONS
-                .Where(q => q.Parent_Question_Id != null && parentIds.Contains((int)q.Parent_Question_Id))
+                .Where(q => 
+                    q.Parent_Question_Id != null 
+                    && parentIds.Contains((int)q.Parent_Question_Id)
+                    && !outOfScopeIds.Contains(q.Mat_Question_Id))
                 .Join(_context.ANSWER,
                     q => q.Mat_Question_Id,
                     a => a.Question_Or_Requirement_Id,
@@ -400,11 +410,14 @@ namespace CSETWebCore.Business.Reports
                     {
                         var newQ = new MatRelevantAnswers();
                         MATURITY_QUESTIONS mq = new();
+                        mq.Maturity_Model_Id = child.Question.Maturity_Model_Id;
+                        mq.Mat_Question_Id = child.Question.Mat_Question_Id;
                         mq.Question_Title = child.Question.Question_Title;
                         mq.Question_Text = $"{parentQText} - {child.Question.Question_Text}";
                         newQ.Mat = mq;
 
                         ANSWER ans = new();
+                        ans.Question_Or_Requirement_Id = child.Answer.Question_Or_Requirement_Id;
                         ans.Answer_Text = child.Answer.Answer_Text;
                         ans.Mark_For_Review = child.Answer.Mark_For_Review;
                         ans.Comment = parent.ANSWER.Comment;

--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -175,10 +175,10 @@
       <mat-sidenav-content class="d-flex flex-column flex-11a oy-auto">
         <div class="max-1000 h-0 d-flex flex-column flex-11a" id="sidenav-content">
           <div
-            class="assessment-header tw:flex tw:justify-between tw:items-center tw:gap-3 tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3"
+            class="assessment-header tw:flex tw:flex-col tw:items-stretch tw:gap-3 tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3"
           >
             <!-- Assessment Name -->
-            <div class="tw:flex-[1_1_18rem] tw:min-w-[16rem]">
+            <div class="tw:w-full tw:flex-none tw:min-w-0">
               <h6
                 class="tw:text-lg tw:font-semibold tw:mb-0 tw:truncate"
                 [matTooltip]="assessment?.assessmentName"
@@ -187,7 +187,7 @@
               </h6>
             </div>
 
-            <div class="tw:flex tw:flex-[0_1_auto] tw:min-w-0 tw:items-center tw:gap-2 tw:lg:gap-4">
+            <div class="tw:flex tw:w-full tw:flex-none tw:min-w-0 tw:justify-start tw:items-center tw:gap-2 tw:lg:gap-4">
               <!-- Progress Section -->
               <div class="tw:flex tw:min-w-[5.25rem] tw:items-center tw:gap-2 tw:lg:gap-3" *ngIf="assessment?.maturityModel?.modelName !== 'CIS'">
                 <progress
@@ -200,17 +200,17 @@
               </div>
 
               <!-- Divider -->
-              <div class="tw:hidden tw:lg:block tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
+              <div class="tw:hidden tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
               <!-- CISA-only JSON upload indicator -->
-              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:flex tw:items-center tw:gap-2">
-                <label for="jsonUploadedSwitch" class="tw:hidden tw:lg:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
+              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:flex tw:flex-none tw:items-center tw:gap-2">
+                <label for="jsonUploadedSwitch" class="tw:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
                   >JSON export uploaded</label
                 >
                 <input
                   type="checkbox"
                   id="jsonUploadedSwitch"
-                  class="tw:toggle"
+                  class="tw:toggle tw:shrink-0"
                   aria-label="JSON export uploaded"
                   matTooltip="JSON export uploaded"
                   [(ngModel)]="jsonUploaded"
@@ -219,15 +219,15 @@
               </div>
 
               <!-- Divider -->
-              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:hidden tw:lg:block tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
+              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:hidden tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
-              <div class="tw:flex tw:items-center tw:gap-3">
-                <label for="assessmentDoneSwitch" class="tw:hidden tw:lg:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
+              <div class="tw:flex tw:flex-none tw:items-center tw:gap-3">
+                <label for="assessmentDoneSwitch" class="tw:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
                   >Mark Assessment Done</label
                 >
                 <input
                   type="checkbox"
-                  class="tw:toggle"
+                  class="tw:toggle tw:shrink-0"
                   id="assessmentDoneSwitch"
                   aria-label="Mark Assessment Done"
                   matTooltip="Mark Assessment Done"

--- a/CSETWebNg/src/app/assessment/assessment.component.html
+++ b/CSETWebNg/src/app/assessment/assessment.component.html
@@ -175,55 +175,62 @@
       <mat-sidenav-content class="d-flex flex-column flex-11a oy-auto">
         <div class="max-1000 h-0 d-flex flex-column flex-11a" id="sidenav-content">
           <div
-            class="assessment-header tw:flex tw:justify-between tw:items-center tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3"
+            class="assessment-header tw:flex tw:justify-between tw:items-center tw:gap-3 tw:p-4 tw:rounded-lg tw:shadow-sm tw:m-3"
           >
             <!-- Assessment Name -->
-            <div class="tw:flex-1 tw:min-w-0">
-              <h6 class="tw:text-lg tw:font-semibold tw:mb-0 tw:truncate">
+            <div class="tw:flex-[1_1_18rem] tw:min-w-[16rem]">
+              <h6
+                class="tw:text-lg tw:font-semibold tw:mb-0 tw:truncate"
+                [matTooltip]="assessment?.assessmentName"
+              >
                 {{ this.assessment?.assessmentName || 'Loading ...' }}
               </h6>
             </div>
 
-            <div class="tw:flex tw:items-center tw:gap-4">
+            <div class="tw:flex tw:flex-[0_1_auto] tw:min-w-0 tw:items-center tw:gap-2 tw:lg:gap-4">
               <!-- Progress Section -->
-              <div class="tw:flex tw:items-center tw:gap-3" *ngIf="assessment?.maturityModel?.modelName !== 'CIS'">
+              <div class="tw:flex tw:min-w-[5.25rem] tw:items-center tw:gap-2 tw:lg:gap-3" *ngIf="assessment?.maturityModel?.modelName !== 'CIS'">
                 <progress
-                  class="tw:w-24 tw:h-4 tw:cursor-pointer tw:rounded-full tw:appearance-none"
+                  class="tw:w-24 tw:min-w-8 tw:shrink tw:h-4 tw:cursor-pointer tw:rounded-full tw:appearance-none"
                   [value]="completionPercentage"
                   [matTooltip]="getProgressTooltip()"
                   max="100"
                 ></progress>
-                <span class="tw:text-sm tw:font-medium tw:min-w-[3rem]">{{ completionPercentage }}%</span>
+                <span class="tw:flex-none tw:text-sm tw:font-medium tw:min-w-[2.5rem]">{{ completionPercentage }}%</span>
               </div>
 
               <!-- Divider -->
-              <div class="tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
+              <div class="tw:hidden tw:lg:block tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
               <!-- CISA-only JSON upload indicator -->
               <div *ngIf="configSvc.userIsCisaAssessor" class="tw:flex tw:items-center tw:gap-2">
-                <label for="jsonUploadedSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap"
+                <label for="jsonUploadedSwitch" class="tw:hidden tw:lg:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
                   >JSON export uploaded</label
                 >
                 <input
                   type="checkbox"
                   id="jsonUploadedSwitch"
                   class="tw:toggle"
+                  aria-label="JSON export uploaded"
+                  matTooltip="JSON export uploaded"
                   [(ngModel)]="jsonUploaded"
                   (change)="saveJsonUploaded()"
                 />
               </div>
 
               <!-- Divider -->
-              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
+              <div *ngIf="configSvc.userIsCisaAssessor" class="tw:hidden tw:lg:block tw:shrink-0 tw:w-px tw:h-8 tw:bg-gray-300 tw:dark:bg-gray-700"></div>
 
               <div class="tw:flex tw:items-center tw:gap-3">
-                <label for="assessmentDoneSwitch" class="tw:text-sm tw:font-medium tw:whitespace-nowrap"
+                <label for="assessmentDoneSwitch" class="tw:hidden tw:lg:inline tw:text-sm tw:font-medium tw:whitespace-nowrap"
                   >Mark Assessment Done</label
                 >
                 <input
                   type="checkbox"
                   class="tw:toggle"
                   id="assessmentDoneSwitch"
+                  aria-label="Mark Assessment Done"
+                  matTooltip="Mark Assessment Done"
                   [checked]="assessment?.done"
                   (change)="setAssessmentDone()"
                 />

--- a/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.html
+++ b/CSETWebNg/src/app/assessment/results/cpg/cpg-domain-summary-table/cpg-domain-summary-table.component.html
@@ -22,21 +22,25 @@
 -------------------------->
 <div class="w-100 d-block" *transloco="let t">
     <table class="table w-fit">
-        <tr>
-            <th class="text-start align-top pe-3">{{t('reports.category')}}</th>
-            <th class="text-end align-top pe-3">{{t('answer-options.labels.imp-cpg')}}</th>
-            <th class="text-end align-top pe-3">{{t('answer-options.labels.prog-cpg')}}</th>
-            <th class="text-end align-top pe-3">{{t('answer-options.labels.scoped-cpg')}}</th>
-            <th class="text-end align-top pe-3">{{t('answer-options.labels.not-cpg')}}</th>
-            <th class="text-end align-top">{{t('answer-options.button-labels.unanswered')}}</th>
-        </tr>
-        <tr *ngFor="let func of data">
-            <td class="pe-3">{{func.name}}</td>
-            <td class="text-end pe-3">{{formatPercent(func, 0)}}</td>
-            <td class="text-end pe-3">{{formatPercent(func, 1)}}</td>
-            <td class="text-end pe-3">{{formatPercent(func, 2)}}</td>
-            <td class="text-end pe-3">{{formatPercent(func, 3)}}</td>
-            <td class="text-end">{{formatPercent(func, 4)}}</td>
-        </tr>
+        <thead>
+            <tr>
+                <th class="text-start align-top pe-3">{{t('reports.category')}}</th>
+                <th class="text-end align-top pe-3">{{t('answer-options.labels.imp-cpg')}}</th>
+                <th class="text-end align-top pe-3">{{t('answer-options.labels.prog-cpg')}}</th>
+                <th class="text-end align-top pe-3">{{t('answer-options.labels.scoped-cpg')}}</th>
+                <th class="text-end align-top pe-3">{{t('answer-options.labels.not-cpg')}}</th>
+                <th class="text-end align-top">{{t('answer-options.button-labels.unanswered')}}</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr *ngFor="let func of data">
+                <td class="pe-3">{{func.name}}</td>
+                <td class="text-end pe-3">{{formatPercent(func, 0)}}</td>
+                <td class="text-end pe-3">{{formatPercent(func, 1)}}</td>
+                <td class="text-end pe-3">{{formatPercent(func, 2)}}</td>
+                <td class="text-end pe-3">{{formatPercent(func, 3)}}</td>
+                <td class="text-end">{{formatPercent(func, 4)}}</td>
+            </tr>
+        </tbody>
     </table>
 </div>

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.html
@@ -204,21 +204,28 @@
         <table aria-label="assessments" matSort (matSortChange)="sortData($event)"
           class="assessment-summary" style="overflow-x: auto">
           <tr>
-            <th aria-label="assessment name" mat-sort-header="assessment" style="width: 25%">
+            <th class="tw:rounded-tl-lg" aria-label="assessment name" mat-sort-header="assessment"
+              style="width: 25%; padding-top: 14px; padding-bottom: 14px; font-size: 14px; font-weight: 700; --mat-sort-arrow-color: currentColor">
               {{ t('assessment name') }}
             </th>
-            <th aria-label="date" mat-sort-header="date" style="width: 15%">{{ t('last modified') }}</th>
-            <th [aria-label]="tSvc.translate('actions')" style="width: 5%" *ngIf="layoutSvc.hp"></th>
+            <th aria-label="date" mat-sort-header="date"
+              style="width: 15%; padding-top: 14px; padding-bottom: 14px; font-size: 14px; font-weight: 700; --mat-sort-arrow-color: currentColor">
+              {{ t('last modified') }}
+            </th>
+            <th class="tw:rounded-tr-lg" [aria-label]="tSvc.translate('actions')"
+              style="width: 5%; padding-top: 14px; padding-bottom: 14px; font-size: 14px; font-weight: 700"
+              *ngIf="layoutSvc.hp"></th>
           </tr>
           <tr *ngFor="let assessment of filteredAssessments; let i = index">
             <td>
               <button tabindex="0"
-                class="btn btn-link btn-link-dark d-flex justify-content-start align-items-start flex-00a wrap-text text-start"
+                class="btn btn-link tw:text-left tw:justify-start tw:h-full tw:w-full tw:text-text-primary"
+                style="text-align: left; justify-content: flex-start;"
                 (click)="this.navSvc.beginAssessment(assessment.assessmentId)">
                 {{ assessment.assessmentName }}
               </button>
             </td>
-            <td>{{ systemTimeTranslator(assessment.lastModifiedDate, 'med') }}</td>
+            <td>{{ systemTimeTranslator(assessment.lastModifiedDate, 'short') }}</td>
             <td class="text-nowrap ps-1">
               <button tabindex="0" class="icon-link-button-dark btn bgc-trans my-0 mx-1 p-0"
                 (click)="removeAssessment(assessment, i)" matTooltip="{{ t('tooltip.remove assessment') }}">

--- a/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
+++ b/CSETWebNg/src/app/initial/my-assessments/my-assessments.component.ts
@@ -203,6 +203,7 @@ export class MyAssessmentsComponent implements OnInit, OnDestroy {
         sortable: true,
         filter: true,
         flex: 2,
+        minWidth: 250,
         cellRenderer: (params: any) => {
           return `
     <button class="btn btn-link tw:text-left tw:justify-start tw:h-full tw:w-full tw:text-text-primary"

--- a/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.ts
+++ b/CSETWebNg/src/app/reports/all-answeredquestions/all-answeredquestions.component.ts
@@ -60,13 +60,15 @@ export class AllAnsweredquestionsComponent implements OnInit {
     this.reportSvc.getStandardAnsweredQuestions().subscribe(
       (r: any) => {
         this.response = r;
-        this.titleService.setTitle(this.tSvc.translate('reports.all.answered statements.tab title'));
       }
     );
 
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        const reportTitle = this.tSvc.translate('reports.all.answered statements.tab title');
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
       }
     );
   }

--- a/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/all-commentsmarked/all-commentsmarked.component.ts
@@ -24,7 +24,6 @@
 import { Component } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { TranslocoService } from '@jsverse/transloco';
-import { ConfigService } from '../../services/config.service';
 import { QuestionsService } from '../../services/questions.service';
 import { ReportService } from '../../services/report.service';
 import { AssessmentService } from '../../services/assessment.service';
@@ -52,7 +51,6 @@ export class AllCommentsmarkedComponent {
     public reportSvc: ReportService,
     public titleService: Title,
     public questionsSvc: QuestionsService,
-    public configSvc: ConfigService,
     public assessSvc: AssessmentService
   ) { }
 
@@ -60,13 +58,14 @@ export class AllCommentsmarkedComponent {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        const reportTitle = this.tSvc.translate('reports.all.cmfr.report title');
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
       }
     );
     this.reportSvc.getStandardCommentsAndMfr().subscribe(
       (r: any) => {
-
         this.response = r;
-        this.titleService.setTitle(this.tSvc.translate('reports.all.cmfr.report title'));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.ts
+++ b/CSETWebNg/src/app/reports/all-reviewed/all-reviewed.component.ts
@@ -60,12 +60,14 @@ export class AllReviewedComponent {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        const reportTitle = this.tSvc.translate('reports.all.reviewed questions.report title');
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
       }
     );
     this.reportSvc.getReviewedQuestions().subscribe(
       (r: any) => {
         this.response = r;
-        this.titleService.setTitle(this.tSvc.translate('reports.all.reviewed questions.report title'));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.ts
+++ b/CSETWebNg/src/app/reports/c2m2/c2m2-report/c2m2-report.component.ts
@@ -22,6 +22,9 @@
 //
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { AssessmentDetail } from '../../../models/assessment-info.model';
+import { AssessmentService } from '../../../services/assessment.service';
 import { ReportService } from '../../../services/report.service';
 
 @Component({
@@ -44,10 +47,17 @@ export class C2m2ReportComponent implements OnInit {
   loading: boolean = true;
 
   constructor(
-    public reportSvc: ReportService
+    public reportSvc: ReportService,
+    private assessSvc: AssessmentService,
+    private titleService: Title
   ) { }
 
   ngOnInit(): void {
+    this.assessSvc.getAssessmentDetail().subscribe((r: AssessmentDetail) => {
+      const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+      this.titleService.setTitle(`C2M2 Report - ${assessmentTitle}`);
+    });
+
     this.reportSvc.getC2M2Donuts().subscribe(
       (data: any) => {
         this.donutData = data;

--- a/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/cis-commentsmarked/cis-commentsmarked.component.ts
@@ -24,8 +24,8 @@
 import { Component, OnInit } from '@angular/core';
 import { ReportAnalysisService } from '../../services/report-analysis.service';
 import { ReportService } from '../../services/report.service';
-import { ConfigService } from '../../services/config.service';
-import { Title, DomSanitizer } from '@angular/platform-browser';
+import { Title } from '@angular/platform-browser';
+import { TranslocoService } from '@jsverse/transloco';
 import { MaturityService } from '../../services/maturity.service';
 import { AssessmentDetail } from '../../models/assessment-info.model';
 import { AssessmentService } from '../../services/assessment.service';
@@ -44,7 +44,8 @@ export class CisCommentsmarkedComponent implements OnInit {
   constructor(
     public analysisSvc: ReportAnalysisService,
     public reportSvc: ReportService,
-    public configSvc: ConfigService,
+    private titleService: Title,
+    public tSvc: TranslocoService,
     public maturitySvc: MaturityService,
     public assessSvc: AssessmentService
   ) { }
@@ -55,6 +56,10 @@ export class CisCommentsmarkedComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cis.4.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
     this.maturitySvc.getReportComments().subscribe(

--- a/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-ranked-deficiency/cis-ranked-deficiency.component.ts
@@ -52,6 +52,9 @@ export class CisRankedDeficiencyComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cis.3.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle => this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-section-scoring/cis-section-scoring.component.ts
@@ -73,6 +73,10 @@ export class CisSectionScoringComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cis.2.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
 

--- a/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.ts
+++ b/CSETWebNg/src/app/reports/cis/cis-survey/cis-survey.component.ts
@@ -69,6 +69,8 @@ export class CisSurveyComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`Survey Report - ${assessmentTitle}`);
       }
     );
 

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-observations/cisa-vadr-observations.component.ts
@@ -22,6 +22,7 @@
 //
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { ReportService } from '../../../services/report.service';
 import { ConfigService } from '../../../services/config.service';
@@ -55,7 +56,8 @@ export class CisaVadrObservationsComponent implements OnInit {
     public assessSvc: AssessmentService,
     public configSvc: ConfigService,
     public reportSvc: ReportService,
-    public observationSvc: ObservationsService
+    public observationSvc: ObservationsService,
+    private titleService: Title
   ) { }
 
   /**
@@ -66,6 +68,8 @@ export class CisaVadrObservationsComponent implements OnInit {
       (r: AssessmentDetail) => {
         this.response = r;
         this.assessSvc.assessment = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`CISA VADR Observations Report - ${assessmentTitle}`);
       }
     );
 

--- a/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.ts
+++ b/CSETWebNg/src/app/reports/cisa-vadr/cisa-vadr-report/cisa-vadr-report.component.ts
@@ -22,6 +22,7 @@
 //
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { ReportService } from '../../../services/report.service';
 import { ConfigService } from '../../../services/config.service';
 import { AssessmentService } from '../../../services/assessment.service';
@@ -44,7 +45,8 @@ export class CisaVadrReportComponent implements OnInit {
   constructor(
     public assessSvc: AssessmentService,
     public configSvc: ConfigService,
-    public reportSvc: ReportService
+    public reportSvc: ReportService,
+    private titleService: Title
   ) { }
 
   /**
@@ -54,6 +56,8 @@ export class CisaVadrReportComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`CISA VADR Report - ${assessmentTitle}`);
       }
     );
 

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-comments-marked/cmmc2-comments-marked.component.ts
@@ -23,7 +23,6 @@
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ConfigService } from '../../../services/config.service';
 import { MaturityService } from '../../../services/maturity.service';
 import { QuestionsService } from '../../../services/questions.service';
 import { TranslocoService } from '@jsverse/transloco';
@@ -47,7 +46,6 @@ export class Cmmc2CommentsMarkedComponent implements OnInit {
   markedForReviewList = [];
 
   constructor(
-    public configSvc: ConfigService,
     private titleService: Title,
     private maturitySvc: MaturityService,
     public questionsSvc: QuestionsService,
@@ -60,12 +58,12 @@ export class Cmmc2CommentsMarkedComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cmmc2.3.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
-
-    this.tSvc.selectTranslate('comments and marked for review', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
 
     this.loading = true;
     this.keyToCategory = this.maturitySvc.keyToCategory;

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-deficiency/cmmc2-deficiency.component.ts
@@ -23,7 +23,6 @@
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ConfigService } from '../../../services/config.service';
 import { MaturityService } from '../../../services/maturity.service';
 import { QuestionsService } from '../../../services/questions.service';
 import { AssessmentService } from '../../../services/assessment.service';
@@ -50,7 +49,6 @@ export class Cmmc2DeficiencyComponent implements OnInit {
   deficienciesList = [];
 
   constructor(
-    public configSvc: ConfigService,
     private titleService: Title,
     private maturitySvc: MaturityService,
     public questionsSvc: QuestionsService,
@@ -60,11 +58,12 @@ export class Cmmc2DeficiencyComponent implements OnInit {
   ngOnInit() {
     this.loading = true;
     this.keyToCategory = this.maturitySvc.keyToCategory;
-    this.titleService.setTitle("CMMC 2.0 Deficiency Report - " + this.configSvc.behaviors.defaultTitle);
 
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`CMMC 2.0 Deficiency Report - ${assessmentTitle}`);
       }
     );
 

--- a/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/cmmc2-scorecard-report/cmmc2-scorecard-report.component.ts
@@ -69,14 +69,13 @@ export class Cmmc2ScorecardReportComponent {
    * 
    */
   ngOnInit(): void {
-    this.tSvc.selectTranslate('scorecard report', {}, { scope: 'reports' })
-      .subscribe(title => {
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle)
-      });
-
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cmmc2.2.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
 

--- a/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.ts
+++ b/CSETWebNg/src/app/reports/cmmc2/executive-cmmc2/executive-cmmc2.component.ts
@@ -83,11 +83,6 @@ export class ExecutiveCMMC2Component implements OnInit, AfterViewInit {
    *
    */
   ngOnInit() {
-
-    this.tSvc.selectTranslate('executive summary', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.targetLevel = 0;
     this.reportSvc.getReport('executivematurity').subscribe(
       (r: any) => {
@@ -100,6 +95,10 @@ export class ExecutiveCMMC2Component implements OnInit, AfterViewInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.response = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.cmmc2.1.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
 

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.html
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.html
@@ -39,7 +39,7 @@
                         {{t('reports.core.rra.cmfr.with comments', {alias: aliasTranslated})}}
                     </h1>
                 </div>
-                <hr class="page-line m-0">
+
                 <table class="w-100 td-align-top">
                     <tr *ngIf="response?.comments?.length > 0">
                         <th>{{questionAliasSingular}}</th>
@@ -106,7 +106,7 @@
             <!-- "Other Remarks"-->
             <div *ngIf="remarks?.length > 0" class="ms-3 me-3 form">
                 <h1 class="page-title">{{t('reports.core.rra.cmfr.other remarks')}}</h1>
-                <hr class="page-line m-0">
+
                 <div class="my-3" [innerHTML]="remarks | linebreakplain">
                 </div>
             </div>
@@ -119,7 +119,7 @@
                         {{t('reports.core.rra.cmfr.marked for review', {alias: aliasTranslated})}}
                     </h1>
                 </div>
-                <hr class="page-line m-0">
+
                 <table class="w-100 td-align-top">
                     <tr *ngIf="markedForReview?.length > 0">
                         <th>{{questionAliasSingular}}</th>

--- a/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
+++ b/CSETWebNg/src/app/reports/commentsmfr/commentsmfr.component.ts
@@ -25,7 +25,6 @@ import { Component, OnInit } from '@angular/core';
 import { ReportAnalysisService } from '../../services/report-analysis.service';
 import { ReportService } from '../../services/report.service';
 import { QuestionsService } from '../../services/questions.service';
-import { ConfigService } from '../../services/config.service';
 import { Title } from '@angular/platform-browser';
 import { MaturityService } from '../../services/maturity.service';
 import { AssessmentService } from '../../services/assessment.service';
@@ -67,7 +66,6 @@ export class CommentsMfrComponent implements OnInit {
     public assessSvc: AssessmentService,
     public reportSvc: ReportService,
     public questionsSvc: QuestionsService,
-    public configSvc: ConfigService,
     private readonly titleService: Title,
     public maturitySvc: MaturityService,
     public tSvc: TranslocoService
@@ -86,13 +84,13 @@ export class CommentsMfrComponent implements OnInit {
   async initAsync() {
     this.loading = true;
 
-    this.tSvc.selectTranslate('comments and marked for review', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('comments and marked for review', {}, { scope: 'reports' })
+          .subscribe(reportTitle => this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
 

--- a/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report-m/compare-report-m.component.ts
@@ -79,8 +79,11 @@ export class CompareReportMComponent implements OnInit, AfterViewChecked {
 
 
   ngOnInit() {
-    this.titleService.setTitle("Compare Report - " + this.configSvc.behaviors.defaultTitle);
     var aggId: number = +localStorage.getItem("aggregationId");
+    this.aggregationSvc.getAggregation().subscribe((aggregation: any) => {
+      const aggregationTitle = aggregation.aggregationName || `aggregation-${aggId}`;
+      this.titleService.setTitle(`Compare Report - ${aggregationTitle}`);
+    });
     this.isCmmc = this.maturitySvc.maturityModelIsCMMC();
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {

--- a/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
+++ b/CSETWebNg/src/app/reports/compare-report/compare-report.component.ts
@@ -71,8 +71,11 @@ export class CompareReportComponent implements OnInit, AfterViewChecked {
 
 
   ngOnInit() {
-    this.titleService.setTitle("Compare Report - " + this.configSvc.behaviors.defaultTitle);
     var aggId: number = +localStorage.getItem("aggregationId");
+    this.aggregationSvc.getAggregation().subscribe((aggregation: any) => {
+      const aggregationTitle = aggregation.aggregationName || `aggregation-${aggId}`;
+      this.titleService.setTitle(`Compare Report - ${aggregationTitle}`);
+    });
     this.isCmmc = this.maturitySvc.maturityModelIsCMMC();
 
     this.reportSvc.getAggReport('compare-report', aggId).subscribe(

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.html
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency-block/cpg-deficiency-block.component.html
@@ -23,17 +23,17 @@
 <table class="w-100">
     <ng-template ngFor let-s [ngForOf]="deficiencyList">
         <tr>
-            <th class="deficiencies-list-item pe-3" style="font-weight: bold; width: 50px;">
+            <td class="deficiencies-list-item pe-3 fw-bold" style="width: 50px;">
                 {{s.mat.question_Title}}
-            </th>
-            <th class="deficiencies-list-comment">{{s.mat.security_Practice}}</th>
-            <th style="padding-top: 1rem; padding-left: 1rem; vertical-align: top; color: #555555">
-                <div style="width: 9rem; font-weight: bold;">
+            </td>
+            <td class="deficiencies-list-comment">{{s.mat.security_Practice}}</td>
+            <td style="padding-top: 1rem; padding-left: 1rem; vertical-align: top; color: #555555">
+                <div style="width: 9rem;">
                     {{questionsSvc.answerDisplayLabel(11, s.answer.answer_Text)}}
                 </div>
-            </th>
-            <th class="deficiencies-list-flag"><img class="marked-flag ms-2 align-self-center" alt="marked for review" *ngIf="s.answer.mark_For_Review"
-                    src="assets/images/icons/MarkedFlag.png"></th>
+            </td>
+            <td class="deficiencies-list-flag"><img class="marked-flag ms-2 align-self-center" alt="marked for review" *ngIf="s.answer.mark_For_Review"
+                    src="assets/images/icons/MarkedFlag.png"></td>
         </tr>
 
         <tr *ngIf="s.answer.comment">

--- a/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-deficiency/cpg-deficiency.component.ts
@@ -24,7 +24,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { AssessmentService } from '../../../services/assessment.service';
-import { ConfigService } from '../../../services/config.service';
 import { CpgService } from '../../../services/cpg.service';
 import { SsgService } from '../../../services/ssg.service';
 import { MaturityService } from '../../../services/maturity.service';
@@ -70,7 +69,6 @@ export class CpgDeficiencyComponent implements OnInit {
     public questionsSvc: QuestionsService,
     public cpgSvc: CpgService,
     public ssgSvc: SsgService,
-    public configSvc: ConfigService,
     public tSvc: TranslocoService
   ) { }
 
@@ -78,17 +76,16 @@ export class CpgDeficiencyComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
-    this.tSvc.selectTranslate('core.cpg.deficiency.cpg deficiency', {}, { scope: 'reports' })
-      .subscribe(title => {
-        this.titleSvc.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle)
-      });
-
     // make sure that the assessSvc has the assessment loaded so that we can determine any SSG model applicable
     this.loadingCpg = true;
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
 
       this.assessSvc.assessment = assessmentDetail;
       this.info = assessmentDetail;
+
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.tSvc.selectTranslate('core.cpg.deficiency.cpg deficiency', {}, { scope: 'reports' })
+        .subscribe(reportTitle => this.titleSvc.setTitle(`${reportTitle} - ${assessmentTitle}`));
 
       // get the deficient answers for the CPG model
       const assessment = this.assessSvc.assessment;

--- a/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
+++ b/CSETWebNg/src/app/reports/cpg/cpg-report/cpg-report.component.ts
@@ -109,6 +109,10 @@ export class CpgReportComponent implements OnInit {
       this.assessSvc.assessment = assessmentDetail;
       this.modelId = this.assessSvc.assessment.maturityModel?.modelId ?? 0;
 
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.tSvc.selectTranslate('core.cpg.report.cpg report', {}, { scope: 'reports' })
+        .subscribe(reportTitle => this.titleSvc.setTitle(`${reportTitle} - ${assessmentTitle}`));
+
       this.initialize();
     });
   }
@@ -131,11 +135,6 @@ export class CpgReportComponent implements OnInit {
    * 
    */
   async initialize() {
-    this.tSvc.selectTranslate('core.cpg.report.cpg report', {}, { scope: 'reports' })
-      .subscribe(title => {
-        this.titleSvc.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle)
-      });
-
     let demog: Demographic = await firstValueFrom(this.demoSvc.getDemographic());
     this.techDomain = demog.techDomain;
     this.assessSvc.assessment.ssgModelIds = demog.ssgModelIds;

--- a/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-detail-report/cre-detail-report.component.ts
@@ -80,13 +80,13 @@ export class CreDetailReportComponent implements OnInit {
    */
   async ngOnInit(): Promise<void> {
     const titleKey = 'core.cre.charts.detail.title';
-    this.tSvc.selectTranslate(titleKey, {}, 'reports').subscribe(t => {
-      this.title = t;
-      this.titleService.setTitle(this.title);
-    });
-
-    this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: any) => {
-      this.assessDetail = assessmentDetail
+    this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
+      this.assessDetail = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.tSvc.selectTranslate(titleKey, {}, 'reports').subscribe(reportTitle => {
+        this.title = reportTitle;
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
+      });
     });
 
     this.domainList22 = await this.getFullModel(22);

--- a/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-final-report/cre-final-report.component.ts
@@ -70,13 +70,14 @@ export class CreFinalReportComponent implements OnInit {
   ngOnInit(): void {
     this.modelId = +this.route.snapshot.params['m'];
 
-    setTimeout(() => {
-      this.title = this.tSvc.translate(`reports.core.cre.final reports.${this.modelId}.title`);
-      this.titleService.setTitle(this.title);
-    }, 500);
-
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
-      this.info = assessmentDetail
+      this.info = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.tSvc.selectTranslate(`core.cre.final reports.${this.modelId}.title`, {}, { scope: 'reports' })
+        .subscribe(reportTitle => {
+          this.title = reportTitle;
+          this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
+        });
     });
   }
 

--- a/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-general-report/cre-general-report.component.ts
@@ -79,13 +79,13 @@ export class CreGeneralReportComponent implements OnInit {
    */
   async ngOnInit(): Promise<void> {
     const titleKey = 'core.cre.charts.general.title';
-    this.tSvc.selectTranslate(titleKey, {}, 'reports').subscribe(t => {
-      this.title = t;
-      this.titleService.setTitle(this.title);
-    });
-
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
       this.info = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.tSvc.selectTranslate(titleKey, {}, 'reports').subscribe(reportTitle => {
+        this.title = reportTitle;
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
+      });
     });
 
     this.distribCoreDomainMil = await this.buildAllDistrib([22, 23, 24]);

--- a/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.ts
+++ b/CSETWebNg/src/app/reports/crePlus/cre-heatmaps/cre-heatmaps.component.ts
@@ -29,6 +29,7 @@ import { ConfigService } from '../../../services/config.service';
 import { TranslocoService } from '@jsverse/transloco';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
+import { AssessmentDetail } from '../../../models/assessment-info.model';
 
 @Component({
   selector: 'app-cre-heatmaps',
@@ -66,6 +67,11 @@ export class CreHeatmapsComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
+    this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.titleService.setTitle(`CRE+ Heatmaps Report - ${assessmentTitle}`);
+    });
+
     this.reportSvc.getHeatmap(22).subscribe((x) => {
       this.heatmapModel22 = x;
     });

--- a/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-comments-marked/crr-comments-marked.component.ts
@@ -25,7 +25,7 @@ import { CmuReportModel } from './../../../models/reports.model';
 import { CmuService } from './../../../services/cmu.service';
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ConfigService } from '../../../services/config.service';
+import { TranslocoService } from '@jsverse/transloco';
 import { QuestionsService } from '../../../services/questions.service';
 import { AssessmentDetail } from '../../../models/assessment-info.model';
 
@@ -51,21 +51,24 @@ export class CrrCommentsMarkedComponent implements OnInit {
   markedForReviewList = [];
 
   constructor(
-    public configSvc: ConfigService,
     private titleService: Title,
+    public tSvc: TranslocoService,
     private cmuSvc: CmuService,
     public questionsSvc: QuestionsService
   ) { }
 
   ngOnInit(): void {
     this.loading = true;
-    this.titleService.setTitle('Comments Report - CISA CRR');
     this.keyToCategory = this.cmuSvc.keyToCategory;
 
     this.cmuSvc.getCmuModel().subscribe(
       (r: CmuReportModel) => {
         this.crrModel = r;
         this.info = r.assessmentDetails;
+        const assessmentTitle = this.info.assessmentName || `assessment-${this.info.id}`;
+        this.tSvc.selectTranslate('launch.crr.3.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
         const commentsCategories = [];
 
         // Build up comments list

--- a/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-deficiency/crr-deficiency.component.ts
@@ -24,7 +24,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { CmuReportModel } from '../../../models/reports.model';
-import { ConfigService } from '../../../services/config.service';
 import { QuestionsService } from '../../../services/questions.service';
 import { CmuService } from './../../../services/cmu.service';
 import { AssessmentDetail } from '../../../models/assessment-info.model';
@@ -50,7 +49,6 @@ export class CrrDeficiencyComponent implements OnInit {
   info: AssessmentDetail;
 
   constructor(
-    public configSvc: ConfigService,
     private titleService: Title,
     private cmuSvc: CmuService,
     public questionsSvc: QuestionsService
@@ -58,13 +56,14 @@ export class CrrDeficiencyComponent implements OnInit {
 
   ngOnInit() {
     this.loading = true;
-    this.titleService.setTitle('Deficiency Report - CRR');
     this.keyToCategory = this.cmuSvc.keyToCategory;
 
     this.cmuSvc.getCmuModel().subscribe(
       (r: CmuReportModel) => {
         this.crrModel = r;
         this.info = r.assessmentDetails;
+        const assessmentTitle = this.info.assessmentName || `assessment-${this.info.id}`;
+        this.titleService.setTitle(`Deficiency Report - CRR - ${assessmentTitle}`);
         const categories = [];
 
         // Build up deficiencies list

--- a/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.ts
+++ b/CSETWebNg/src/app/reports/crr/crr-report/crr-report.component.ts
@@ -61,9 +61,10 @@ export class CrrReportComponent implements OnInit {
       conf !== 'None' ? (this.confidentiality = conf) : (this.confidentiality = '');
     }
 
-    this.titleSvc.setTitle('CRR Report - ' + this.configSvc.behaviors.defaultTitle);
     this.cmuSvc.getCmuModel().subscribe(
       (data: CmuReportModel) => {
+        const assessmentTitle = data.assessmentDetails.assessmentName || `assessment-${data.assessmentDetails.id}`;
+        this.titleSvc.setTitle(`CRR Report - ${assessmentTitle}`);
         data.structure.Model.Domain.forEach((d) => {
           d.Goal.forEach((g) => {
             // The Question object needs to be an array for the template to work.

--- a/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
+++ b/CSETWebNg/src/app/reports/edm-commentsmarked/edm-commentsmarked.component.ts
@@ -25,8 +25,8 @@ import { Component, OnInit } from '@angular/core';
 import { ReportAnalysisService } from '../../services/report-analysis.service';
 import { ReportService } from '../../services/report.service';
 import { QuestionsService } from '../../services/questions.service';
-import { ConfigService } from '../../services/config.service';
-import { Title, DomSanitizer } from '@angular/platform-browser';
+import { Title } from '@angular/platform-browser';
+import { TranslocoService } from '@jsverse/transloco';
 import { MaturityService } from '../../services/maturity.service';
 import { AssessmentService } from '../../services/assessment.service';
 import { AssessmentDetail } from '../../models/assessment-info.model';
@@ -47,20 +47,22 @@ export class EdmCommentsmarkedComponent implements OnInit {
     public analysisSvc: ReportAnalysisService,
     public reportSvc: ReportService,
     public questionsSvc: QuestionsService,
-    public configSvc: ConfigService,
     private titleService: Title,
+    public tSvc: TranslocoService,
     public maturitySvc: MaturityService,
-    private sanitizer: DomSanitizer,
     public assessSvc: AssessmentService
   ) { }
 
   ngOnInit(): void {
     this.loading = true;
-    this.titleService.setTitle("Comments Report - CISA EDM");
 
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('launch.edm.4.title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
     this.maturitySvc.getReportComments().subscribe(

--- a/CSETWebNg/src/app/reports/edm/edm.component.ts
+++ b/CSETWebNg/src/app/reports/edm/edm.component.ts
@@ -26,7 +26,7 @@ import { Title } from '@angular/platform-browser';
 import { MaturityService } from '../../services/maturity.service';
 import { DemographicService } from '../../services/demographic.service';
 import { MaturityQuestionResponse } from '../../models/questions.model';
-import { Demographic } from '../../models/assessment-info.model';
+import { AssessmentDetail, Demographic } from '../../models/assessment-info.model';
 import { ReportService } from '../../services/report.service';
 import { saveAs } from "file-saver";
 import { AssessmentService } from '../../services/assessment.service';
@@ -67,7 +67,10 @@ export class EdmComponent implements OnInit, AfterContentInit {
    *
    */
   ngOnInit(): void {
-    this.titleService.setTitle("Report - EDM");
+    this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.titleService.setTitle(`EDM Report - ${assessmentTitle}`);
+    });
     this.currentTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     this.currentTimeZone = this.currentTimeZone.replace("_", " ")
     this.currentDate = new Date();

--- a/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
+++ b/CSETWebNg/src/app/reports/executive-summary/executive-summary.component.ts
@@ -76,16 +76,13 @@ export class ExecutiveSummaryComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-
-    this.titleService.setTitle("Executive Summary - " + this.configSvc.behaviors.defaultTitle);
-
-    this.tSvc.selectTranslate('core.executive summary.report title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.executive summary.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
 

--- a/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.html
+++ b/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.html
@@ -48,7 +48,7 @@
                 <p style="color: #de761c;text-align: right;">Marked for Review - <img class="marked-flag"
                         src="assets/images/icons/MarkedFlag.png" alt="marked for review"> </p>
             </div>
-            <hr class="page-line m-0">
+
             <table role="presentation">
                 <ng-template ngFor let-s [ngForOf]="response?.deficienciesList">
                     <tr>

--- a/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/general-deficiency/general-deficiency.component.ts
@@ -24,7 +24,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ReportAnalysisService } from '../../services/report-analysis.service';
 import { ReportService } from '../../services/report.service';
-import { ConfigService } from '../../services/config.service';
 import { Title } from '@angular/platform-browser';
 import { MaturityService } from '../../services/maturity.service';
 import { QuestionsService } from '../../services/questions.service';
@@ -56,7 +55,6 @@ export class GeneralDeficiencyComponent implements OnInit {
   constructor(
     public analysisSvc: ReportAnalysisService,
     public reportSvc: ReportService,
-    public configSvc: ConfigService,
     public questionsSvc: QuestionsService,
     private titleService: Title,
     public maturitySvc: MaturityService,
@@ -73,11 +71,11 @@ export class GeneralDeficiencyComponent implements OnInit {
     this.route.queryParams.subscribe(params => {
       this.moduleName = params.m;
 
-      this.titleService.setTitle("Deficiency Report - " + this.moduleName);
-
       this.assessSvc.getAssessmentDetail().subscribe(
         (r: AssessmentDetail) => {
           this.info = r;
+          const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+          this.titleService.setTitle(`Deficiency Report - ${this.moduleName} - ${assessmentTitle}`);
         }
       );
       this.maturitySvc.getMaturityDeficiency(this.moduleName).subscribe(

--- a/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
+++ b/CSETWebNg/src/app/reports/imr/imr-report/imr-report.component.ts
@@ -64,9 +64,10 @@ export class ImrReportComponent implements OnInit {
       conf !== 'None' ? (this.confidentiality = conf) : (this.confidentiality = '');
     }
 
-    this.titleSvc.setTitle('IMR Report - ' + this.configSvc.behaviors.defaultTitle);
     this.reportSvc.getAssessmentInfoForReport().subscribe((resp: any) => {
       this.model.assessmentDetails = resp;
+      const assessmentTitle = resp.assessmentName || `assessment-${resp.id}`;
+      this.titleSvc.setTitle(`IMR Report - ${assessmentTitle}`);
     });
 
     this.reportSvc.getModelContent('').subscribe(

--- a/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
+++ b/CSETWebNg/src/app/reports/mvra/mvra-report.component.ts
@@ -53,11 +53,11 @@ export class MvraReportComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    this.titleService.setTitle("MVRA Report - " + this.configSvc.behaviors.defaultTitle);
-
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`MVRA Report - ${assessmentTitle}`);
       }
     );
 

--- a/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
+++ b/CSETWebNg/src/app/reports/observation-tearouts/observation-tearouts.component.ts
@@ -63,15 +63,15 @@ export class ObservationTearoutsComponent implements OnInit {
     this.reportSvc.getReport('observations/tearout').subscribe(
       (r: any) => {
         this.response = r;
-
-        var title = this.tSvc.translate('reports.observations tear-out sheets.tab title', { defaultTitle: this.configSvc.behaviors.defaultTitle });
-        this.titleService.setTitle(title);
       },
       error => console.error('Observation Tear Out Sheets report load Error: ' + (<Error>error).message)
     );
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        const reportTitle = this.tSvc.translate('reports.observations tear-out sheets.report title');
+        this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`);
       }
     );
   }

--- a/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
+++ b/CSETWebNg/src/app/reports/physical-summary/physical-summary.component.ts
@@ -72,10 +72,6 @@ export class PhysicalSummaryComponent implements OnInit, AfterViewInit {
   ) { }
 
   ngOnInit() {
-    this.tSvc.selectTranslate('core.physical summary.report title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.reportSvc.getReport('physicalsummary').subscribe(
       (r: any) => {
         this.response = r;
@@ -85,6 +81,10 @@ export class PhysicalSummaryComponent implements OnInit, AfterViewInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.physical summary.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/reports.scss
+++ b/CSETWebNg/src/app/reports/reports.scss
@@ -110,6 +110,16 @@ body {
   .noprint {
     visibility: hidden;
   }
+
+  thead {
+    display: table-header-group;
+  }
+
+  thead,
+  tbody tr:first-child {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
 }
 
 

--- a/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-deficiency/rra-deficiency.component.ts
@@ -23,7 +23,6 @@
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ConfigService } from '../../../services/config.service';
 import { MaturityService } from '../../../services/maturity.service';
 import { QuestionsService } from '../../../services/questions.service';
 import { ReportAnalysisService } from '../../../services/report-analysis.service';
@@ -60,7 +59,6 @@ export class RraDeficiencyComponent implements OnInit {
   constructor(
     public analysisSvc: ReportAnalysisService,
     public reportSvc: ReportService,
-    public configSvc: ConfigService,
     private titleService: Title,
     public maturitySvc: MaturityService,
     public questionsSvc: QuestionsService,
@@ -73,11 +71,6 @@ export class RraDeficiencyComponent implements OnInit {
 
   ngOnInit() {
     this.loading = true;
-
-    this.tSvc.selectTranslate('core.rra.rra deficiency report', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
 
     this.maturitySvc.getMaturityDeficiency("RRA").subscribe(
       (r: any) => {
@@ -121,6 +114,9 @@ export class RraDeficiencyComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.rra.rra deficiency report', {}, { scope: 'reports' })
+          .subscribe(reportTitle => this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
+++ b/CSETWebNg/src/app/reports/rra/rra-report/rra-report.component.ts
@@ -141,13 +141,13 @@ export class RraReportComponent implements OnInit {
       error => console.error('Main RRA report load Error: ' + (<Error>error).message)
     );
 
-    this.tSvc.selectTranslate('core.rra.tab title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.rra.tab title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-comments/sd-owner-comments-mfr.component.ts
@@ -25,7 +25,6 @@ import { Component } from '@angular/core';
 import { ReportAnalysisService } from '../../../services/report-analysis.service';
 import { ReportService } from '../../../services/report.service';
 import { QuestionsService } from '../../../services/questions.service';
-import { ConfigService } from '../../../services/config.service';
 import { MaturityService } from '../../../services/maturity.service';
 import { AssessmentService } from '../../../services/assessment.service';
 import { TranslocoService } from '@jsverse/transloco';
@@ -52,7 +51,6 @@ export class SdOwnerCommentsMfrComponent {
     public assessSvc: AssessmentService,
     public reportSvc: ReportService,
     public questionsSvc: QuestionsService,
-    public configSvc: ConfigService,
     private titleService: Title,
     public maturitySvc: MaturityService,
     public tSvc: TranslocoService
@@ -60,11 +58,6 @@ export class SdOwnerCommentsMfrComponent {
 
   ngOnInit(): void {
     this.loading = true;
-
-    this.tSvc.selectTranslate('core.rra.cmfr.report title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
 
     this.maturitySvc.getReportComments().subscribe(
       (r: any) => {
@@ -85,6 +78,10 @@ export class SdOwnerCommentsMfrComponent {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.rra.cmfr.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/sd-owner/sd-owner-deficiency/sd-owner-deficiency.component.ts
@@ -74,7 +74,6 @@ export class SdOwnerDeficiencyComponent {
   ) { }
 
   ngOnInit(): void {
-    this.titleService.setTitle("Deficiency Report");
     this.loading = true;
 
     this.getAssessmentDetails();
@@ -84,6 +83,8 @@ export class SdOwnerDeficiencyComponent {
   getAssessmentDetails() {
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
       this.info = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.titleService.setTitle(`Deficiency Report - ${assessmentTitle}`);
     });
   }
 

--- a/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.ts
+++ b/CSETWebNg/src/app/reports/sd/sd-answer-summary-report/sd-answer-summary-report.component.ts
@@ -56,11 +56,12 @@ export class SdAnswerSummaryReportComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
-    this.titleService.setTitle("Answer Summary - Pipeline SD02 Series");
     this.loading = true;
 
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: AssessmentDetail) => {
-      this.info = assessmentDetail
+      this.info = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.titleService.setTitle(`Answer Summary - Pipeline SD02 Series - ${assessmentTitle}`);
     });
 
     this.questionsNestedSvc.getSection(0).subscribe((resp: any) => {

--- a/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
+++ b/CSETWebNg/src/app/reports/securityplan/securityplan.component.ts
@@ -71,11 +71,6 @@ export class SecurityplanComponent implements OnInit {
    *
    */
   ngOnInit() {
-    this.tSvc.selectTranslate('core.security plan.report title', {}, { scope: 'reports' })
-      .subscribe(title => {
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle)
-      });
-
     this.reportSvc.getReport('securityplan').subscribe(
       (r: any) => {
         this.response = r;
@@ -103,6 +98,10 @@ export class SecurityplanComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.security plan.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
+++ b/CSETWebNg/src/app/reports/site-detail/site-detail.component.ts
@@ -85,10 +85,6 @@ export class SiteDetailComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.tSvc.selectTranslate('core.site detail report.report title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.reportSvc.getReport('detail').subscribe(
       (r: any) => {
         this.response = r;
@@ -119,6 +115,10 @@ export class SiteDetailComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.site detail report.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
+++ b/CSETWebNg/src/app/reports/site-summary/site-summary.component.ts
@@ -92,10 +92,6 @@ export class SiteSummaryComponent implements OnInit, AfterViewInit {
   ) { }
 
   ngOnInit() {
-    this.tSvc.selectTranslate('core.site summary.report title', {}, { scope: 'reports' })
-      .subscribe(title =>
-        this.titleService.setTitle(title + ' - ' + this.configSvc.behaviors.defaultTitle));
-
     this.isCmmc = this.maturitySvc.maturityModelIsCMMC();
 
     this.reportSvc.getReport('sitesummary').subscribe(
@@ -137,6 +133,10 @@ export class SiteSummaryComponent implements OnInit, AfterViewInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.tSvc.selectTranslate('core.site summary.report title', {}, { scope: 'reports' })
+          .subscribe(reportTitle =>
+            this.titleService.setTitle(`${reportTitle} - ${assessmentTitle}`));
       }
     );
   }

--- a/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
+++ b/CSETWebNg/src/app/reports/trend-report/trend-report.component.ts
@@ -82,8 +82,11 @@ export class TrendReportComponent implements OnInit, AfterViewChecked {
 
 
   ngOnInit() {
-    this.titleService.setTitle("Trend Report - " + this.configSvc.behaviors.defaultTitle);
     var aggId: number = +localStorage.getItem("aggregationId");
+    this.aggregationSvc.getAggregation().subscribe((aggregation: any) => {
+      const aggregationTitle = aggregation.aggregationName || `aggregation-${aggId}`;
+      this.titleService.setTitle(`Trend Report - ${aggregationTitle}`);
+    });
     this.reportSvc.getAggReport('trend-report', aggId).subscribe(
       (r: any) => {
         this.response = r;

--- a/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.ts
+++ b/CSETWebNg/src/app/reports/tsa-sd/tsa-sd.component.ts
@@ -53,11 +53,12 @@ export class TsaSdComponent implements OnInit {
    * 
    */
   ngOnInit(): void {
-    this.titleService.setTitle("Deficiency Report - Pipeline SD02 Series");
     this.loading = true;
 
     this.assessSvc.getAssessmentDetail().subscribe((assessmentDetail: any) => {
       this.info = assessmentDetail;
+      const assessmentTitle = assessmentDetail.assessmentName || `assessment-${assessmentDetail.id}`;
+      this.titleService.setTitle(`Deficiency Report - Pipeline SD02 Series - ${assessmentTitle}`);
     });
 
     this.maturitySvc.getMaturityDeficiencySd().subscribe(

--- a/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/open-ended-questions/open-ended-questions.component.ts
@@ -98,9 +98,6 @@ export class OpenEndedQuestionsComponent implements OnInit {
 
   ngOnInit() {
     this.loadQuestions();
-    this.titleService.setTitle(
-      "Validated Architecture Design Review Report - VADR"
-    );
     this.maturitySvc.getMaturityDeficiency("VADR").subscribe((r: any) => {
       this.response = r;
       // this.response.deficienciesList = this.response.deficienciesList.filter(x => x.mat.parent_Question_Id == null);
@@ -108,6 +105,8 @@ export class OpenEndedQuestionsComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`VADR Open-Ended Questions Report - ${assessmentTitle}`);
       }
     );
   }

--- a/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-deficiency/vadr-deficiency.component.ts
@@ -23,7 +23,6 @@
 ////////////////////////////////
 import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ConfigService } from '../../../services/config.service';
 import { MaturityService } from '../../../services/maturity.service';
 import { ReportAnalysisService } from '../../../services/report-analysis.service';
 import { ReportService } from '../../../services/report.service';
@@ -61,7 +60,6 @@ export class VadrDeficiencyComponent implements OnInit {
     public analysisSvc: ReportAnalysisService,
     public reportSvc: ReportService,
     public questionsSvc: QuestionsService,
-    public configSvc: ConfigService,
     private titleService: Title,
     public maturitySvc: MaturityService,
     public assessSvc: AssessmentService
@@ -69,7 +67,6 @@ export class VadrDeficiencyComponent implements OnInit {
 
   ngOnInit() {
     this.loading = true;
-    this.titleService.setTitle("Validated Architecture Design Review Report - VADR");
 
     this.maturitySvc.getMaturityDeficiency("VADR").subscribe(
       (r: any) => {
@@ -84,6 +81,8 @@ export class VadrDeficiencyComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`Validated Architecture Design Review Report - VADR - ${assessmentTitle}`);
       }
     );
   }

--- a/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
+++ b/CSETWebNg/src/app/reports/vadr/vadr-report/vadr-report.component.ts
@@ -142,9 +142,6 @@ export class VadrReportComponent implements OnInit {
       this.createQuestionReferenceTable(r);
     });
 
-
-    this.titleService.setTitle("Validated Architecture Design Review Report - VADR");
-
     this.vadrDataSvc.getReport('vadrmain').subscribe(
       (r: any) => {
         this.mainResponse = r;
@@ -155,6 +152,8 @@ export class VadrReportComponent implements OnInit {
     this.assessSvc.getAssessmentDetail().subscribe(
       (r: AssessmentDetail) => {
         this.info = r;
+        const assessmentTitle = r.assessmentName || `assessment-${r.id}`;
+        this.titleService.setTitle(`Validated Architecture Design Review Report - VADR - ${assessmentTitle}`);
       }
     );
   }


### PR DESCRIPTION
This pull request introduces several improvements across the application, focusing on report accessibility, UI consistency, and backend data filtering. The most significant changes include enhancing report page titles to include the assessment name for better context and accessibility, refining the UI for assessment and report components, and improving backend filtering logic for child questions. Below are the most important changes grouped by theme:

### Accessibility and Usability Improvements

* All report components now set the browser tab title to include both the report type and the assessment name, improving accessibility and user navigation. This is implemented for components such as All Answered Questions, All Comments Marked, All Reviewed, C2M2 Report, CIS Comments Marked, CIS Ranked Deficiency, CIS Section Scoring, CIS Survey, and CISA VADR Observations. [[1]](diffhunk://#diff-477f87f8c50b48ac42e826cb81ce25fc3478f97692be473a32c2b6e58966ac64L63-R71) [[2]](diffhunk://#diff-9e963ef5721139a462a6e4f207952475f68494efd6ffe92a223c60013a91dec8L55-L69) [[3]](diffhunk://#diff-329e830fab1427b449f7d54e1e25e403178906a462da819e22e2e40701f47b7dR63-L68) [[4]](diffhunk://#diff-fecace483a568d88924bc9e9479ee5ef8acc769b8700e85a34e5a279c866b501L47-R60) [[5]](diffhunk://#diff-9ea2c21487b5985faa78138deb675099e897ef8be77df7398a30e66e2680c17fR59-R62) [[6]](diffhunk://#diff-c91c98761d4f3d7a6f664f335449fa54c78ae94a33a972b21b7358d2d37961f2R55-R57) [[7]](diffhunk://#diff-da470c72c8bfef9b426d884ca7220d3881854ffcadeb10dc038421b4368ecf11R76-R79) [[8]](diffhunk://#diff-734d5f13db09cc3414acfdb7153b7965f4a418eb58f3458b9ccaa1f0e1d71efeR72-R73) [[9]](diffhunk://#diff-ce1eba61d9bbde978beee611f74d6a029cf32e9b11794e7ce3ddf92f681609efL58-R60)

### UI and Layout Enhancements

* The assessment header and controls in `assessment.component.html` have been refactored for improved responsiveness, accessibility, and consistent spacing, including better tooltips and ARIA labels for toggles.
* The "My Assessments" table header and assessment links have been visually improved for clarity and alignment, and the date format has been made more concise. [[1]](diffhunk://#diff-014158e4faff7f074dc1ece8b4c426417a5a6b62394ade841804f9ede89aa822L207-R228) [[2]](diffhunk://#diff-6d033bacedda66f367204807708b46a19ac179b86180ff36423fedf9dc049d69R206)
* The CPG domain summary table now uses proper `<thead>` and `<tbody>` HTML elements for better semantic structure and accessibility. [[1]](diffhunk://#diff-0a5b0f4c53d2ff6b9f609799e1af532f23bd412cd312d8e0b93c9d61e3be0bbeR25) [[2]](diffhunk://#diff-0a5b0f4c53d2ff6b9f609799e1af532f23bd412cd312d8e0b93c9d61e3be0bbeR34-R35) [[3]](diffhunk://#diff-0a5b0f4c53d2ff6b9f609799e1af532f23bd412cd312d8e0b93c9d61e3be0bbeR44)

### Backend Logic and Data Filtering

* The backend method `ConvertParentsToChildren` now filters out-of-scope child questions based on the technology domain, ensuring only relevant questions are included in reports.
* When creating child question/answer objects, additional fields are now set to ensure completeness of data.

### Code Cleanup

* Unused imports and constructor parameters have been removed from several report components, reducing code clutter. [[1]](diffhunk://#diff-9e963ef5721139a462a6e4f207952475f68494efd6ffe92a223c60013a91dec8L27) [[2]](diffhunk://#diff-9e963ef5721139a462a6e4f207952475f68494efd6ffe92a223c60013a91dec8L55-L69) [[3]](diffhunk://#diff-9ea2c21487b5985faa78138deb675099e897ef8be77df7398a30e66e2680c17fL27-R28) [[4]](diffhunk://#diff-9ea2c21487b5985faa78138deb675099e897ef8be77df7398a30e66e2680c17fL47-R48)

These changes collectively enhance the user experience, accessibility, and data accuracy throughout the application.


<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
