### PR TITLE
Fix extended demographics import from CSETW files

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ColumnImportRules.xml
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/ColumnImportRules.xml
@@ -64,8 +64,6 @@
     </Column>
   </Table>
   
-  <Table name="DETAILS_DEMOGRAPHICS" />
-  
   <Table name="ASSESSMENT_SECTOR_SUBSECTOR" />
 
   <Table name="CIS_CSI_SERVICE_COMPOSITION"/>

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/Importer.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/AssessmentIO/Import/Importer.cs
@@ -257,6 +257,8 @@ namespace CSETWebCore.Business.AssessmentIO.Import
             var genericImporter = new GenericImporter(assessmentId);
             genericImporter.SetManualIdentityMaps(this.mapIdentity);
             genericImporter.SaveFromJson(jsonObject, context);
+
+            ImportDetailsDemographics(assessmentId);
         }
 
 
@@ -297,36 +299,50 @@ namespace CSETWebCore.Business.AssessmentIO.Import
 
                 _context.SaveChanges();
             }
+        }
 
+        private void ImportDetailsDemographics(int assessmentId)
+        {
+            var demographicExtBiz = new DemographicExtBusiness(_context);
             foreach (var demographics in _model.jDETAILS_DEMOGRAPHICS)
             {
-                var _demographicExtBiz = new DemographicExtBusiness(_context);
+                if (string.IsNullOrWhiteSpace(demographics.DataItemName))
+                {
+                    continue;
+                }
+
                 if (demographics.StringValue != null)
                 {
                     var value = demographics.StringValue;
-                    _demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
                 }
                 else if (demographics.IntValue != null)
                 {
                     var value = demographics.IntValue;
-                    _demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
                 }
                 else if (demographics.FloatValue != null)
                 {
                     var value = demographics.FloatValue;
-                    _demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
                 }
                 else if (demographics.BoolValue != null)
                 {
                     var value = demographics.BoolValue;
-                    _demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
                 }
                 else if (demographics.DateTimeValue != null)
                 {
                     var value = demographics.DateTimeValue;
-                    _demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, value);
+                }
+                else
+                {
+                    demographicExtBiz.SaveX(assessmentId, demographics.DataItemName, null);
                 }
             }
+
+            _context.SaveChanges();
         }
     }
 }


### PR DESCRIPTION
Import extended demographics through DemographicExtBusiness.SaveX instead of the generic insert path.

This prevents composite-key conflicts with demographic records created during assessment initialization and restores values such as ORG-NAME for both new and overwrite imports. Invalid unnamed records are skipped, and null demographic values are preserved.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
