### PR TITLE
Fix maturity report ordering and CPG heatmap labels

### DIFF
--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Maturity/HeatmapGenerator.cs
@@ -216,6 +216,11 @@ namespace CSETWebCore.Business.Maturity
         /// </summary>
         private string CustomizeTitle(Model.Nested.Question q, int modelId)
         {
+            if (modelId == Constants.Constants.Model_CPG)
+            {
+                return q.DisplayNumber;   // "1.A", "2.H", etc.
+            }
+
             if (modelId == Constants.Constants.Model_CPG2)
             {
                 // create labels for OT/IT followups in CPG2

--- a/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
+++ b/CSETWebApi/CSETWeb_Api/CSETWebCore.Business/Reports/ReportsData/ReportsDataBusiness.cs
@@ -121,7 +121,6 @@ namespace CSETWebCore.Business.Reports
                               && mq.Maturity_Model_Id == targetModelId
                               && a.Question_Type == "Maturity"
                               && !this.OutOfScopeQuestions.Contains(mq.Mat_Question_Id)
-                        orderby mq.Grouping_Id, mq.Maturity_Level_Id, mq.Mat_Question_Id ascending
                         select new MatRelevantAnswers()
                         {
                             ANSWER = a,
@@ -188,7 +187,132 @@ namespace CSETWebCore.Business.Reports
             }
 
 
-            return responseList;
+            return OrderByMaturityModelSequence(responseList, targetModelId);
+        }
+
+
+        /// <summary>
+        /// Orders a flat list of maturity answers in the same sequence as the model structure.
+        /// Grouping and question sequence values are scoped to their siblings, so the model must
+        /// be traversed recursively rather than sorted by identifiers or sequence values alone.
+        /// </summary>
+        private List<MatRelevantAnswers> OrderByMaturityModelSequence(List<MatRelevantAnswers> responseList, int modelId)
+        {
+            var groupings = _context.MATURITY_GROUPINGS
+                .AsNoTracking()
+                .Where(x => x.Maturity_Model_Id == modelId)
+                .ToList();
+
+            var questions = _context.MATURITY_QUESTIONS
+                .AsNoTracking()
+                .Where(x => x.Maturity_Model_Id == modelId)
+                .ToList();
+
+            var questionIds = questions.Select(x => x.Mat_Question_Id).ToList();
+            var options = _context.MATURITY_ANSWER_OPTIONS
+                .AsNoTracking()
+                .Where(x => questionIds.Contains(x.Mat_Question_Id))
+                .ToList();
+
+            var childGroupings = groupings.ToLookup(x => x.Parent_Id ?? 0);
+            var questionsByGrouping = questions.ToLookup(x => x.Grouping_Id ?? 0);
+            var directFollowups = questions
+                .Where(x => x.Parent_Question_Id != null && x.Parent_Option_Id == null)
+                .ToLookup(x => x.Parent_Question_Id.Value);
+            var optionFollowups = questions
+                .Where(x => x.Parent_Option_Id != null)
+                .ToLookup(x => x.Parent_Option_Id.Value);
+            var optionsByQuestion = options.ToLookup(x => x.Mat_Question_Id);
+
+            var questionOrder = new Dictionary<int, int>();
+            var visitedGroupings = new HashSet<int>();
+            var visitedQuestions = new HashSet<int>();
+            var nextOrdinal = 0;
+
+            void AddQuestion(MATURITY_QUESTIONS question)
+            {
+                if (!visitedQuestions.Add(question.Mat_Question_Id))
+                {
+                    return;
+                }
+
+                questionOrder[question.Mat_Question_Id] = nextOrdinal++;
+
+                foreach (var option in optionsByQuestion[question.Mat_Question_Id]
+                    .OrderBy(x => x.Answer_Sequence)
+                    .ThenBy(x => x.Mat_Option_Id))
+                {
+                    foreach (var followup in optionFollowups[option.Mat_Option_Id]
+                        .OrderBy(x => x.Sequence)
+                        .ThenBy(x => x.Mat_Question_Id))
+                    {
+                        AddQuestion(followup);
+                    }
+                }
+
+                foreach (var followup in directFollowups[question.Mat_Question_Id]
+                    .OrderBy(x => x.Sequence)
+                    .ThenBy(x => x.Mat_Question_Id))
+                {
+                    AddQuestion(followup);
+                }
+            }
+
+            void AddGrouping(MATURITY_GROUPINGS grouping)
+            {
+                if (!visitedGroupings.Add(grouping.Grouping_Id))
+                {
+                    return;
+                }
+
+                foreach (var question in questionsByGrouping[grouping.Grouping_Id]
+                    .Where(x => x.Parent_Question_Id == null && x.Parent_Option_Id == null)
+                    .OrderBy(x => x.Sequence)
+                    .ThenBy(x => x.Mat_Question_Id))
+                {
+                    AddQuestion(question);
+                }
+
+                foreach (var childGrouping in childGroupings[grouping.Grouping_Id]
+                    .OrderBy(x => x.Sequence)
+                    .ThenBy(x => x.Grouping_Id))
+                {
+                    AddGrouping(childGrouping);
+                }
+            }
+
+            foreach (var grouping in childGroupings[0]
+                .OrderBy(x => x.Sequence)
+                .ThenBy(x => x.Grouping_Id))
+            {
+                AddGrouping(grouping);
+            }
+
+            // Keep malformed or orphaned model records deterministic without allowing them
+            // to disrupt the defined hierarchy order.
+            foreach (var grouping in groupings
+                .Where(x => !visitedGroupings.Contains(x.Grouping_Id))
+                .OrderBy(x => x.Sequence)
+                .ThenBy(x => x.Grouping_Id))
+            {
+                AddGrouping(grouping);
+            }
+
+            foreach (var question in questions
+                .Where(x => !visitedQuestions.Contains(x.Mat_Question_Id))
+                .OrderBy(x => x.Sequence)
+                .ThenBy(x => x.Mat_Question_Id))
+            {
+                AddQuestion(question);
+            }
+
+            return responseList
+                .OrderBy(x => x.Mat != null && questionOrder.TryGetValue(x.Mat.Mat_Question_Id, out var ordinal)
+                    ? ordinal
+                    : int.MaxValue)
+                .ThenBy(x => x.Mat?.Sequence ?? int.MaxValue)
+                .ThenBy(x => x.Mat?.Mat_Question_Id ?? int.MaxValue)
+                .ToList();
         }
 
 


### PR DESCRIPTION
- Order maturity report answers by recursively traversing the model’s grouping, question, and follow-up hierarchy.
- Preserve deterministic ordering for orphaned or malformed model records.
- Display complete CPG question numbers, such as 1.A and 2.H, in heatmap cells.
- Preserve the existing specialized CPG2 heatmap labels.

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
