### PR TITLE
Tightened up question page header controls

### DIFF
--- a/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/diagram-questions/diagram-questions.component.html
@@ -24,7 +24,7 @@
   <div class="white-panel-controls">
 
     <div id="top"></div>
-    <div class="flex-column flex-wrap justify-content-between align-items-start flex-11a mb-4">
+    <div class="flex-column flex-wrap justify-content-between align-items-start flex-11a mb-2">
 
       <div class="d-flex sticky-sal p-1 justify-content-end align-items-start flex-11a tw:dark:bg-bg-secondary"
         style="float: right;">

--- a/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
+++ b/CSETWebNg/src/app/assessment/questions/maturity-questions/maturity-questions.component.html
@@ -23,7 +23,7 @@
 <div *transloco="let t">
   <div class="white-panel-controls">
     <div id="top"></div>
-    <div class="flex-column flex-wrap justify-content-between align-items-start flex-11a mb-4">
+    <div class="flex-column flex-wrap justify-content-between align-items-start flex-11a mb-2">
 
       <div class="d-flex p-1 justify-content-end align-items-start flex-11a"
         style="width: max-content; float: right;">

--- a/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
+++ b/CSETWebNg/src/app/layout/iod-layout/iod-layout.component.scss
@@ -548,8 +548,8 @@ label[required]::after {
 
 .white-panel-controls {
   background-color: var(--bg-secondary);
-  margin: 1em 1em 0em 1em;
-  padding: 1.5em 2em .5em 2em;
+  margin: 0 1em;
+  padding: .5em 2em 0 2em;
   overflow-y: auto;
   overflow-x: hidden;
   border-top-left-radius: 8px;

--- a/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
+++ b/CSETWebNg/src/app/layout/layout-main/layout-main.component.scss
@@ -547,8 +547,8 @@ label[required]::after {
 
 .white-panel-controls {
   background-color: $gray-50;
-  margin: 1em 1em 0em 1em;
-  padding: 1.5em 2em .5em 2em;
+  margin: 0 1em;
+  padding: .5em 2em 0 2em;
   overflow-y: auto;
   overflow-x: hidden;
   border-top-left-radius: 8px;


### PR DESCRIPTION
This pull request makes consistent adjustments to the spacing and padding of the `.white-panel-controls` container across several components. The main goal is to reduce the top margin and padding, resulting in a more compact and uniform appearance for panels throughout the application.

**Styling consistency and spacing adjustments:**

* Reduced top margin and padding of `.white-panel-controls` in `iod-layout.component.scss` for a more compact panel appearance.
* Reduced top margin and padding of `.white-panel-controls` in `layout-main.component.scss` to match other components.

**Component template spacing:**

* Changed the bottom margin from `mb-4` to `mb-2` in the `.white-panel-controls` container in `diagram-questions.component.html` for tighter vertical spacing.
* Changed the bottom margin from `mb-4` to `mb-2` in the `.white-panel-controls` container in `maturity-questions.component.html` for consistency across question components.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
